### PR TITLE
Hotfix/op implementation artifacts path

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -342,15 +342,22 @@ func getConfig() config.Configuration {
 func readInfraViperConfig(cfg *config.Configuration) {
 	infras := viper.GetStringMap("infrastructures")
 	for infraName, infraConf := range infras {
-		infraConfMap, ok := infraConf.(map[interface{}]interface{})
+		infraConfMap, ok := infraConf.(map[string]interface{})
 		if !ok {
-			log.Fatalf("Invalid configuration format for infrastructure %q", infraName)
+			tmpInfraMap, ok := infraConf.(map[interface{}]interface{})
+			if !ok {
+				log.Fatalf("Invalid configuration format for infrastructure %q", infraName)
+			}
+			infraConfMap = make(map[string]interface{})
+			for k, v := range tmpInfraMap {
+				infraConfMap[fmt.Sprint(k)] = v
+			}
 		}
 		if cfg.Infrastructures[infraName] == nil {
 			cfg.Infrastructures[infraName] = make(config.DynamicMap)
 		}
 		for k, v := range infraConfMap {
-			cfg.Infrastructures[infraName].Set(fmt.Sprint(k), v)
+			cfg.Infrastructures[infraName].Set(k, v)
 		}
 	}
 }

--- a/commands/server.go
+++ b/commands/server.go
@@ -342,7 +342,7 @@ func getConfig() config.Configuration {
 func readInfraViperConfig(cfg *config.Configuration) {
 	infras := viper.GetStringMap("infrastructures")
 	for infraName, infraConf := range infras {
-		infraConfMap, ok := infraConf.(map[string]interface{})
+		infraConfMap, ok := infraConf.(map[interface{}]interface{})
 		if !ok {
 			log.Fatalf("Invalid configuration format for infrastructure %q", infraName)
 		}
@@ -350,7 +350,7 @@ func readInfraViperConfig(cfg *config.Configuration) {
 			cfg.Infrastructures[infraName] = make(config.DynamicMap)
 		}
 		for k, v := range infraConfMap {
-			cfg.Infrastructures[infraName].Set(k, v)
+			cfg.Infrastructures[infraName].Set(fmt.Sprint(k), v)
 		}
 	}
 }

--- a/deployments/artifacts_test.go
+++ b/deployments/artifacts_test.go
@@ -31,6 +31,7 @@ func testArtifacts(t *testing.T, srv1 *testutil.TestServer, kv *api.KV) {
 	srv1.PopulateKV(t, map[string][]byte{
 
 		consulutil.DeploymentKVPrefix + "/t1/topology/types/yorc.types.A/derived_from":        []byte("yorc.types.ParentA"),
+		consulutil.DeploymentKVPrefix + "/t1/topology/types/yorc.types.A/importPath":          []byte("path/to/typeA"),
 		consulutil.DeploymentKVPrefix + "/t1/topology/types/yorc.types.A/artifacts/art1/name": []byte("art1"),
 		consulutil.DeploymentKVPrefix + "/t1/topology/types/yorc.types.A/artifacts/art1/file": []byte("TypeA"),
 		consulutil.DeploymentKVPrefix + "/t1/topology/types/yorc.types.A/artifacts/art2/name": []byte("art2"),
@@ -77,11 +78,11 @@ func testGetArtifactsForType(t *testing.T, kv *api.KV) {
 	require.NotNil(t, artifacts)
 	require.Len(t, artifacts, 5)
 	require.Contains(t, artifacts, "art1")
-	require.Equal(t, "TypeA", artifacts["art1"])
+	require.Equal(t, "path/to/typeA/TypeA", artifacts["art1"])
 	require.Contains(t, artifacts, "art2")
-	require.Equal(t, "TypeA", artifacts["art2"])
+	require.Equal(t, "path/to/typeA/TypeA", artifacts["art2"])
 	require.Contains(t, artifacts, "art6")
-	require.Equal(t, "TypeA", artifacts["art6"])
+	require.Equal(t, "path/to/typeA/TypeA", artifacts["art6"])
 	require.Contains(t, artifacts, "art3")
 	require.Equal(t, "ParentA", artifacts["art3"])
 	require.Contains(t, artifacts, "art5")
@@ -121,7 +122,7 @@ func testGetArtifactsForNode(t *testing.T, kv *api.KV) {
 	require.Contains(t, artifacts, "art5")
 	require.Equal(t, "ParentA", artifacts["art5"])
 	require.Contains(t, artifacts, "art6")
-	require.Equal(t, "TypeA", artifacts["art6"])
+	require.Equal(t, "path/to/typeA/TypeA", artifacts["art6"])
 
 	artifacts, err = GetArtifactsForNode(kv, "t1", "NodeB")
 	require.Nil(t, err)

--- a/deployments/consul_test.go
+++ b/deployments/consul_test.go
@@ -75,5 +75,8 @@ func TestRunConsulDeploymentsPackageTests(t *testing.T) {
 		t.Run("testImportTopologyTemplate", func(t *testing.T) {
 			testImportTopologyTemplate(t, kv)
 		})
+		t.Run("TestOperationImplementationArtifact(", func(t *testing.T) {
+			testOperationImplementationArtifact(t, kv)
+		})
 	})
 }

--- a/deployments/definition_store_test.go
+++ b/deployments/definition_store_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/ystia/yorc/helper/consulutil"
 	"github.com/ystia/yorc/prov"
-	"github.com/ystia/yorc/testutil"
 )
 
 func testDefinitionStore(t *testing.T, kv *api.KV) {
@@ -39,9 +38,6 @@ func testDefinitionStore(t *testing.T, kv *api.KV) {
 		})
 		t.Run("TestValueAssignments", func(t *testing.T) {
 			testValueAssignments(t, kv)
-		})
-		t.Run("TestOperationImplementationArtifact(", func(t *testing.T) {
-			testOperationImplementationArtifact(t, kv)
 		})
 	})
 }
@@ -924,39 +920,4 @@ func testImportTopologyTemplate(t *testing.T, kv *api.KV) {
 		require.NotNil(t, kvp, "Unexpected null value for key %s", consulKey)
 		assert.Equal(t, string(kvp.Value), expectedValue, "Wrong value for key %s", key)
 	}
-}
-
-func testOperationImplementationArtifact(t *testing.T, kv *api.KV) {
-	deploymentID := testutil.BuildDeploymentID(t)
-	err := StoreDeploymentDefinition(context.Background(), kv, deploymentID, "testdata/operation_implementation_artifact.yaml")
-	require.NoError(t, err, "Failed to store test topology deployment definition")
-
-	type args struct {
-		typeName  string
-		operation string
-	}
-	type checks struct {
-		implementationType string
-		primary            string
-	}
-	oiaTests := []struct {
-		name string
-		args args
-		want checks
-	}{
-		{"TestBashOnNodeType", args{"yorc.tests.nodes.OpImplementationArtifact", "standard.create"}, checks{"tosca.artifacts.Implementation.Bash", "scripts/create.sh"}},
-		{"TestBashOnRelType", args{"yorc.tests.relationships.OpImplementationArtifact", "configure.pre_configure_source"}, checks{"tosca.artifacts.Implementation.Bash", "something"}},
-	}
-
-	for _, tt := range oiaTests {
-		t.Run(tt.name, func(t *testing.T) {
-			implType, err := GetOperationImplementationType(kv, deploymentID, tt.args.typeName, tt.args.operation)
-			require.NoError(t, err)
-			assert.Equal(t, tt.want.implementationType, implType)
-			_, primary, err := GetOperationPathAndPrimaryImplementationForNodeType(kv, deploymentID, tt.args.typeName, tt.args.operation)
-			require.NoError(t, err)
-			assert.Equal(t, tt.want.primary, primary)
-		})
-	}
-
 }

--- a/deployments/operations.go
+++ b/deployments/operations.go
@@ -472,7 +472,7 @@ func GetOperationInput(kv *api.KV, deploymentID, nodeName string, operation prov
 		var hasAttrOnSrcOrSelf bool
 		for _, ga := range f.GetFunctionsByOperator(tosca.GetAttributeOperator) {
 			switch ga.Operands[0].String() {
-			case funcKeywordTARGET:
+			case funcKeywordTARGET, funcKeywordRTARGET:
 				hasAttrOnTarget = true
 			case funcKeywordSELF, funcKeywordSOURCE, funcKeywordHOST:
 				hasAttrOnSrcOrSelf = true

--- a/deployments/operations_test.go
+++ b/deployments/operations_test.go
@@ -1,0 +1,108 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployments
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/ystia/yorc/testutil"
+)
+
+func testOperationImplementationArtifact(t *testing.T, kv *api.KV) {
+	deploymentID := testutil.BuildDeploymentID(t)
+	err := StoreDeploymentDefinition(context.Background(), kv, deploymentID, "testdata/operation_implementation_artifact.yaml")
+	require.NoError(t, err, "Failed to store test topology deployment definition")
+
+	t.Run("GetPrimaryImplementationForNodeType", func(t *testing.T) {
+		testOperationImplementationArtifactPrimary(t, kv, deploymentID)
+	})
+
+	t.Run("testGetOperationImplementationFile", func(t *testing.T) {
+		testGetOperationImplementationFile(t, kv, deploymentID)
+	})
+}
+
+func testOperationImplementationArtifactPrimary(t *testing.T, kv *api.KV, deploymentID string) {
+
+	type args struct {
+		typeName  string
+		operation string
+	}
+	type checks struct {
+		implementationType string
+		primary            string
+	}
+	oiaTests := []struct {
+		name string
+		args args
+		want checks
+	}{
+		{"TestBashOnNodeType", args{"yorc.tests.nodes.OpImplementationArtifact", "standard.create"}, checks{"tosca.artifacts.Implementation.Bash", "scripts/create.sh"}},
+		{"TestBashOnRelType", args{"yorc.tests.relationships.OpImplementationArtifact", "configure.pre_configure_source"}, checks{"tosca.artifacts.Implementation.Bash", "something"}},
+		{"TestBashOnImportedRelType", args{"yorc.tests.relationships.imports.OpImplementationArtifact", "configure.pre_configure_source"}, checks{"tosca.artifacts.Implementation.Bash", "imports/something"}},
+		{"TestBashOnImportedNodeType", args{"yorc.tests.nodes.imports.OpImplementationArtifact", "standard.create"}, checks{"tosca.artifacts.Implementation.Bash", "imports/scripts/create.sh"}},
+	}
+
+	for _, tt := range oiaTests {
+		t.Run(tt.name, func(t *testing.T) {
+			implType, err := GetOperationImplementationType(kv, deploymentID, tt.args.typeName, tt.args.operation)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want.implementationType, implType)
+			_, primary, err := GetOperationPathAndPrimaryImplementationForNodeType(kv, deploymentID, tt.args.typeName, tt.args.operation)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want.primary, primary)
+		})
+	}
+
+}
+
+func testGetOperationImplementationFile(t *testing.T, kv *api.KV, deploymentID string) {
+	type args struct {
+		nodeType      string
+		operationName string
+	}
+	type want struct {
+		file         string
+		relativeFile string
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{"TestOpImplemFileOnImplemArtifactNodeType", args{"yorc.tests.nodes.OpImplementationArtifact", "standard.create"}, want{"scripts/create.sh", "scripts/create.sh"}},
+		{"TestOpImplemFileOnImplemArtifactRelType", args{"yorc.tests.relationships.OpImplementationArtifact", "configure.pre_configure_source"}, want{"something", "something"}},
+		{"TestOpImplemFileOnImplemArtifactImportedNodeType", args{"yorc.tests.nodes.imports.OpImplementationArtifact", "standard.create"}, want{"scripts/create.sh", "imports/scripts/create.sh"}},
+		{"TestOpImplemFileOnImplemArtifactImportedRelType", args{"yorc.tests.relationships.imports.OpImplementationArtifact", "configure.pre_configure_source"}, want{"something", "imports/something"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetOperationImplementationFile(kv, deploymentID, tt.args.nodeType, tt.args.operationName)
+			require.NoError(t, err, "GetOperationImplementationFile() error = %v", err)
+			if got != tt.want.file {
+				t.Errorf("GetOperationImplementationFile() = %v, want %v", got, tt.want)
+			}
+			got, err = GetOperationImplementationFileWithRelativePath(kv, deploymentID, tt.args.nodeType, tt.args.operationName)
+			require.NoError(t, err, "GetOperationImplementationFileWithRelativePath() error = %v", err)
+			if got != tt.want.relativeFile {
+				t.Errorf("GetOperationImplementationFileWithRelativePath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/deployments/resolver.go
+++ b/deployments/resolver.go
@@ -32,6 +32,7 @@ const funcKeywordSELF string = "SELF"
 const funcKeywordHOST string = "HOST"
 const funcKeywordSOURCE string = "SOURCE"
 const funcKeywordTARGET string = "TARGET"
+const funcKeywordRTARGET string = "R_TARGET"
 const funcKeywordREQTARGET string = "REQ_TARGET"
 
 // functionResolver is used to resolve TOSCA functions
@@ -152,7 +153,7 @@ func (fr *functionResolver) resolveGetOperationOutput(operands []string) (string
 		}
 		// Workaround to be backward compatible lets look at relationships
 		return getOperationOutputForRequirements(fr.kv, fr.deploymentID, fr.nodeName, fr.instanceName, ifName, opName, varName)
-	case funcKeywordTARGET:
+	case funcKeywordTARGET, funcKeywordRTARGET:
 		if fr.requirementIndex != "" {
 			return "", errors.Errorf("Keyword %q not supported for an node expression (only supported in relationships)", funcKeywordTARGET)
 		}
@@ -190,7 +191,7 @@ func (fr *functionResolver) resolveGetPropertyOrAttribute(rType string, operands
 
 	if entity == funcKeywordHOST && fr.requirementIndex != "" {
 		return "", errors.Errorf(`Can't resolve %q %s keyword is not supported in the context of a relationship`, funcString, funcKeywordHOST)
-	} else if fr.requirementIndex == "" && (entity == funcKeywordSOURCE || entity == funcKeywordTARGET) {
+	} else if fr.requirementIndex == "" && (entity == funcKeywordSOURCE || entity == funcKeywordTARGET || entity == funcKeywordRTARGET) {
 		return "", errors.Errorf(`Can't resolve %q %s keyword is supported only in the context of a relationship`, funcString, entity)
 	}
 	// First get the node on which we should resolve the get_property
@@ -205,7 +206,7 @@ func (fr *functionResolver) resolveGetPropertyOrAttribute(rType string, operands
 		if err != nil {
 			return "", err
 		}
-	case funcKeywordTARGET:
+	case funcKeywordTARGET, funcKeywordRTARGET:
 		actualNode, err = GetTargetNodeForRequirement(fr.kv, fr.deploymentID, fr.nodeName, fr.requirementIndex)
 		if err != nil {
 			return "", err

--- a/deployments/resolver.go
+++ b/deployments/resolver.go
@@ -32,6 +32,8 @@ const funcKeywordSELF string = "SELF"
 const funcKeywordHOST string = "HOST"
 const funcKeywordSOURCE string = "SOURCE"
 const funcKeywordTARGET string = "TARGET"
+
+// R_TARGET has a special meaning for A4C but we just consider it as an alias for TARGET
 const funcKeywordRTARGET string = "R_TARGET"
 const funcKeywordREQTARGET string = "REQ_TARGET"
 

--- a/deployments/testdata/imports/operation_implementation_artifact.yaml
+++ b/deployments/testdata/imports/operation_implementation_artifact.yaml
@@ -4,12 +4,8 @@ template_name: GetOpOutputTest2
 template_version: 0.1.0-SNAPSHOT
 template_author: admin
 
-imports:
-  - <normative-types.yml>
-  - imports/operation_implementation_artifact.yaml
-
 node_types:
-  yorc.tests.nodes.OpImplementationArtifact:
+  yorc.tests.nodes.imports.OpImplementationArtifact:
     derived_from: tosca.nodes.Root
     properties:
       p1:
@@ -26,7 +22,7 @@ node_types:
             type: tosca.artifacts.Implementation.Bash
 
 relationship_types:
-  yorc.tests.relationships.OpImplementationArtifact:
+  yorc.tests.relationships.imports.OpImplementationArtifact:
     derived_from: tosca.relationships.Root
     interfaces:
       Configure:

--- a/deployments/types.go
+++ b/deployments/types.go
@@ -279,3 +279,15 @@ func isTypePropOrAttrRequired(kv *api.KV, deploymentID, typeName, originalTypeNa
 	// Not required only if explicitly set to false
 	return !(strings.ToLower(string(kvp.Value)) == "false"), nil
 }
+
+// GetTypeImportPath returns the import path relative to the root of a CSAR of a given TOSCA type.
+//
+// This is particulary useful for resolving artifacts and implementation
+func GetTypeImportPath(kv *api.KV, deploymentID, typeName string) (string, error) {
+	kvp, _, err := kv.Get(path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/types", typeName, "importPath"), nil)
+	if err != nil || kvp == nil {
+		return "", errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+	}
+	// Can be empty if type is definied into the root topology
+	return string(kvp.Value), nil
+}


### PR DESCRIPTION
# Pull Request description

## Description of the change
Refactor the way we handle import path of types to use with implementation and artifacts.

### What I did
Import path is now stored in the type description and could be retrieved with  `deployments.GetTypeImportPath(kv *api.KV, deploymentID, typeName string) (string, error)` function.
Artifact files and Implementation file are not anymore stored with the import path. But functions were updated to return the same result thanks to GetTypeImportPath.
