### PR TITLE
Fixed typo in YORC_PLUGINS_DIRECTORY env var

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -535,7 +535,7 @@ Environment variables
 
 .. _option_plugindir_env:
 
-  * ``YORC_PLUGIN_DIRECTORY``: Equivalent to :ref:`--plugins_directory <option_pluginsdir_cmd>` command-line flag.
+  * ``YORC_PLUGINS_DIRECTORY``: Equivalent to :ref:`--plugins_directory <option_pluginsdir_cmd>` command-line flag.
 
 .. _option_resources_prefix_env:
 


### PR DESCRIPTION
# Pull Request description

Documentation: typo in the name of the environment variable allowing to specify a directory where to find orchestrator plugins.
It describes YORC_PLUGIN_DIRECTORY 
while the code expects YORC_PLUGINS_DIRECTORY.

## Description of the change

Changing documentation:
YORC_PLUGIN_DIRECTORY becomes YORC_PLUGINS_DIRECTORY

### What I did

One-liner change

### How I did it

### How to verify it

### Description for the changelog

## Applicable Issues
