### PR TITLE
Brbdcf 775 regroup related janus config options

### DIFF
--- a/bench/server_bench_test.go
+++ b/bench/server_bench_test.go
@@ -52,9 +52,8 @@ func setupServer(b *testing.B) (*testutil.TestServer, chan struct{}) {
 	b.Fatalf("Failed to setup consul server: %v", err)
 
 	configuration := config.Configuration{
-		WorkingDirectory:     defaultWorkingDirectory,
-		ConsulAddress:        srv1.HTTPAddr,
-		ConsulPubMaxRoutines: config.DefaultConsulPubMaxRoutines,
+		WorkingDirectory: defaultWorkingDirectory,
+		Consul:           config.Consul{Address: srv1.HTTPAddr, PubMaxRoutines: config.DefaultConsulPubMaxRoutines},
 	}
 	shutdownCh := make(chan struct{})
 	go func() {

--- a/commands/server.go
+++ b/commands/server.go
@@ -276,15 +276,11 @@ func setConfig() {
 
 func getConfig() config.Configuration {
 	configuration := config.Configuration{}
-	/*  TODO: uncomment when deprecated uses will be forbidden */
-	/* Ansible part
 	configuration.AnsibleUseOpenSSH = viper.GetBool("ansible.use_openssh")
 	configuration.AnsibleDebugExec = viper.GetBool("ansible.debug")
 	configuration.AnsibleConnectionRetries = viper.GetInt("ansible.connection_retries")
 	configuration.OperationRemoteBaseDir = viper.GetString("ansible.operation_remote_base_dir")
 	configuration.KeepOperationRemotePath = viper.GetBool("ansible.keep_operation_remote_path")
-	*/
-	deprecatedConfig(&configuration) //Toremove when deprecated uses will be forbidden
 	configuration.WorkingDirectory = viper.GetString("working_directory")
 	configuration.PluginsDirectory = viper.GetString("plugins_directory")
 	configuration.WorkersNumber = viper.GetInt("workers_number")
@@ -293,7 +289,6 @@ func getConfig() config.Configuration {
 	configuration.CertFile = viper.GetString("cert_file")
 	configuration.KeyFile = viper.GetString("key_file")
 	configuration.ResourcesPrefix = viper.GetString("resources_prefix")
-	/* Consul part
 	configuration.ConsulAddress = viper.GetString("consul.address")
 	configuration.ConsulDatacenter = viper.GetString("consul.datacenter")
 	configuration.ConsulToken = viper.GetString("consul.token")
@@ -304,7 +299,6 @@ func getConfig() config.Configuration {
 	configuration.ConsulCAPath = viper.GetString("consul.ca_path")
 	configuration.ConsulSSL = viper.GetBool("consul.ssl")
 	configuration.ConsulSSLVerify = viper.GetBool("consul.ssl_verify")
-	*/
 	configuration.ServerGracefulShutdownTimeout = viper.GetDuration("server_graceful_shutdown_timeout")
 	configuration.WfStepGracefulTerminationTimeout = viper.GetDuration("wf_step_graceful_termination_timeout")
 	configuration.Infrastructures = make(map[string]config.DynamicMap)
@@ -324,35 +318,6 @@ func getConfig() config.Configuration {
 	configuration.Telemetry.DisableGoRuntimeMetrics = viper.GetBool("telemetry.disable_go_runtime_metrics")
 
 	return configuration
-}
-
-func deprecatedConfig(cfg *config.Configuration) {
-	/* Ansible part */
-	cfg.AnsibleUseOpenSSH = chooseNew("ansible_use_openssh", "ansible.use_openssh").(bool)
-	cfg.AnsibleDebugExec = chooseNew("ansible_debug", "ansible.debug").(bool)
-	cfg.AnsibleConnectionRetries = int(chooseNew("ansible_connection_retries", "ansible.connection_retries").(float64))
-	cfg.OperationRemoteBaseDir = chooseNew("operation_remote_base_dir", "ansible.operation_remote_base_dir").(string)
-	cfg.AnsibleUseOpenSSH = chooseNew("keep_operation_remote_path", "ansible.keep_operation_remote_path").(bool)
-	/* Consul part */
-	cfg.ConsulAddress = chooseNew("consul_address", "consul.address").(string)
-	cfg.ConsulDatacenter = chooseNew("consul_datacenter", "consul.datacenter").(string)
-	cfg.ConsulToken = chooseNew("consul_token", "consul.token").(string)
-	cfg.ConsulPubMaxRoutines = int(chooseNew("consul_publisher_max_routines", "consul.publisher_max_routines").(float64))
-	cfg.ConsulKey = chooseNew("consul_key_file", "consul.key_file").(string)
-	cfg.ConsulCert = chooseNew("consul_cert_file", "consul.cert_file").(string)
-	cfg.ConsulCA = chooseNew("consul_ca_cert", "consul.ca_cert").(string)
-	cfg.ConsulCAPath = chooseNew("consul_ca_path", "consul.ca_path").(string)
-	cfg.ConsulSSL = chooseNew("consul_ssl", "consul.ssl").(bool)
-	cfg.ConsulSSLVerify = chooseNew("consul_ssl_verify", "consul.ssl_verify").(bool)
-}
-func chooseNew(oldName string, newName string) interface{} {
-	old := viper.Get(oldName)
-	new := viper.Get(newName)
-	if new != "" && new != nil {
-		return new
-	}
-	log.Printf("Warning: You are using deprecated configuration file. Do not use anymore \"%s\" parameter. Refer to the doc for more information.", oldName)
-	return old
 }
 
 func readInfraViperConfig(cfg *config.Configuration) {

--- a/commands/server.go
+++ b/commands/server.go
@@ -404,7 +404,7 @@ func deprecateFlatKeys(configuration map[string]interface{}, configurationName s
 	}
 
 	if deprecatedMsg != "" {
-		log.Printf("Deprecated values are used in configuration file. The following lines:\n%sshould now have this format:\n\t%s{\n%s\t}",
+		log.Printf("Deprecated values are used in configuration file. The following lines:\n%sshould now have this format:\n\t%q:{\n%s\t}",
 			deprecatedMsg,
 			configurationName,
 			newValueMsg)

--- a/commands/server.go
+++ b/commands/server.go
@@ -395,8 +395,9 @@ func deprecateFlatKeys(configuration map[string]interface{}, configurationName s
 	for key, defaultValue := range configuration {
 		deprecatedKey := toFlatKey(key)
 		if value := viper.Get(deprecatedKey); value != nil {
+			subkeys := strings.SplitN(key, ".", 2)
 			deprecatedMsg += fmt.Sprintf(msgFlatKeyFormat, deprecatedKey, defaultValue)
-			newValueMsg += fmt.Sprintf(msgNestedKeyFormat, key, defaultValue)
+			newValueMsg += fmt.Sprintf(msgNestedKeyFormat, subkeys[1], defaultValue)
 			// Let viper manage the nested key as the primary key,
 			// and the flat key as an alias
 			viper.RegisterAlias(deprecatedKey, key)

--- a/commands/server.go
+++ b/commands/server.go
@@ -277,21 +277,21 @@ func setConfig() {
 
 	// Consul configuration default settings
 	// TODO: uncomment this block
-/*
-	viper.SetDefault("consul.address", "") // Use consul api default
-	viper.SetDefault("consul.datacenter", "dc1")
-	viper.SetDefault("consul.token", "anonymous")
-	viper.SetDefault("consul.ssl_verify", true)
-	viper.SetDefault("consul.publisher_max_routines", config.DefaultConsulPubMaxRoutines)
+	/*
+		viper.SetDefault("consul.address", "") // Use consul api default
+		viper.SetDefault("consul.datacenter", "dc1")
+		viper.SetDefault("consul.token", "anonymous")
+		viper.SetDefault("consul.ssl_verify", true)
+		viper.SetDefault("consul.publisher_max_routines", config.DefaultConsulPubMaxRoutines)
 
-	// Ansible configuration default settings
+		// Ansible configuration default settings
 
-	viper.SetDefault("ansible.use_openssh", false)
-	viper.SetDefault("ansible.debug", false)
-	viper.SetDefault("ansible.connection_retries", 5)
-	viper.SetDefault("ansible.operation_remote_base_dir", ".yorc")
-	viper.SetDefault("ansible.keep_operation_remote_path", config.DefaultKeepOperationRemotePath)
-*/
+		viper.SetDefault("ansible.use_openssh", false)
+		viper.SetDefault("ansible.debug", false)
+		viper.SetDefault("ansible.connection_retries", 5)
+		viper.SetDefault("ansible.operation_remote_base_dir", ".yorc")
+		viper.SetDefault("ansible.keep_operation_remote_path", config.DefaultKeepOperationRemotePath)
+	*/
 	//Configuration file directories
 	viper.SetConfigName("config.yorc") // name of config file (without extension)
 	viper.AddConfigPath("/etc/yorc/")  // adding home directory as first search path

--- a/commands/server_test.go
+++ b/commands/server_test.go
@@ -157,7 +157,7 @@ func TestConfigFile(t *testing.T) {
 		AnsibleConfig config.Ansible
 		ConsulConfig  config.Consul
 	}{
-		{FileName: "testData/config_flat.yorc.json",
+		{FileName: "testdata/config_flat.yorc.json",
 			AnsibleConfig: config.Ansible{
 				UseOpenSSH:              true,
 				DebugExec:               true,
@@ -176,7 +176,7 @@ func TestConfigFile(t *testing.T) {
 				SSLVerify:      false,
 				PubMaxRoutines: 1234},
 		},
-		{FileName: "testData/config_structured.yorc.json",
+		{FileName: "testdata/config_structured.yorc.json",
 			AnsibleConfig: config.Ansible{
 				UseOpenSSH:              true,
 				DebugExec:               true,

--- a/commands/server_test.go
+++ b/commands/server_test.go
@@ -147,9 +147,9 @@ func TestServerInitVaultExtraFlagsWithSpaceDelimiterAndBoolAtEnd(t *testing.T) {
 	require.Equal(t, resolvedServerExtraParams[1].viperNames[2], "vault.secured3")
 }
 
-// Tests Ansible and Consul Config Values:
-// - using a configuration file with flat data (backwrd compatibility)
-// - using a configuration file with structured data
+// Tests configuration values:
+// - using a configuration file with deprecated values (backward compatibility check)
+// - using a configuration file with the expected format
 func TestConfigFile(t *testing.T) {
 
 	fileToExpectedValues := []struct {
@@ -203,67 +203,95 @@ func TestConfigFile(t *testing.T) {
 
 		testResetConfig()
 		setConfig()
-		testLoadConfigFile(t, fileToExpectedValue.FileName)
+		viper.SetConfigFile(fileToExpectedValue.FileName)
+		initConfig()
 		testConfig := getConfig()
 
 		assert.Equal(t, fileToExpectedValue.AnsibleConfig, testConfig.Ansible, "Ansible configuration differs from value defined in config file %s", fileToExpectedValue.FileName)
 		assert.Equal(t, fileToExpectedValue.ConsulConfig, testConfig.Consul, "Consul configuration differs from value defined in config file %s", fileToExpectedValue.FileName)
 	}
-
 }
 
-// Tests Ansible and Consul default values
-func TestDefaultValues(t *testing.T) {
+// Tests Ansible configuration default values
+func TestAnsibleDefaultValues(t *testing.T) {
 
-	// TODO: uncomment this block
-	/*
-		expectedAnsibleConfig := config.Ansible {
-			UseOpenSSH: 				false,
-			DebugExec: 					false,
-			ConnectionRetries: 			5,
-			OperationRemoteBaseDir:		".yorc",
-			KeepOperationRemotePath:	false,
-		}
+	expectedAnsibleConfig := config.Ansible{
+		UseOpenSSH:              false,
+		DebugExec:               false,
+		ConnectionRetries:       5,
+		OperationRemoteBaseDir:  ".yorc",
+		KeepOperationRemotePath: false,
+	}
 
-		expectedConsulConfig := config.Consul {
-			Token: 			"anonymous",
-			Datacenter: 	"dc1",
-			Address: 		"",
-			Key: 			"",
-			Cert: 			"",
-			CA: 			"",
-			CAPath: 		"",
-			SSL: 			false,
-			SSLVerify: 		true,
-			PubMaxRoutines:	config.DefaultConsulPubMaxRoutines,
-		}
+	testResetConfig()
+	setConfig()
+	initConfig()
+	testConfig := getConfig()
 
-		testResetConfig()
-		// No Configuration file specified here to check default values
-		setConfig()
-		initConfig()
-		TODO : uncomment this block
-		testConfig := getConfig()
-
-		assert.Equal(t, expectedAnsibleConfig, testConfig.Ansible, "Ansible configuration differs from expected default configuration")
-		assert.Equal(t, expectedConsulConfig, testConfig.Consul, "Consul configuration differs from expected default configuration")
-		viper.Debug()
-	*/
-
+	assert.Equal(t, expectedAnsibleConfig, testConfig.Ansible, "Ansible configuration differs from expected default configuration")
 }
 
-// Tests Ansible and Consul configuration using environment variables
-func TestEnvVariables(t *testing.T) {
+// Tests Consul configuration default values
+func TestConsulDefaultValues(t *testing.T) {
+
+	expectedConsulConfig := config.Consul{
+		Token:          "anonymous",
+		Datacenter:     "dc1",
+		Address:        "",
+		Key:            "",
+		Cert:           "",
+		CA:             "",
+		CAPath:         "",
+		SSL:            false,
+		SSLVerify:      true,
+		PubMaxRoutines: config.DefaultConsulPubMaxRoutines,
+	}
+
+	testResetConfig()
+	setConfig()
+	initConfig()
+	testConfig := getConfig()
+
+	assert.Equal(t, expectedConsulConfig, testConfig.Consul, "Consul configuration differs from expected default configuration")
+}
+
+// Tests Ansible configuration using environment variables
+func TestAnsibleEnvVariables(t *testing.T) {
 	expectedAnsibleConfig := config.Ansible{
 		UseOpenSSH:              true,
 		DebugExec:               true,
 		ConnectionRetries:       12,
-		OperationRemoteBaseDir:  ".yorctestEnv",
+		OperationRemoteBaseDir:  "testEnvBaseDir",
 		KeepOperationRemotePath: true,
 	}
 
+	// Set Ansible configuration environment ariables
+	os.Setenv("YORC_ANSIBLE_USE_OPENSSH", strconv.FormatBool(expectedAnsibleConfig.UseOpenSSH))
+	os.Setenv("YORC_ANSIBLE_DEBUG", strconv.FormatBool(expectedAnsibleConfig.DebugExec))
+	os.Setenv("YORC_ANSIBLE_CONNECTION_RETRIES", strconv.Itoa(expectedAnsibleConfig.ConnectionRetries))
+	os.Setenv("YORC_OPERATION_REMOTE_BASE_DIR", expectedAnsibleConfig.OperationRemoteBaseDir)
+	os.Setenv("YORC_KEEP_OPERATION_REMOTE_PATH", strconv.FormatBool(expectedAnsibleConfig.KeepOperationRemotePath))
+
+	testResetConfig()
+	setConfig()
+	initConfig()
+	testConfig := getConfig()
+
+	assert.Equal(t, expectedAnsibleConfig, testConfig.Ansible, "Ansible configuration differs from expected environment configuration")
+
+	// cleanup env
+	os.Unsetenv("YORC_ANSIBLE_USE_OPENSSH")
+	os.Unsetenv("YORC_ANSIBLE_DEBUG")
+	os.Unsetenv("YORC_ANSIBLE_CONNECTION_RETRIES")
+	os.Unsetenv("YORC_OPERATION_REMOTE_BASE_DIR")
+	os.Unsetenv("YORC_KEEP_OPERATION_REMOTE_PATH")
+}
+
+// Tests Consul configuration using environment variables
+func TestConsulEnvVariables(t *testing.T) {
+
 	expectedConsulConfig := config.Consul{
-		Token:          "testTokenEnv",
+		Token:          "testEnvToken",
 		Datacenter:     "testEnvDC",
 		Address:        "testEnvAddress",
 		Key:            "testEnvKey",
@@ -274,13 +302,6 @@ func TestEnvVariables(t *testing.T) {
 		SSLVerify:      false,
 		PubMaxRoutines: 125,
 	}
-
-	// Set Ansible configuration environment ariables
-	os.Setenv("YORC_ANSIBLE_USE_OPENSSH", strconv.FormatBool(expectedAnsibleConfig.UseOpenSSH))
-	os.Setenv("YORC_ANSIBLE_DEBUG", strconv.FormatBool(expectedAnsibleConfig.DebugExec))
-	os.Setenv("YORC_ANSIBLE_CONNECTION_RETRIES", strconv.Itoa(expectedAnsibleConfig.ConnectionRetries))
-	os.Setenv("YORC_OPERATION_REMOTE_BASE_DIR", expectedAnsibleConfig.OperationRemoteBaseDir)
-	os.Setenv("YORC_KEEP_OPERATION_REMOTE_PATH", strconv.FormatBool(expectedAnsibleConfig.KeepOperationRemotePath))
 
 	// Set Consul configuration environment variables
 	os.Setenv("YORC_CONSUL_ADDRESS", expectedConsulConfig.Address)
@@ -295,27 +316,107 @@ func TestEnvVariables(t *testing.T) {
 	os.Setenv("YORC_CONSUL_PUBLISHER_MAX_ROUTINES", strconv.Itoa(expectedConsulConfig.PubMaxRoutines))
 
 	testResetConfig()
-	// No Configuration file specified here. Just checking environment variables.
 	setConfig()
 	initConfig()
 	testConfig := getConfig()
 
-	assert.Equal(t, expectedAnsibleConfig, testConfig.Ansible, "Ansible configuration differs from expected environment configuration")
 	assert.Equal(t, expectedConsulConfig, testConfig.Consul, "Consul configuration differs from expected environment configuration")
+
+	// cleanup env
+	os.Unsetenv("YORC_CONSUL_ADDRESS")
+	os.Unsetenv("YORC_CONSUL_TOKEN")
+	os.Unsetenv("YORC_CONSUL_DATACENTER")
+	os.Unsetenv("YORC_CONSUL_KEY_FILE")
+	os.Unsetenv("YORC_CONSUL_CERT_FILE")
+	os.Unsetenv("YORC_CONSUL_CA_CERT")
+	os.Unsetenv("YORC_CONSUL_CA_PATH")
+	os.Unsetenv("YORC_CONSUL_SSL")
+	os.Unsetenv("YORC_CONSUL_SSL_VERIFY")
+	os.Unsetenv("YORC_CONSUL_PUBLISHER_MAX_ROUTINES")
+}
+
+// Tests Ansible configuration using persistent flags
+func TestAnsiblePersistentFlags(t *testing.T) {
+
+	expectedAnsibleConfig := config.Ansible{
+		UseOpenSSH:              true,
+		DebugExec:               true,
+		ConnectionRetries:       15,
+		OperationRemoteBaseDir:  "testPFlagBaseDir",
+		KeepOperationRemotePath: true,
+	}
+
+	ansiblePFlagConfiguration := map[string]string{
+		"ansible_use_openssh":        strconv.FormatBool(expectedAnsibleConfig.UseOpenSSH),
+		"ansible_debug":              strconv.FormatBool(expectedAnsibleConfig.DebugExec),
+		"ansible_connection_retries": strconv.Itoa(expectedAnsibleConfig.ConnectionRetries),
+		"operation_remote_base_dir":  expectedAnsibleConfig.OperationRemoteBaseDir,
+		"keep_operation_remote_path": strconv.FormatBool(expectedAnsibleConfig.KeepOperationRemotePath),
+	}
+
+	testResetConfig()
+	// No Configuration file specified here. Just checking environment variables.
+	setConfig()
+	initConfig()
+
+	// Set persistent flags
+	for key, value := range ansiblePFlagConfiguration {
+		err := serverCmd.PersistentFlags().Set(key, value)
+		require.NoError(t, err, "Could not set persistent flag %s", key)
+	}
+
+	testConfig := getConfig()
+
+	assert.Equal(t, expectedAnsibleConfig, testConfig.Ansible, "Ansible configuration differs from persistent flags settings")
+}
+
+// Tests Consul configuration using persistent flags
+func TestConsulPersistentFlags(t *testing.T) {
+
+	expectedConsulConfig := config.Consul{
+		Token:          "testPFlagToken",
+		Datacenter:     "testPFlagDC",
+		Address:        "testPFlagAddress",
+		Key:            "testPFlagKey",
+		Cert:           "testPFlagCert",
+		CA:             "testPFlagCA",
+		CAPath:         "testEnvCAPath",
+		SSL:            true,
+		SSLVerify:      false,
+		PubMaxRoutines: 123,
+	}
+
+	consulPFlagConfiguration := map[string]string{
+		"consul_token":                  expectedConsulConfig.Token,
+		"consul_datacenter":             expectedConsulConfig.Datacenter,
+		"consul_address":                expectedConsulConfig.Address,
+		"consul_key_file":               expectedConsulConfig.Key,
+		"consul_cert_file":              expectedConsulConfig.Cert,
+		"consul_ca_cert":                expectedConsulConfig.CA,
+		"consul_ca_path":                expectedConsulConfig.CAPath,
+		"consul_ssl":                    strconv.FormatBool(expectedConsulConfig.SSL),
+		"consul_ssl_verify":             strconv.FormatBool(expectedConsulConfig.SSLVerify),
+		"consul_publisher_max_routines": strconv.Itoa(expectedConsulConfig.PubMaxRoutines),
+	}
+
+	testResetConfig()
+	// No Configuration file specified here. Just checking environment variables.
+	setConfig()
+	initConfig()
+
+	// Set persistent flags
+	for key, value := range consulPFlagConfiguration {
+		err := serverCmd.PersistentFlags().Set(key, value)
+		require.NoError(t, err, "Could not set persistent flag %s", key)
+	}
+
+	testConfig := getConfig()
+
+	assert.Equal(t, expectedConsulConfig, testConfig.Consul, "Consul configuration differs from persistent flags settings")
 }
 
 // Test utility resetting the Orchestrator config
 func testResetConfig() {
 	viper.Reset()
 	serverCmd.ResetFlags()
-}
-
-// Test utility loading the content of a config file
-func testLoadConfigFile(t *testing.T, fileName string) {
-
-	viper.SetConfigFile(fileName)
-	err := viper.ReadInConfig()
-	require.NoError(t, err, "Failure reading Config file %s", fileName)
-
-	initConfig()
 }

--- a/commands/server_test.go
+++ b/commands/server_test.go
@@ -153,126 +153,126 @@ func TestServerInitVaultExtraFlagsWithSpaceDelimiterAndBoolAtEnd(t *testing.T) {
 func TestConfigFile(t *testing.T) {
 
 	fileToExpectedValues := []struct {
-		FileName string
+		FileName      string
 		AnsibleConfig config.Ansible
-		ConsulConfig config.Consul
+		ConsulConfig  config.Consul
 	}{
 		{FileName: "testData/config_flat.yorc.json",
 			AnsibleConfig: config.Ansible{
-				UseOpenSSH: 				true,
-				DebugExec: 					true,
-				ConnectionRetries: 			10,
-				OperationRemoteBaseDir:		"test_base_dir",
-				KeepOperationRemotePath:	true},
+				UseOpenSSH:              true,
+				DebugExec:               true,
+				ConnectionRetries:       10,
+				OperationRemoteBaseDir:  "test_base_dir",
+				KeepOperationRemotePath: true},
 			ConsulConfig: config.Consul{
-				Token:			"testToken",
-				Datacenter:		"testDC",
-				Address:		"http://127.0.0.1:8500",
-				Key:			"testKeyFile",
-				Cert:			"testCertFile",
-				CA:				"testCACert",
-				CAPath:			"testCAPath",
-				SSL:			true,
-				SSLVerify:		false,
-				PubMaxRoutines:	1234},
+				Token:          "testToken",
+				Datacenter:     "testDC",
+				Address:        "http://127.0.0.1:8500",
+				Key:            "testKeyFile",
+				Cert:           "testCertFile",
+				CA:             "testCACert",
+				CAPath:         "testCAPath",
+				SSL:            true,
+				SSLVerify:      false,
+				PubMaxRoutines: 1234},
 		},
 		{FileName: "testData/config_structured.yorc.json",
 			AnsibleConfig: config.Ansible{
-			   UseOpenSSH: 				true,
-			   DebugExec:				true,
-			   ConnectionRetries:		11,
-			   OperationRemoteBaseDir:	"test_base_dir2",
-			   KeepOperationRemotePath:	true,
+				UseOpenSSH:              true,
+				DebugExec:               true,
+				ConnectionRetries:       11,
+				OperationRemoteBaseDir:  "test_base_dir2",
+				KeepOperationRemotePath: true,
 			},
 			ConsulConfig: config.Consul{
-			   Token:			"testToken2",
-			   Datacenter:		"testDC2",
-			   Address:			"http://127.0.0.1:8502",
-			   Key:				"testKeyFile2",
-			   Cert:			"testCertFile2",
-			   CA:				"testCACert2",
-			   CAPath:			"testCAPath2",
-			   SSL:				true,
-			   SSLVerify:		false,
-			   PubMaxRoutines:	4321,
+				Token:          "testToken2",
+				Datacenter:     "testDC2",
+				Address:        "http://127.0.0.1:8502",
+				Key:            "testKeyFile2",
+				Cert:           "testCertFile2",
+				CA:             "testCACert2",
+				CAPath:         "testCAPath2",
+				SSL:            true,
+				SSLVerify:      false,
+				PubMaxRoutines: 4321,
 			},
 		},
 	}
-	
+
 	for _, fileToExpectedValue := range fileToExpectedValues {
-		
+
 		testResetConfig()
 		setConfig()
 		testLoadConfigFile(t, fileToExpectedValue.FileName)
 		testConfig := getConfig()
-	
-		assert.Equal(t, fileToExpectedValue.AnsibleConfig, testConfig.Ansible, "Ansible configuration differs from value defined in config file %s", fileToExpectedValue.FileName) 
+
+		assert.Equal(t, fileToExpectedValue.AnsibleConfig, testConfig.Ansible, "Ansible configuration differs from value defined in config file %s", fileToExpectedValue.FileName)
 		assert.Equal(t, fileToExpectedValue.ConsulConfig, testConfig.Consul, "Consul configuration differs from value defined in config file %s", fileToExpectedValue.FileName)
 	}
 
 }
 
 // Tests Ansible and Consul default values
-func TestDefaultValues(t *testing.T){
+func TestDefaultValues(t *testing.T) {
 
 	// TODO: uncomment this block
-/*
-	expectedAnsibleConfig := config.Ansible {
-		UseOpenSSH: 				false,
-		DebugExec: 					false,
-		ConnectionRetries: 			5,
-		OperationRemoteBaseDir:		".yorc",
-		KeepOperationRemotePath:	false,
-	}
-	
-	expectedConsulConfig := config.Consul {
-		Token: 			"anonymous",
-		Datacenter: 	"dc1",
-		Address: 		"",
-		Key: 			"",
-		Cert: 			"",
-		CA: 			"",
-		CAPath: 		"",
-		SSL: 			false,
-		SSLVerify: 		true,
-		PubMaxRoutines:	config.DefaultConsulPubMaxRoutines,
-	}
+	/*
+		expectedAnsibleConfig := config.Ansible {
+			UseOpenSSH: 				false,
+			DebugExec: 					false,
+			ConnectionRetries: 			5,
+			OperationRemoteBaseDir:		".yorc",
+			KeepOperationRemotePath:	false,
+		}
 
-	testResetConfig()
-	// No Configuration file specified here to check default values
-	setConfig()
-	initConfig()
-	TODO : uncomment this block
-	testConfig := getConfig()
-	
-	assert.Equal(t, expectedAnsibleConfig, testConfig.Ansible, "Ansible configuration differs from expected default configuration") 
-	assert.Equal(t, expectedConsulConfig, testConfig.Consul, "Consul configuration differs from expected default configuration")
-	viper.Debug()
-*/
+		expectedConsulConfig := config.Consul {
+			Token: 			"anonymous",
+			Datacenter: 	"dc1",
+			Address: 		"",
+			Key: 			"",
+			Cert: 			"",
+			CA: 			"",
+			CAPath: 		"",
+			SSL: 			false,
+			SSLVerify: 		true,
+			PubMaxRoutines:	config.DefaultConsulPubMaxRoutines,
+		}
+
+		testResetConfig()
+		// No Configuration file specified here to check default values
+		setConfig()
+		initConfig()
+		TODO : uncomment this block
+		testConfig := getConfig()
+
+		assert.Equal(t, expectedAnsibleConfig, testConfig.Ansible, "Ansible configuration differs from expected default configuration")
+		assert.Equal(t, expectedConsulConfig, testConfig.Consul, "Consul configuration differs from expected default configuration")
+		viper.Debug()
+	*/
 
 }
 
 // Tests Ansible and Consul configuration using environment variables
-func TestEnvVariables(t *testing.T){
-	expectedAnsibleConfig := config.Ansible {
-		UseOpenSSH: 				true,
-		DebugExec: 					true,
-		ConnectionRetries: 			12,
-		OperationRemoteBaseDir:		".yorctestEnv",
-		KeepOperationRemotePath:	true,
+func TestEnvVariables(t *testing.T) {
+	expectedAnsibleConfig := config.Ansible{
+		UseOpenSSH:              true,
+		DebugExec:               true,
+		ConnectionRetries:       12,
+		OperationRemoteBaseDir:  ".yorctestEnv",
+		KeepOperationRemotePath: true,
 	}
-	
-	expectedConsulConfig := config.Consul {
-		Token: 			"testTokenEnv",
-		Datacenter: 	"testEnvDC",
-		Address: 		"testEnvAddress",
-		Key: 			"testEnvKey",
-		Cert: 			"testEnvCert",
-		CA: 			"testEnvCA",
-		CAPath: 		"testEnvCAPath",
-		SSL: 			true,
-		SSLVerify: 		false,
-		PubMaxRoutines:	125,
+
+	expectedConsulConfig := config.Consul{
+		Token:          "testTokenEnv",
+		Datacenter:     "testEnvDC",
+		Address:        "testEnvAddress",
+		Key:            "testEnvKey",
+		Cert:           "testEnvCert",
+		CA:             "testEnvCA",
+		CAPath:         "testEnvCAPath",
+		SSL:            true,
+		SSLVerify:      false,
+		PubMaxRoutines: 125,
 	}
 
 	// Set Ansible configuration environment ariables
@@ -294,28 +294,28 @@ func TestEnvVariables(t *testing.T){
 	os.Setenv("YORC_CONSUL_SSL_VERIFY", strconv.FormatBool(expectedConsulConfig.SSLVerify))
 	os.Setenv("YORC_CONSUL_PUBLISHER_MAX_ROUTINES", strconv.Itoa(expectedConsulConfig.PubMaxRoutines))
 
-	testResetConfig()	
+	testResetConfig()
 	// No Configuration file specified here. Just checking environment variables.
 	setConfig()
 	initConfig()
 	testConfig := getConfig()
-	
-	assert.Equal(t, expectedAnsibleConfig, testConfig.Ansible, "Ansible configuration differs from expected environment configuration") 
+
+	assert.Equal(t, expectedAnsibleConfig, testConfig.Ansible, "Ansible configuration differs from expected environment configuration")
 	assert.Equal(t, expectedConsulConfig, testConfig.Consul, "Consul configuration differs from expected environment configuration")
 }
 
 // Test utility resetting the Orchestrator config
-func testResetConfig(){
+func testResetConfig() {
 	viper.Reset()
 	serverCmd.ResetFlags()
 }
 
 // Test utility loading the content of a config file
-func testLoadConfigFile(t *testing.T, fileName string){
+func testLoadConfigFile(t *testing.T, fileName string) {
 
 	viper.SetConfigFile(fileName)
 	err := viper.ReadInConfig()
 	require.NoError(t, err, "Failure reading Config file %s", fileName)
 
 	initConfig()
-} 
+}

--- a/commands/testdata/config_flat.yorc.json
+++ b/commands/testdata/config_flat.yorc.json
@@ -1,0 +1,67 @@
+{
+  "working_directory": "work",
+  "plugins_directory": "plugins",
+  "workers_number": 3,
+  "server_graceful_shutdown_timeout": "5m",
+  "wf_step_graceful_termination_timeout": "2m",
+  "http_port": 8800,
+  "http_address": "0.0.0.0",
+  "resources_prefix": "yorc-",
+  "ansible_use_openssh": true,
+  "ansible_debug": true,
+  "ansible_connection_retries": 10,
+  "operation_remote_base_dir": "test_base_dir",
+	"keep_operation_remote_path": true, 
+  "consul_address": "http://127.0.0.1:8500",
+  "consul_datacenter": "testDC",
+  "consul_token": "testToken",
+  "consul_publisher_max_routines": 1234,
+  "consul_key_file": "testKeyFile",
+  "consul_cert_file": "testCertFile",
+  "consul_ca_cert": "testCACert",
+  "consul_ca_path": "testCAPath",
+  "consul_ssl": true,
+  "consul_ssl_verify": false,
+  "telemetry":{
+    "statsd_address": "127.0.0.1:8125",
+    "expose_prometheus_endpoint": true
+  },
+  "vault": {
+    "type": "hashicorp",
+    "address": "http://127.0.0.1:8200",
+    "max_retries": "5",
+    "timeout": "5m",
+    "ca_cert": "/etc/pki/yorc/vault/ca/ca.pem",
+    "ca_path": "/etc/pki/yorc/vault/ca/",
+    "client_cert": "/etc/pki/yorc/vault/client/client.pem",
+    "client_key": "/etc/pki/yorc/vault/client/client.key",
+    "tls_server_name": "vault.yorc.rocks",
+    "tls_skip_verify": false,
+    "token": "blabla"
+  },
+  "infrastructures":{
+    "openstack": {
+      "auth_url": "http://openstack:5000/v2.0",
+      "tenant_name": "Tname",
+      "tenant_id": "use_tid_or_tname",
+      "user_name": "{{with (secret \"/secret/yorc/mysecret\").Raw}}{{.Data.value}}{{end}}",
+      "password": "{{secret \"/secret/yorc/mysecret\" \"data=value\" | print}}",
+      "region": "RegionOne",
+      "private_network_name": "private-test",
+      "public_network_name": "not_supported",
+      "os_default_security_groups": ["default", "lax"]
+    },
+    "kubernetes": {
+      "master_url": "https://kube:6443",
+      "cert_file": "/etc/pki/yorc/k8s-client.crt",
+      "key_file": "/etc/pki/yorc/k8s-client.key",
+      "ca_file": "/etc/pki/yorc/k8s-ca.crt"
+    },
+    "aws":{
+      "region": "us-east-2"
+    },
+    "slurm":{
+      "default_job_name": "xBD"
+    }
+  }
+}

--- a/commands/testdata/config_structured.yorc.json
+++ b/commands/testdata/config_structured.yorc.json
@@ -1,0 +1,71 @@
+{
+  "working_directory": "work2",
+  "plugins_directory": "plugins",
+  "workers_number": 3,
+  "server_graceful_shutdown_timeout": "5m",
+  "wf_step_graceful_termination_timeout": "2m",
+  "http_port": 8800,
+  "http_address": "0.0.0.0",
+  "resources_prefix": "yorc-",
+  "ansible":{
+    "use_openssh": true,
+    "debug": true,
+    "connection_retries": 11,
+    "operation_remote_base_dir": "test_base_dir2",
+    "keep_operation_remote_path": true
+  },
+  "consul":{
+    "address": "http://127.0.0.1:8502",
+    "datacenter": "testDC2",
+    "token": "testToken2",
+    "publisher_max_routines": 4321,
+    "key_file": "testKeyFile2",
+    "cert_file": "testCertFile2",
+    "ca_cert": "testCACert2",
+    "ca_path": "testCAPath2",
+    "ssl": true,
+    "ssl_verify": false  
+  }, 
+   "telemetry":{
+    "statsd_address": "127.0.0.1:8125",
+    "expose_prometheus_endpoint": true
+  },
+  "vault": {
+    "type": "hashicorp",
+    "address": "http://127.0.0.1:8200",
+    "max_retries": "5",
+    "timeout": "5m",
+    "ca_cert": "/etc/pki/yorc/vault/ca/ca.pem",
+    "ca_path": "/etc/pki/yorc/vault/ca/",
+    "client_cert": "/etc/pki/yorc/vault/client/client.pem",
+    "client_key": "/etc/pki/yorc/vault/client/client.key",
+    "tls_server_name": "vault.yorc.rocks",
+    "tls_skip_verify": false,
+    "token": "blabla"
+  },
+  "infrastructures":{
+    "openstack": {
+      "auth_url": "http://openstack:5000/v2.0",
+      "tenant_name": "Tname",
+      "tenant_id": "use_tid_or_tname",
+      "user_name": "{{with (secret \"/secret/yorc/mysecret\").Raw}}{{.Data.value}}{{end}}",
+      "password": "{{secret \"/secret/yorc/mysecret\" \"data=value\" | print}}",
+      "region": "RegionOne",
+      "private_network_name": "private-test",
+      "public_network_name": "not_supported",
+      "os_default_security_groups": ["default", "lax"]
+    },
+    "kubernetes": {
+      "master_url": "https://kube:6443",
+      "cert_file": "/etc/pki/yorc/k8s-client.crt",
+      "key_file": "/etc/pki/yorc/k8s-client.key",
+      "ca_file": "/etc/pki/yorc/k8s-ca.crt"
+    },
+    "aws":{
+      "region": "us-east-2"
+    },
+    "slurm":{
+      "default_job_name": "xBD"
+    }
+  }
+}

--- a/config/config.go
+++ b/config/config.go
@@ -53,7 +53,7 @@ const DefaultWfStepGracefulTerminationTimeout = 2 * time.Minute
 
 // Configuration holds config information filled by Cobra and Viper (see commands package for more information)
 type Configuration struct {
-	Ansible                			 Ansible
+	Ansible                          Ansible
 	PluginsDirectory                 string
 	WorkingDirectory                 string
 	WorkersNumber                    int
@@ -63,7 +63,7 @@ type Configuration struct {
 	KeyFile                          string
 	CertFile                         string
 	ResourcesPrefix                  string
-	Consul							 Consul
+	Consul                           Consul
 	Telemetry                        Telemetry
 	Infrastructures                  map[string]DynamicMap
 	Vault                            DynamicMap
@@ -72,25 +72,25 @@ type Configuration struct {
 
 // Ansible configuration
 type Ansible struct {
-	UseOpenSSH				bool
-	DebugExec				bool
-	ConnectionRetries		int
-	OperationRemoteBaseDir	string
-	KeepOperationRemotePath	bool
+	UseOpenSSH              bool
+	DebugExec               bool
+	ConnectionRetries       int
+	OperationRemoteBaseDir  string
+	KeepOperationRemotePath bool
 }
 
 // Consul configuration
 type Consul struct {
-	Token           string
-	Datacenter      string
-	Address         string
-	Key             string
-	Cert            string
-	CA              string
-	CAPath          string
-	SSL             bool
-	SSLVerify       bool
-	PubMaxRoutines	int
+	Token          string
+	Datacenter     string
+	Address        string
+	Key            string
+	Cert           string
+	CA             string
+	CAPath         string
+	SSL            bool
+	SSLVerify      bool
+	PubMaxRoutines int
 }
 
 // Telemetry holds the configuration for the telemetry service

--- a/config/config.go
+++ b/config/config.go
@@ -53,10 +53,7 @@ const DefaultWfStepGracefulTerminationTimeout = 2 * time.Minute
 
 // Configuration holds config information filled by Cobra and Viper (see commands package for more information)
 type Configuration struct {
-	AnsibleUseOpenSSH                bool
-	AnsibleDebugExec                 bool
-	AnsibleConnectionRetries         int
-	OperationRemoteBaseDir           string
+	Ansible                			 Ansible
 	PluginsDirectory                 string
 	WorkingDirectory                 string
 	WorkersNumber                    int
@@ -65,22 +62,35 @@ type Configuration struct {
 	HTTPAddress                      string
 	KeyFile                          string
 	CertFile                         string
-	KeepOperationRemotePath          bool
 	ResourcesPrefix                  string
-	ConsulToken                      string
-	ConsulDatacenter                 string
-	ConsulAddress                    string
-	ConsulKey                        string
-	ConsulCert                       string
-	ConsulCA                         string
-	ConsulCAPath                     string
-	ConsulSSL                        bool
-	ConsulSSLVerify                  bool
-	ConsulPubMaxRoutines             int
+	Consul							 Consul
 	Telemetry                        Telemetry
 	Infrastructures                  map[string]DynamicMap
 	Vault                            DynamicMap
 	WfStepGracefulTerminationTimeout time.Duration
+}
+
+// Ansible configuration
+type Ansible struct {
+	UseOpenSSH				bool
+	DebugExec				bool
+	ConnectionRetries		int
+	OperationRemoteBaseDir	string
+	KeepOperationRemotePath	bool
+}
+
+// Consul configuration
+type Consul struct {
+	Token           string
+	Datacenter      string
+	Address         string
+	Key             string
+	Cert            string
+	CA              string
+	CAPath          string
+	SSL             bool
+	SSLVerify       bool
+	PubMaxRoutines	int
 }
 
 // Telemetry holds the configuration for the telemetry service

--- a/config/consul.go
+++ b/config/consul.go
@@ -23,33 +23,33 @@ import (
 func (cfg Configuration) GetConsulClient() (*api.Client, error) {
 
 	consulCustomConfig := api.DefaultConfig()
-	if cfg.ConsulAddress != "" {
-		consulCustomConfig.Address = cfg.ConsulAddress
+	if cfg.Consul.Address != "" {
+		consulCustomConfig.Address = cfg.Consul.Address
 	}
-	if cfg.ConsulDatacenter != "" {
-		consulCustomConfig.Datacenter = cfg.ConsulDatacenter
+	if cfg.Consul.Datacenter != "" {
+		consulCustomConfig.Datacenter = cfg.Consul.Datacenter
 	}
-	if cfg.ConsulToken != "" {
-		consulCustomConfig.Token = cfg.ConsulToken
+	if cfg.Consul.Token != "" {
+		consulCustomConfig.Token = cfg.Consul.Token
 	}
-	if cfg.ConsulSSL {
+	if cfg.Consul.SSL {
 		consulCustomConfig.Scheme = "https"
 	}
-	if cfg.ConsulKey != "" {
-		consulCustomConfig.TLSConfig.KeyFile = cfg.ConsulKey
+	if cfg.Consul.Key != "" {
+		consulCustomConfig.TLSConfig.KeyFile = cfg.Consul.Key
 	}
-	if cfg.ConsulCert != "" {
-		consulCustomConfig.TLSConfig.CertFile = cfg.ConsulCert
+	if cfg.Consul.Cert != "" {
+		consulCustomConfig.TLSConfig.CertFile = cfg.Consul.Cert
 	}
-	if cfg.ConsulCA != "" {
-		consulCustomConfig.TLSConfig.CAFile = cfg.ConsulCA
+	if cfg.Consul.CA != "" {
+		consulCustomConfig.TLSConfig.CAFile = cfg.Consul.CA
 	}
-	if cfg.ConsulCAPath != "" {
-		consulCustomConfig.TLSConfig.CAPath = cfg.ConsulCAPath
+	if cfg.Consul.CAPath != "" {
+		consulCustomConfig.TLSConfig.CAPath = cfg.Consul.CAPath
 	}
-	if !cfg.ConsulSSLVerify {
+	if !cfg.Consul.SSLVerify {
 		consulCustomConfig.TLSConfig.InsecureSkipVerify = true
 	}
 	client, err := api.NewClient(consulCustomConfig)
-	return client, errors.Wrapf(err, "Failed to connect to consul %q", cfg.ConsulAddress)
+	return client, errors.Wrapf(err, "Failed to connect to consul %q", cfg.Consul.Address)
 }

--- a/config/consul_test.go
+++ b/config/consul_test.go
@@ -41,15 +41,17 @@ func TestConfiguration_GetConsulClient(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := Configuration{
-				ConsulToken:      tt.fields.ConsulToken,
-				ConsulDatacenter: tt.fields.ConsulDatacenter,
-				ConsulAddress:    tt.fields.ConsulAddress,
-				ConsulKey:        tt.fields.ConsulKey,
-				ConsulCert:       tt.fields.ConsulCert,
-				ConsulCA:         tt.fields.ConsulCA,
-				ConsulCAPath:     tt.fields.ConsulCAPath,
-				ConsulSSL:        tt.fields.ConsulSSL,
-				ConsulSSLVerify:  tt.fields.ConsulSSLVerify,
+				Consul: Consul{
+					Token:      tt.fields.ConsulToken,
+					Datacenter: tt.fields.ConsulDatacenter,
+					Address:    tt.fields.ConsulAddress,
+					Key:        tt.fields.ConsulKey,
+					Cert:       tt.fields.ConsulCert,
+					CA:         tt.fields.ConsulCA,
+					CAPath:     tt.fields.ConsulCAPath,
+					SSL:        tt.fields.ConsulSSL,
+					SSLVerify:  tt.fields.ConsulSSLVerify,
+				},
 			}
 			got, err := cfg.GetConsulClient()
 			if (err != nil) != tt.wantErr {

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -143,7 +143,7 @@ Below is an example of configuration file.
     }
 
 
-Below is an example of configuration file with TLS enable.
+Below is an example of configuration file with TLS enabled.
 
 .. code-block:: JSON
     
@@ -163,63 +163,6 @@ Below is an example of configuration file with TLS enable.
       }
     }
 
-.. _option_ansible_ssh_cfg:
-
-  * ``ansible_use_openssh``: Equivalent to :ref:`--ansible_use_openssh <option_ansible_ssh_cmd>` command-line flag.
-
-.. _option_ansible_debug_cfg:
-
-  * ``ansible_debug``: Equivalent to :ref:`--ansible_debug <option_ansible_debug_cmd>` command-line flag.
-
-.. _option_ansible_connection_retries_cfg:
-
-  * ``ansible_connection_retries``: Equivalent to :ref:`--ansible_connection_retries <option_ansible_connection_retries_cmd>` command-line flag.
-
-.. _option_operation_remote_base_dir_cfg:
-
-  * ``operation_remote_base_dir``: Equivalent to :ref:`--operation_remote_base_dir <option_operation_remote_base_dir_cmd>` command-line flag.
-
-.. _option_consul_addr_cfg:
-
-  * ``consul_address``: Equivalent to :ref:`--consul_address <option_consul_addr_cmd>` command-line flag.
-
-.. _option_consul_token_cfg:
-
-  * ``consul_token``: Equivalent to :ref:`--consul_token <option_consul_token_cmd>` command-line flag.
-
-.. _option_consul_dc_cfg:
-
-  * ``consul_datacenter``: Equivalent to :ref:`--consul_datacenter <option_consul_dc_cmd>` command-line flag.
-
-.. _option_consul_key_cfg:
-
-  * ``consul_key_file``: Equivalent to :ref:`--consul_key_file <option_consul_key_cmd>` command-line flag.
-
-.. _option_consul_cert_cfg:
-
-  * ``consul_cert_file``: Equivalent to :ref:`--consul_cert_file <option_consul_cert_cmd>` command-line flag.
-
-.. _option_consul_ca_cert_cfg:
-
-  * ``consul_ca_cert``: Equivalent to :ref:`--consul_ca_cert <option_consul_ca_cert_cmd>` command-line flag.
-
-.. _option_consul_ca_path_cfg:
-
-  * ``consul_ca_path``: Equivalent to :ref:`--consul_ca_path <option_consul_ca_path_cmd>` command-line flag.
-
-.. _option_consul_ssl_cfg:
-
-  * ``consul_ssl``: Equivalent to :ref:`--consul_ssl <option_consul_ssl_cmd>` command-line flag.
-
-.. _option_consul_ssl_verify_cfg:
-
-  * ``consul_ssl_verify``: Equivalent to :ref:`--consul_ssl_verify <option_consul_ssl_verify_cmd>` command-line flag.
-
-
-.. _option_pub_routines_cfg:
-
-  * ``consul_publisher_max_routines``: Equivalent to :ref:`--consul_publisher_max_routines <option_pub_routines_cmd>` command-line flag.
-
 .. _option_shut_timeout_cfg:
 
   * ``server_graceful_shutdown_timeout``: Equivalent to :ref:`--graceful_shutdown_timeout <option_shut_timeout_cmd>` command-line flag.
@@ -235,10 +178,6 @@ Below is an example of configuration file with TLS enable.
 .. _option_http_port_cfg:
 
   * ``http_port``: Equivalent to :ref:`--http_port <option_http_port_cmd>` command-line flag.
-
-.. _option_keep_remote_path_cfg:
-
-  * ``keep_operation_remote_path``: Equivalent to :ref:`--keep_operation_remote_path <option_keep_remote_path_cmd>` command-line flag.
 
 .. _option_keyfile_cfg:
 
@@ -263,6 +202,125 @@ Below is an example of configuration file with TLS enable.
 .. _option_workdir_cfg: 
 
   * ``working_directory``: Equivalent to :ref:`--working_directory <option_workdir_cmd>` command-line flag.
+
+.. _yorc_config_file_ansible_section:
+
+Ansible configuration
+~~~~~~~~~~~~~~~~~~~~~
+
+Below is an example of configuration file with Ansible configuration options.
+
+.. code-block:: JSON
+    
+    {
+      "resources_prefix": "yorc1-",
+      "infrastructures": {
+        "openstack": {
+          "auth_url": "http://your-openstack:5000/v2.0",
+          "tenant_name": "your-tenant",
+          "user_name": "os-user",
+          "password": "os-password",
+          "private_network_name": "default-private-network",
+          "default_security_groups": ["default"]
+        }
+      },
+      "ansible": {
+        "use_openssh": true,
+        "connection_retries": 3
+      }
+    }
+
+All available configuration options for Ansible are:
+
+.. _option_ansible_ssh_cfg:
+
+  * ``use_openssh``: Equivalent to :ref:`--ansible_use_openssh <option_ansible_ssh_cmd>` command-line flag.
+
+.. _option_ansible_debug_cfg:
+
+  * ``debug``: Equivalent to :ref:`--ansible_debug <option_ansible_debug_cmd>` command-line flag.
+
+.. _option_ansible_connection_retries_cfg:
+
+  * ``connection_retries``: Equivalent to :ref:`--ansible_connection_retries <option_ansible_connection_retries_cmd>` command-line flag.
+
+.. _option_operation_remote_base_dir_cfg:
+
+  * ``operation_remote_base_dir``: Equivalent to :ref:`--operation_remote_base_dir <option_operation_remote_base_dir_cmd>` command-line flag.
+
+.. _option_keep_remote_path_cfg:
+
+  * ``keep_operation_remote_path``: Equivalent to :ref:`--keep_operation_remote_path <option_keep_remote_path_cmd>` command-line flag.
+
+.. _yorc_config_file_consul_section:
+
+Consul configuration
+~~~~~~~~~~~~~~~~~~~~
+
+Below is an example of configuration file with Consul configuration options.
+
+.. code-block:: JSON
+    
+    {
+      "resources_prefix": "yorc1-",
+      "infrastructures": {
+        "openstack": {
+          "auth_url": "http://your-openstack:5000/v2.0",
+          "tenant_name": "your-tenant",
+          "user_name": "os-user",
+          "password": "os-password",
+          "private_network_name": "default-private-network",
+          "default_security_groups": ["default"]
+        }
+      },
+      "consul": {
+        "address": "http://consul-host:8500",
+        "datacenter": "dc1",
+        "publisher_max_routines": 500
+      }
+    }
+
+All available configuration options for Consul are:
+
+.. _option_consul_addr_cfg:
+
+  * ``address``: Equivalent to :ref:`--consul_address <option_consul_addr_cmd>` command-line flag.
+
+.. _option_consul_token_cfg:
+
+  * ``token``: Equivalent to :ref:`--consul_token <option_consul_token_cmd>` command-line flag.
+
+.. _option_consul_dc_cfg:
+
+  * ``datacenter``: Equivalent to :ref:`--consul_datacenter <option_consul_dc_cmd>` command-line flag.
+
+.. _option_consul_key_cfg:
+
+  * ``key_file``: Equivalent to :ref:`--consul_key_file <option_consul_key_cmd>` command-line flag.
+
+.. _option_consul_cert_cfg:
+
+  * ``cert_file``: Equivalent to :ref:`--consul_cert_file <option_consul_cert_cmd>` command-line flag.
+
+.. _option_consul_ca_cert_cfg:
+
+  * ``ca_cert``: Equivalent to :ref:`--consul_ca_cert <option_consul_ca_cert_cmd>` command-line flag.
+
+.. _option_consul_ca_path_cfg:
+
+  * ``ca_path``: Equivalent to :ref:`--consul_ca_path <option_consul_ca_path_cmd>` command-line flag.
+
+.. _option_consul_ssl_cfg:
+
+  * ``ssl``: Equivalent to :ref:`--consul_ssl <option_consul_ssl_cmd>` command-line flag.
+
+.. _option_consul_ssl_verify_cfg:
+
+  * ``ssl_verify``: Equivalent to :ref:`--consul_ssl_verify <option_consul_ssl_verify_cmd>` command-line flag.
+
+.. _option_pub_routines_cfg:
+
+  * ``publisher_max_routines``: Equivalent to :ref:`--consul_publisher_max_routines <option_pub_routines_cmd>` command-line flag.
 
 .. _yorc_config_file_telemetry_section:
 
@@ -321,6 +379,72 @@ All available configuration options for telemetry are:
 .. _option_telemetry_prom_cfg:
 
   * ``expose_prometheus_endpoint``: Specify if an HTTP Prometheus endpoint should be exposed allowing Prometheus to scrape metrics.
+
+.. _yorc_config_file_deprecated_section:
+
+Deprecated configuration options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 3.0.0
+.. _option_deprecated_ansible_ssh_cfg:
+
+  * ``ansible_use_openssh``: Equivalent to :ref:`--ansible_use_openssh <option_ansible_ssh_cmd>` command-line flag.
+
+.. _option_deprecated_ansible_debug_cfg:
+
+  * ``ansible_debug``: Equivalent to :ref:`--ansible_debug <option_ansible_debug_cmd>` command-line flag.
+
+.. _option_deprecated_ansible_connection_retries_cfg:
+
+  * ``ansible_connection_retries``: Equivalent to :ref:`--ansible_connection_retries <option_ansible_connection_retries_cmd>` command-line flag.
+
+.. _option_deprecated_operation_remote_base_dir_cfg:
+
+  * ``operation_remote_base_dir``: Equivalent to :ref:`--operation_remote_base_dir <option_operation_remote_base_dir_cmd>` command-line flag.
+
+.. _option_deprecated_keep_remote_path_cfg:
+
+  * ``keep_operation_remote_path``: Equivalent to :ref:`--keep_operation_remote_path <option_keep_remote_path_cmd>` command-line flag.
+
+.. _option_deprecated_consul_addr_cfg:
+
+  * ``consul_address``: Equivalent to :ref:`--consul_address <option_consul_addr_cmd>` command-line flag.
+
+.. _option_deprecated_consul_token_cfg:
+
+  * ``consul_token``: Equivalent to :ref:`--consul_token <option_consul_token_cmd>` command-line flag.
+
+.. _option_deprecated_consul_dc_cfg:
+
+  * ``consul_datacenter``: Equivalent to :ref:`--consul_datacenter <option_consul_dc_cmd>` command-line flag.
+
+.. _option_deprecated_consul_key_cfg:
+
+  * ``consul_key_file``: Equivalent to :ref:`--consul_key_file <option_consul_key_cmd>` command-line flag.
+
+.. _option_deprecated_consul_cert_cfg:
+
+  * ``consul_cert_file``: Equivalent to :ref:`--consul_cert_file <option_consul_cert_cmd>` command-line flag.
+
+.. _option_deprecated_consul_ca_cert_cfg:
+
+  * ``consul_ca_cert``: Equivalent to :ref:`--consul_ca_cert <option_consul_ca_cert_cmd>` command-line flag.
+
+.. _option_deprecated_consul_ca_path_cfg:
+
+  * ``consul_ca_path``: Equivalent to :ref:`--consul_ca_path <option_consul_ca_path_cmd>` command-line flag.
+
+.. _option_deprecated_consul_ssl_cfg:
+
+  * ``consul_ssl``: Equivalent to :ref:`--consul_ssl <option_consul_ssl_cmd>` command-line flag.
+
+.. _option_deprecated_consul_ssl_verify_cfg:
+
+  * ``consul_ssl_verify``: Equivalent to :ref:`--consul_ssl_verify <option_consul_ssl_verify_cmd>` command-line flag.
+
+.. _option_deprecated_pub_routines_cfg:
+
+  * ``consul_publisher_max_routines``: Equivalent to :ref:`--consul_publisher_max_routines <option_pub_routines_cmd>` command-line flag.
 
 Environment variables
 ---------------------

--- a/plugin/config.go
+++ b/plugin/config.go
@@ -42,7 +42,7 @@ func (cm *defaultConfigManager) SetupConfig(cfg config.Configuration) error {
 		return err
 	}
 	kv := cClient.KV()
-	maxPubSub := cfg.ConsulPubMaxRoutines
+	maxPubSub := cfg.Consul.PubMaxRoutines
 	if maxPubSub == 0 {
 		maxPubSub = config.DefaultConsulPubMaxRoutines
 	}

--- a/plugin/config_test.go
+++ b/plugin/config_test.go
@@ -34,7 +34,7 @@ func (m *mockConfigManager) SetupConfig(cfg config.Configuration) error {
 	m.setupConfigCalled = true
 	m.conf = cfg
 
-	if m.conf.ConsulAddress == "testFailure" {
+	if m.conf.Consul.Address == "testFailure" {
 		return NewRPCError(errors.New("a failure occurred during plugin exec operation"))
 	}
 	return nil
@@ -53,11 +53,11 @@ func TestConfigManagerSetupConfig(t *testing.T) {
 
 	cm := raw.(ConfigManager)
 
-	err = cm.SetupConfig(config.Configuration{ConsulAddress: "test", ConsulDatacenter: "testdc"})
+	err = cm.SetupConfig(config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}})
 	require.Nil(t, err)
 	require.True(t, mock.setupConfigCalled)
-	require.Equal(t, "test", mock.conf.ConsulAddress)
-	require.Equal(t, "testdc", mock.conf.ConsulDatacenter)
+	require.Equal(t, "test", mock.conf.Consul.Address)
+	require.Equal(t, "testdc", mock.conf.Consul.Datacenter)
 }
 
 func TestConfigManagerSetupConfigWithFailure(t *testing.T) {
@@ -73,6 +73,6 @@ func TestConfigManagerSetupConfigWithFailure(t *testing.T) {
 
 	cm := raw.(ConfigManager)
 
-	err = cm.SetupConfig(config.Configuration{ConsulAddress: "testFailure", ConsulDatacenter: "testdc"})
+	err = cm.SetupConfig(config.Configuration{Consul: config.Consul{Address: "testFailure", Datacenter: "testdc"}})
 	require.Error(t, err, "An error was expected during executing plugin operation")
 }

--- a/plugin/delegate_test.go
+++ b/plugin/delegate_test.go
@@ -72,11 +72,14 @@ func TestDelegateExecutorExecDelegate(t *testing.T) {
 
 	delegate := raw.(prov.DelegateExecutor)
 
-	err = delegate.ExecDelegate(context.Background(), config.Configuration{ConsulAddress: "test", ConsulDatacenter: "testdc"}, "TestTaskID", "TestDepID", "TestNodeName", "TestDelegateOP")
+	err = delegate.ExecDelegate(
+		context.Background(),
+		config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
+		"TestTaskID", "TestDepID", "TestNodeName", "TestDelegateOP")
 	require.Nil(t, err)
 	require.True(t, mock.execDelegateCalled)
-	require.Equal(t, "test", mock.conf.ConsulAddress)
-	require.Equal(t, "testdc", mock.conf.ConsulDatacenter)
+	require.Equal(t, "test", mock.conf.Consul.Address)
+	require.Equal(t, "testdc", mock.conf.Consul.Datacenter)
 	require.Equal(t, "TestTaskID", mock.taskID)
 	require.Equal(t, "TestDepID", mock.deploymentID)
 	require.Equal(t, "TestNodeName", mock.nodeName)
@@ -98,7 +101,10 @@ func TestDelegateExecutorExecDelegateWithFailure(t *testing.T) {
 
 	delegate := raw.(prov.DelegateExecutor)
 
-	err = delegate.ExecDelegate(context.Background(), config.Configuration{ConsulAddress: "test", ConsulDatacenter: "testdc"}, "TestTaskID", "TestFailure", "TestNodeName", "TestDelegateOP")
+	err = delegate.ExecDelegate(
+		context.Background(),
+		config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
+		"TestTaskID", "TestFailure", "TestNodeName", "TestDelegateOP")
 	require.Error(t, err, "An error was expected during executing plugin operation")
 }
 
@@ -119,7 +125,10 @@ func TestDelegateExecutorExecDelegateWithCancel(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancelF := context.WithCancel(ctx)
 	go func() {
-		err = delegate.ExecDelegate(ctx, config.Configuration{ConsulAddress: "test", ConsulDatacenter: "testdc"}, "TestTaskID", "TestCancel", "TestNodeName", "TestDelegateOP")
+		err = delegate.ExecDelegate(
+			ctx,
+			config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
+			"TestTaskID", "TestCancel", "TestNodeName", "TestDelegateOP")
 		require.Nil(t, err)
 	}()
 	cancelF()

--- a/plugin/infra_usage_collector_test.go
+++ b/plugin/infra_usage_collector_test.go
@@ -73,11 +73,14 @@ func TestInfraUsageCollectorGetUsageInfo(t *testing.T) {
 
 	plugin := raw.(prov.InfraUsageCollector)
 
-	info, err := plugin.GetUsageInfo(context.Background(), config.Configuration{ConsulAddress: "test", ConsulDatacenter: "testdc"}, "TestTaskID", "myInfra")
+	info, err := plugin.GetUsageInfo(
+		context.Background(),
+		config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
+		"TestTaskID", "myInfra")
 	require.Nil(t, err)
 	require.True(t, mock.getUsageInfoCalled)
-	require.Equal(t, "test", mock.conf.ConsulAddress)
-	require.Equal(t, "testdc", mock.conf.ConsulDatacenter)
+	require.Equal(t, "test", mock.conf.Consul.Address)
+	require.Equal(t, "testdc", mock.conf.Consul.Datacenter)
 	require.Equal(t, "TestTaskID", mock.taskID)
 	require.Equal(t, "myInfra", mock.infraName)
 	require.Equal(t, 3, len(info))
@@ -110,7 +113,10 @@ func TestInfraUsageCollectorGetUsageInfoWithFailure(t *testing.T) {
 
 	plugin := raw.(prov.InfraUsageCollector)
 
-	_, err = plugin.GetUsageInfo(context.Background(), config.Configuration{ConsulAddress: "test", ConsulDatacenter: "testdc"}, "TestFailure", "myInfra")
+	_, err = plugin.GetUsageInfo(
+		context.Background(),
+		config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
+		"TestFailure", "myInfra")
 	require.Error(t, err, "An error was expected during executing plugin infra usage collector")
 }
 
@@ -132,7 +138,10 @@ func TestInfraUsageCollectorGetUsageInfoWithCancel(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancelF := context.WithCancel(ctx)
 	go func() {
-		_, err = plugin.GetUsageInfo(ctx, config.Configuration{ConsulAddress: "test", ConsulDatacenter: "testdc"}, "TestCancel", "myInfra")
+		_, err = plugin.GetUsageInfo(
+			ctx,
+			config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
+			"TestCancel", "myInfra")
 		require.Nil(t, err)
 	}()
 	cancelF()

--- a/plugin/operation_test.go
+++ b/plugin/operation_test.go
@@ -80,11 +80,14 @@ func TestOperationExecutorExecOperation(t *testing.T) {
 			TargetNodeName:          "AnotherNode",
 		},
 	}
-	err = plugin.ExecOperation(context.Background(), config.Configuration{ConsulAddress: "test", ConsulDatacenter: "testdc"}, "TestTaskID", "TestDepID", "TestNodeName", op)
+	err = plugin.ExecOperation(
+		context.Background(),
+		config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
+		"TestTaskID", "TestDepID", "TestNodeName", op)
 	require.Nil(t, err)
 	require.True(t, mock.execoperationCalled)
-	require.Equal(t, "test", mock.conf.ConsulAddress)
-	require.Equal(t, "testdc", mock.conf.ConsulDatacenter)
+	require.Equal(t, "test", mock.conf.Consul.Address)
+	require.Equal(t, "testdc", mock.conf.Consul.Datacenter)
 	require.Equal(t, "TestTaskID", mock.taskID)
 	require.Equal(t, "TestDepID", mock.deploymentID)
 	require.Equal(t, "TestNodeName", mock.nodeName)
@@ -114,7 +117,10 @@ func TestOperationExecutorExecOperationWithFailure(t *testing.T) {
 			TargetNodeName:          "AnotherNode",
 		},
 	}
-	err = plugin.ExecOperation(context.Background(), config.Configuration{ConsulAddress: "test", ConsulDatacenter: "testdc"}, "TestTaskID", "TestFailure", "TestNodeName", op)
+	err = plugin.ExecOperation(
+		context.Background(),
+		config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
+		"TestTaskID", "TestFailure", "TestNodeName", op)
 	require.Error(t, err, "An error was expected during executing plugin operation")
 }
 
@@ -135,7 +141,10 @@ func TestOperationExecutorExecOperationWithCancel(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancelF := context.WithCancel(ctx)
 	go func() {
-		err = plugin.ExecOperation(ctx, config.Configuration{ConsulAddress: "test", ConsulDatacenter: "testdc"}, "TestTaskID", "TestCancel", "TestNodeName", prov.Operation{})
+		err = plugin.ExecOperation(
+			ctx,
+			config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
+			"TestTaskID", "TestCancel", "TestNodeName", prov.Operation{})
 		require.Nil(t, err)
 	}()
 	cancelF()

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -140,7 +140,7 @@ func newExecution(kv *api.KV, cfg config.Configuration, taskID, deploymentID, no
 		deploymentID: deploymentID,
 		NodeName:     nodeName,
 		//KeepOperationRemotePath property is required to be public when resolving templates.
-		KeepOperationRemotePath: cfg.KeepOperationRemotePath,
+		KeepOperationRemotePath: cfg.Ansible.KeepOperationRemotePath,
 		operation:               operation,
 		VarInputsNames:          make([]string, 0),
 		EnvInputs:               make([]*operations.EnvInput, 0),
@@ -777,7 +777,7 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 		return err
 	}
 	// e.OperationRemoteBaseDir is an unique base temp directory for multiple executions
-	e.OperationRemoteBaseDir = stringutil.UniqueTimestampedName(e.cfg.OperationRemoteBaseDir+"_", "")
+	e.OperationRemoteBaseDir = stringutil.UniqueTimestampedName(e.cfg.Ansible.OperationRemoteBaseDir+"_", "")
 	if e.operation.RelOp.IsRelationshipOperation {
 		e.OperationRemotePath = path.Join(e.OperationRemoteBaseDir, e.NodeName, e.relationshipType, e.operation.Name)
 	} else {

--- a/prov/ansible/execution_ansible.go
+++ b/prov/ansible/execution_ansible.go
@@ -168,10 +168,10 @@ func (e *executionAnsible) runAnsible(ctx context.Context, retry bool, currentIn
 	if _, err = os.Stat(filepath.Join(ansibleRecipePath, "run.ansible.retry")); retry && (err == nil || !os.IsNotExist(err)) {
 		cmd.Args = append(cmd.Args, "--limit", filepath.Join("@", ansibleRecipePath, "run.ansible.retry"))
 	}
-	if e.cfg.AnsibleDebugExec {
+	if e.cfg.Ansible.DebugExec {
 		cmd.Args = append(cmd.Args, "-vvvv")
 	}
-	if e.cfg.AnsibleUseOpenSSH {
+	if e.cfg.Ansible.UseOpenSSH {
 		cmd.Args = append(cmd.Args, "-c", "ssh")
 	} else {
 		cmd.Args = append(cmd.Args, "-c", "paramiko")

--- a/prov/ansible/execution_scripts.go
+++ b/prov/ansible/execution_scripts.go
@@ -247,10 +247,10 @@ func (e *executionScript) runAnsible(ctx context.Context, retry bool, currentIns
 	if _, err = os.Stat(filepath.Join(ansibleRecipePath, "run.ansible.retry")); retry && (err == nil || !os.IsNotExist(err)) {
 		cmd.Args = append(cmd.Args, "--limit", filepath.Join("@", ansibleRecipePath, "run.ansible.retry"))
 	}
-	if e.cfg.AnsibleDebugExec {
+	if e.cfg.Ansible.DebugExec {
 		cmd.Args = append(cmd.Args, "-vvvvv")
 	}
-	if e.cfg.AnsibleUseOpenSSH {
+	if e.cfg.Ansible.UseOpenSSH {
 		cmd.Args = append(cmd.Args, "-c", "ssh")
 	} else {
 		cmd.Args = append(cmd.Args, "-c", "paramiko")

--- a/prov/ansible/executor.go
+++ b/prov/ansible/executor.go
@@ -49,7 +49,7 @@ func (e *defaultExecutor) ExecOperation(ctx context.Context, conf config.Configu
 	}
 
 	// Execute operation
-	err = exec.execute(ctx, conf.AnsibleConnectionRetries != 0)
+	err = exec.execute(ctx, conf.Ansible.ConnectionRetries != 0)
 	if err == nil {
 		return nil
 	}
@@ -58,10 +58,10 @@ func (e *defaultExecutor) ExecOperation(ctx context.Context, conf config.Configu
 	}
 
 	// Retry operation if error is retriable and AnsibleConnectionRetries > 0
-	log.Debugf("Ansible Connection Retries:%d", conf.AnsibleConnectionRetries)
-	if conf.AnsibleConnectionRetries > 0 {
-		for i := 0; i < conf.AnsibleConnectionRetries; i++ {
-			log.Printf("Deployment: %q, Node: %q, Operation: %s: Caught a retriable error from Ansible: '%s'. Let's retry in few seconds (%d/%d)", deploymentID, nodeName, operation, err, i+1, conf.AnsibleConnectionRetries)
+	log.Debugf("Ansible Connection Retries:%d", conf.Ansible.ConnectionRetries)
+	if conf.Ansible.ConnectionRetries > 0 {
+		for i := 0; i < conf.Ansible.ConnectionRetries; i++ {
+			log.Printf("Deployment: %q, Node: %q, Operation: %s: Caught a retriable error from Ansible: '%s'. Let's retry in few seconds (%d/%d)", deploymentID, nodeName, operation, err, i+1, conf.Ansible.ConnectionRetries)
 			time.Sleep(time.Duration(e.r.Int63n(10)) * time.Second)
 			err = exec.execute(ctx, i != 0)
 			if err == nil {
@@ -72,7 +72,7 @@ func (e *defaultExecutor) ExecOperation(ctx context.Context, conf config.Configu
 			}
 		}
 
-		log.Printf("Deployment: %q, Node: %q, Operation: %s: Giving up retries for Ansible error: '%s' (%d/%d)", deploymentID, nodeName, operation, err, conf.AnsibleConnectionRetries, conf.AnsibleConnectionRetries)
+		log.Printf("Deployment: %q, Node: %q, Operation: %s: Giving up retries for Ansible error: '%s' (%d/%d)", deploymentID, nodeName, operation, err, conf.Ansible.ConnectionRetries, conf.Ansible.ConnectionRetries)
 	}
 
 	return err

--- a/prov/terraform/aws/generator.go
+++ b/prov/terraform/aws/generator.go
@@ -50,24 +50,24 @@ func (g *awsGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg co
 	infrastructure := commons.Infrastructure{}
 
 	consulAddress := "127.0.0.1:8500"
-	if cfg.ConsulAddress != "" {
-		consulAddress = cfg.ConsulAddress
+	if cfg.Consul.Address != "" {
+		consulAddress = cfg.Consul.Address
 	}
 	consulScheme := "http"
-	if cfg.ConsulSSL {
+	if cfg.Consul.SSL {
 		consulScheme = "https"
 	}
 	consulCA := ""
-	if cfg.ConsulCA != "" {
-		consulCA = cfg.ConsulCA
+	if cfg.Consul.CA != "" {
+		consulCA = cfg.Consul.CA
 	}
 	consulKey := ""
-	if cfg.ConsulKey != "" {
-		consulKey = cfg.ConsulKey
+	if cfg.Consul.Key != "" {
+		consulKey = cfg.Consul.Key
 	}
 	consulCert := ""
-	if cfg.ConsulCert != "" {
-		consulCert = cfg.ConsulCert
+	if cfg.Consul.Cert != "" {
+		consulCert = cfg.Consul.Cert
 	}
 
 	// Remote Configuration for Terraform State to store it in the Consul KV store

--- a/prov/terraform/openstack/generator.go
+++ b/prov/terraform/openstack/generator.go
@@ -64,24 +64,24 @@ func (g *osGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg con
 	infrastructure := commons.Infrastructure{}
 
 	consulAddress := "127.0.0.1:8500"
-	if cfg.ConsulAddress != "" {
-		consulAddress = cfg.ConsulAddress
+	if cfg.Consul.Address != "" {
+		consulAddress = cfg.Consul.Address
 	}
 	consulScheme := "http"
-	if cfg.ConsulSSL {
+	if cfg.Consul.SSL {
 		consulScheme = "https"
 	}
 	consulCA := ""
-	if cfg.ConsulCA != "" {
-		consulCA = cfg.ConsulCA
+	if cfg.Consul.CA != "" {
+		consulCA = cfg.Consul.CA
 	}
 	consulKey := ""
-	if cfg.ConsulKey != "" {
-		consulKey = cfg.ConsulKey
+	if cfg.Consul.Key != "" {
+		consulKey = cfg.Consul.Key
 	}
 	consulCert := ""
-	if cfg.ConsulCert != "" {
-		consulCert = cfg.ConsulCert
+	if cfg.Consul.Cert != "" {
+		consulCert = cfg.Consul.Cert
 	}
 
 	log.Debugf("Generating infrastructure for deployment with node %s", nodeName)

--- a/server/server.go
+++ b/server/server.go
@@ -54,7 +54,7 @@ func RunServer(configuration config.Configuration, shutdownCh chan struct{}) err
 		return errors.Wrap(err, "Can't connect to Consul")
 	}
 
-	maxConsulPubRoutines := configuration.ConsulPubMaxRoutines
+	maxConsulPubRoutines := configuration.Consul.PubMaxRoutines
 	if maxConsulPubRoutines <= 0 {
 		maxConsulPubRoutines = config.DefaultConsulPubMaxRoutines
 	}


### PR DESCRIPTION
# Pull Request description

Grouping Ansible and Consul configuration options in JSON config file.

## Description of the change

Flat options in JSON config files to describe Ansible and Consul configuration are now deprecated.
Instead options are grouped, similarly to what was already done for telemetry configuration.

### What I did

Marking flat keys options as deprecated in the documentation.
A message informs the user of deprecated options if they are used in his config file.
Added unit tests to verify new options as well as backward compatibility with deprecated options.

### How I did it

Using viper aliases to be able to still manage deprecated keys.

### How to verify it

Change the configuration files to use the new syntax for Ansible and Consul configuration.
The documentation describes available options and an example is provided in unit tests in commands/testdata/config_structured.yorc.json

### Description for the changelog

## Applicable Issues
