### PR TITLE
Trimming null characters

### DIFF
--- a/prov/slurm/executor.go
+++ b/prov/slurm/executor.go
@@ -266,8 +266,8 @@ func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, 
 	if len(split) != 2 {
 		return errors.New("Malformed command : " + squeueCmd)
 	}
-	slurmNodeName := strings.Trim(split[0], "\" \t\n")
-	slurmPartition := strings.Trim(split[1], "\" \t\n")
+	slurmNodeName := strings.Trim(split[0], "\" \t\n\x00")
+	slurmPartition := strings.Trim(split[1], "\" \t\n\x00")
 
 	err = deployments.SetInstanceCapabilityAttribute(deploymentID, nodeName, nodeAlloc.instanceName, "endpoint", "ip_address", slurmNodeName)
 	if err != nil {


### PR DESCRIPTION
# Pull Request description

Minor change to fix an issue on a Slurm location : had null characters in allocated hostname

## Description of the change

Adding the null character to the list of characters to trim in the output of squeue slurm command

### What I did

### How I did it

### How to verify it

Manually checked it fixed the issue on the slurm location where the problem occured.

### Description for the changelog

## Applicable Issues
