### PR TITLE
Feature/brbdcf 1126 refactor ansible errors logs

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at dl-ystia-opensource@atos.net. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/events/buff_consul_writer.go
+++ b/events/buff_consul_writer.go
@@ -15,10 +15,11 @@
 package events
 
 import (
-	"fmt"
 	"io"
 	"regexp"
 	"time"
+
+	"github.com/ystia/yorc/log"
 )
 
 // A BufferedLogEntryWriter is a Writer that buffers writes and flushes its buffer as an event log on a regular basis (every 5s)
@@ -53,7 +54,7 @@ func (b *bufferedConsulWriter) flush(logEntry LogEntry) error {
 	if len(b.buf) == 0 {
 		return nil
 	}
-	fmt.Print(string(b.buf))
+	log.Debug(string(b.buf))
 	reg := regexp.MustCompile(`\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]`)
 	out := reg.ReplaceAll(b.buf, []byte(""))
 	logEntry.Register(out)
@@ -69,13 +70,13 @@ func (b *bufferedConsulWriter) run(quit chan bool, logEntry LogEntry) {
 			case <-quit:
 				err := b.flush(logEntry)
 				if err != nil {
-					fmt.Print(err)
+					log.Print(err)
 				}
 				return
 			case <-time.After(b.timeout):
 				err := b.flush(logEntry)
 				if err != nil {
-					fmt.Print(err)
+					log.Print(err)
 				}
 			}
 		}

--- a/events/log_entries_test.go
+++ b/events/log_entries_test.go
@@ -15,6 +15,7 @@
 package events
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -145,5 +146,29 @@ func testLogsSortedByTimestamp(t *testing.T, kv *api.KV) {
 		require.NoError(t, err, "Failure scanning integer in string %s", logEntries[i]["content"])
 		assert.Equal(t, i, value, "Unexpected log entry at index %d: %s", i, logEntries[i]["content"])
 	}
+
+}
+
+func TestContext(t *testing.T) {
+	rootLogOpts := LogOptionalFields{WorkFlowID: "wf"}
+	require.Len(t, rootLogOpts, 1)
+	rootCtx := NewContext(context.Background(), rootLogOpts)
+	require.NotNil(t, rootCtx)
+
+	lof1, ok := FromContext(rootCtx)
+	assert.True(t, ok)
+	assert.NotNil(t, lof1)
+
+	lof1[NodeID] = "node"
+	assert.Len(t, lof1, 2)
+	assert.Len(t, rootLogOpts, 1)
+
+	lof2, ok := FromContext(rootCtx)
+	assert.True(t, ok)
+	assert.NotNil(t, lof2)
+
+	lof2[InstanceID] = "1"
+	assert.Len(t, lof2, 2)
+	assert.Len(t, rootLogOpts, 1)
 
 }

--- a/plugin/error.go
+++ b/plugin/error.go
@@ -16,6 +16,7 @@ package plugin
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 )
 

--- a/plugin/serve.go
+++ b/plugin/serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/go-plugin"
 
 	"github.com/ystia/yorc/config"
+	"github.com/ystia/yorc/events"
 	"github.com/ystia/yorc/log"
 	"github.com/ystia/yorc/prov"
 	"github.com/ystia/yorc/vault"
@@ -101,6 +102,7 @@ func getPlugins(opts *ServeOpts) map[string]plugin.Plugin {
 func SetupPluginCommunication() {
 	// As we have type []interface{} in the config.Configuration structure, we need to register it before sending config from yorc server to plugins
 	gob.Register(make(map[string]interface{}, 0))
+	gob.Register(make(events.LogOptionalFields, 0))
 	gob.Register(make([]interface{}, 0))
 	gob.Register(make([]string, 0))
 	gob.RegisterName("DynamicMap", &config.DynamicMap{})

--- a/prov/ansible/consul_test.go
+++ b/prov/ansible/consul_test.go
@@ -31,4 +31,7 @@ func TestRunConsulAnsiblePackageTests(t *testing.T) {
 	t.Run("TestExecution", func(t *testing.T) {
 		testExecution(t, srv, kv)
 	})
+	t.Run("TestLogAnsibleOutputInConsul", func(t *testing.T) {
+		testLogAnsibleOutputInConsul(t, kv)
+	})
 }

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -638,16 +638,13 @@ func (e *executionCommon) execute(ctx context.Context, retry bool) error {
 
 func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry bool, currentInstance string) error {
 	// Fill log optional fields for log registration
-	wfName, _ := tasks.GetTaskData(e.kv, e.taskID, "workflowName")
-	logOptFields := events.LogOptionalFields{
-		events.WorkFlowID:    wfName,
-		events.NodeID:        e.NodeName,
-		events.OperationName: stringutil.GetLastElement(e.operation.Name, "."),
-		events.InstanceID:    currentInstance,
-		events.InterfaceName: stringutil.GetAllExceptLastElement(e.operation.Name, "."),
+	logOptFields, ok := events.FromContext(ctx)
+	if !ok {
+		return errors.New("Missing context log fields")
 	}
-
-	events.WithOptionalFields(logOptFields).NewLogEntry(events.INFO, e.deploymentID).RegisterAsString("Start the ansible execution of : " + e.NodeName + " with operation : " + e.operation.Name)
+	logOptFields[events.InstanceID] = currentInstance
+	ctx = events.NewContext(ctx, logOptFields)
+	events.WithContextOptionalFields(ctx).NewLogEntry(events.INFO, e.deploymentID).RegisterAsString("Start the ansible execution of : " + e.NodeName + " with operation : " + e.operation.Name)
 	var ansibleRecipePath string
 	if e.operation.RelOp.IsRelationshipOperation {
 		ansibleRecipePath = filepath.Join(e.cfg.WorkingDirectory, "deployments", e.deploymentID, "ansible", e.NodeName, e.relationshipType, e.operation.TargetRelationship, e.operation.Name, currentInstance)
@@ -661,12 +658,12 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 	if err = os.RemoveAll(ansibleRecipePath); err != nil {
 		err = errors.Wrapf(err, "Failed to remove ansible recipe directory %q for node %q operation %q", ansibleRecipePath, e.NodeName, e.operation.Name)
 		log.Debugf("%+v", err)
-		events.WithOptionalFields(logOptFields).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
 		return err
 	}
 	ansibleHostVarsPath := filepath.Join(ansibleRecipePath, "host_vars")
 	if err = os.MkdirAll(ansibleHostVarsPath, 0775); err != nil {
-		events.WithOptionalFields(logOptFields).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
 		return err
 	}
 	log.Debugf("Generating hosts files hosts: %+v ", e.hosts)
@@ -678,13 +675,13 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 		if sshUser == "" {
 			// Use root as default user
 			sshUser = "root"
-			events.WithOptionalFields(logOptFields).NewLogEntry(events.WARN, e.deploymentID).RegisterAsString("Ansible provisioning: Missing ssh user information, trying to use root user.")
+			events.WithContextOptionalFields(ctx).NewLogEntry(events.WARN, e.deploymentID).RegisterAsString("Ansible provisioning: Missing ssh user information, trying to use root user.")
 		}
 		sshPassword := host.password
 		sshPrivateKey := host.privateKey
 		if sshPrivateKey == "" && sshPassword == "" {
 			sshPrivateKey = "~/.ssh/yorc.pem"
-			events.WithOptionalFields(logOptFields).NewLogEntry(events.WARN, e.deploymentID).RegisterAsString("Ansible provisioning: Missing ssh password or private key information, trying to use default private key ~/.ssh/yorc.pem.")
+			events.WithContextOptionalFields(ctx).NewLogEntry(events.WARN, e.deploymentID).RegisterAsString("Ansible provisioning: Missing ssh password or private key information, trying to use default private key ~/.ssh/yorc.pem.")
 		}
 		buffer.WriteString(fmt.Sprintf(" ansible_ssh_user=%s ansible_ssh_common_args=\"-o ConnectionAttempts=20\"", sshUser))
 		if sshPrivateKey != "" {
@@ -768,12 +765,12 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 
 	if err = ioutil.WriteFile(filepath.Join(ansibleRecipePath, "hosts"), buffer.Bytes(), 0664); err != nil {
 		err = errors.Wrap(err, "Failed to write hosts file")
-		events.WithOptionalFields(logOptFields).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
 		return err
 	}
 	if err = ioutil.WriteFile(filepath.Join(ansibleRecipePath, "ansible.cfg"), []byte(strings.Replace(ansibleConfig, "#PLAY_PATH#", ansibleRecipePath, -1)), 0664); err != nil {
 		err = errors.Wrap(err, "Failed to write ansible.cfg file")
-		events.WithOptionalFields(logOptFields).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
 		return err
 	}
 	// e.OperationRemoteBaseDir is an unique base temp directory for multiple executions
@@ -792,21 +789,21 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 		outputsFiles, err := filepath.Glob(filepath.Join(ansibleRecipePath, "*-out.csv"))
 		if err != nil {
 			err = errors.Wrapf(err, "Output retrieving of Ansible execution for node %q failed", e.NodeName)
-			events.WithOptionalFields(logOptFields).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
+			events.WithContextOptionalFields(ctx).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
 			return err
 		}
 		for _, outFile := range outputsFiles {
 			fi, err := os.Open(outFile)
 			if err != nil {
 				err = errors.Wrapf(err, "Output retrieving of Ansible execution for node %q failed", e.NodeName)
-				events.WithOptionalFields(logOptFields).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
+				events.WithContextOptionalFields(ctx).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
 				return err
 			}
 			r := csv.NewReader(fi)
 			records, err := r.ReadAll()
 			if err != nil {
 				err = errors.Wrapf(err, "Output retrieving of Ansible execution for node %q failed", e.NodeName)
-				events.WithOptionalFields(logOptFields).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
+				events.WithContextOptionalFields(ctx).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
 				return err
 			}
 			for _, line := range records {
@@ -821,8 +818,8 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 
 }
 
-func (e *executionCommon) checkAnsibleRetriableError(err error, logOptFields events.LogOptionalFields) error {
-	events.WithOptionalFields(logOptFields).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(errors.Wrapf(err, "Ansible execution for operation %q on node %q failed", e.operation.Name, e.NodeName).Error())
+func (e *executionCommon) checkAnsibleRetriableError(ctx context.Context, err error) error {
+	events.WithContextOptionalFields(ctx).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(errors.Wrapf(err, "Ansible execution for operation %q on node %q failed", e.operation.Name, e.NodeName).Error())
 	log.Debugf(err.Error())
 	if exiterr, ok := err.(*exec.ExitError); ok {
 		// The program has exited with an exit code != 0

--- a/prov/ansible/json_output.go
+++ b/prov/ansible/json_output.go
@@ -22,17 +22,18 @@ import (
 	"github.com/antonholmquist/jason"
 	"github.com/pkg/errors"
 	"github.com/ystia/yorc/events"
+	"github.com/ystia/yorc/helper/collections"
 	"github.com/ystia/yorc/log"
 )
 
-func getAnsibleJSONResult(output *bytes.Buffer) (*jason.Object, error) {
+func getAnsibleJSONResult(output *bytes.Buffer) (*jason.Object, []string, error) {
 	// Workaround https://github.com/ansible/ansible/issues/17122
 	log.Debugf("Ansible result: %s", output)
 	b := output.Bytes()
 	if i := bytes.Index(b, []byte("\"plays\":")); i >= 0 {
 		b = append([]byte("{\n"), b[i:]...)
 	} else {
-		return nil, errors.New("Not a valid JSON output")
+		return nil, nil, errors.New("Not a valid JSON output")
 	}
 	//Construct the JSON from the buffer
 	v, err := jason.NewObjectFromBytes(b)
@@ -41,14 +42,42 @@ func getAnsibleJSONResult(output *bytes.Buffer) (*jason.Object, error) {
 		log.Printf("%v", err)
 		log.Debugf("%+v", err)
 		log.Debugf("String: %q", string(b))
-		return nil, err
+		return nil, nil, err
 	}
-	return v, nil
+
+	failedHosts := make([]string, 0)
+	stats, err := v.GetObject("stats")
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "Failed to retrieve play stats")
+	}
+	for host, statsValue := range stats.Map() {
+		statsObj, err := statsValue.Object()
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "Failed to retrieve play stats")
+		}
+		failures, err := statsObj.GetInt64("failures")
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "Failed to retrieve play stats")
+		}
+		if failures > 0 {
+			failedHosts = append(failedHosts, host)
+			continue
+		}
+		unreachables, err := statsObj.GetInt64("unreachable")
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "Failed to retrieve play stats")
+		}
+		if unreachables > 0 {
+			failedHosts = append(failedHosts, host)
+		}
+	}
+
+	return v, failedHosts, nil
 }
 
 func (e *executionCommon) logAnsibleOutputInConsul(output *bytes.Buffer, logOptionalFields events.LogOptionalFields) error {
 
-	v, err := getAnsibleJSONResult(output)
+	v, failedHosts, err := getAnsibleJSONResult(output)
 	if err != nil {
 		return err
 	}
@@ -88,24 +117,31 @@ func (e *executionCommon) logAnsibleOutputInConsul(output *bytes.Buffer, logOpti
 					log.Debugf("%+v", err)
 					continue
 				}
+				stdErrLogLevel := events.WARN
+				logLevel := events.INFO
+				if collections.ContainsString(failedHosts, host) {
+					stdErrLogLevel = events.ERROR
+					logLevel = events.ERROR
+				}
+
 				//Check if a stderr field is present (The stdout field is exported for shell tasks on ansible)
 				if std, err := obj.GetString("stderr"); err == nil && std != "" {
 					//Display it and store it in consul
 					log.Debugf("Stderr found on host : %s  message : %s", host, std)
-					events.WithOptionalFields(logOptionalFields).NewLogEntry(events.INFO, e.deploymentID).RegisterAsString(fmt.Sprintf("node %q, host %q, stderr:\n%s", e.NodeName, host, std))
+					events.WithOptionalFields(logOptionalFields).NewLogEntry(stdErrLogLevel, e.deploymentID).RegisterAsString(fmt.Sprintf("node %q, host %q, stderr:\n%s", e.NodeName, host, std))
 				}
 				//Check if a stdout field is present (The stdout field is exported for shell tasks on ansible)
 				if std, err := obj.GetString("stdout"); err == nil && std != "" {
 					//Display it and store it in consul
 					log.Debugf("Stdout found on host : %s  message : %s", host, std)
-					events.WithOptionalFields(logOptionalFields).NewLogEntry(events.INFO, e.deploymentID).RegisterAsString(fmt.Sprintf("node %q, host %q, stdout:\n%s", e.NodeName, host, std))
+					events.WithOptionalFields(logOptionalFields).NewLogEntry(logLevel, e.deploymentID).RegisterAsString(fmt.Sprintf("node %q, host %q, stdout:\n%s", e.NodeName, host, std))
 				}
 
 				//Check if a msg field is present (The stdout field is exported for shell tasks on ansible)
 				if std, err := obj.GetString("msg"); err == nil && std != "" {
 					//Display it and store it in consul
 					log.Debugf("Stdout found on host : %s  message : %s", host, std)
-					events.WithOptionalFields(logOptionalFields).NewLogEntry(events.INFO, e.deploymentID).RegisterAsString(fmt.Sprintf("node %q, host %q, msg:\n%s", e.NodeName, host, std))
+					events.WithOptionalFields(logOptionalFields).NewLogEntry(logLevel, e.deploymentID).RegisterAsString(fmt.Sprintf("node %q, host %q, msg:\n%s", e.NodeName, host, std))
 				}
 			}
 		}
@@ -117,7 +153,7 @@ func (e *executionCommon) logAnsibleOutputInConsul(output *bytes.Buffer, logOpti
 
 func (e *executionAnsible) logAnsibleOutputInConsul(output *bytes.Buffer, logOptionalFields events.LogOptionalFields) error {
 
-	v, err := getAnsibleJSONResult(output)
+	v, failedHosts, err := getAnsibleJSONResult(output)
 	if err != nil {
 		return err
 	}
@@ -244,7 +280,12 @@ func (e *executionAnsible) logAnsibleOutputInConsul(output *bytes.Buffer, logOpt
 
 	}
 
+	logLevel := events.INFO
+	if len(failedHosts) > 0 {
+		logLevel = events.ERROR
+	}
+
 	// Register log entry
-	events.WithOptionalFields(logOptionalFields).NewLogEntry(events.INFO, e.deploymentID).Register(buf.Bytes())
+	events.WithOptionalFields(logOptionalFields).NewLogEntry(logLevel, e.deploymentID).Register(buf.Bytes())
 	return nil
 }

--- a/prov/ansible/json_output_test.go
+++ b/prov/ansible/json_output_test.go
@@ -16,6 +16,7 @@ package ansible
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
@@ -270,7 +271,8 @@ func testLogAnsibleOutputInConsul(t *testing.T, kv *api.KV) {
 		events.OperationName: stringutil.GetLastElement(ec.operation.Name, "."),
 		events.InterfaceName: stringutil.GetAllExceptLastElement(ec.operation.Name, "."),
 	}
-	err := ea.logAnsibleOutputInConsul(&buf, logOptFields)
+	ctx := events.NewContext(context.Background(), logOptFields)
+	err := ea.logAnsibleOutputInConsul(ctx, &buf)
 	t.Logf("%+v", err)
 	require.Nil(t, err)
 

--- a/prov/ansible/json_output_test.go
+++ b/prov/ansible/json_output_test.go
@@ -17,15 +17,13 @@ package ansible
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/ystia/yorc/log"
-
-	"path"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	"github.com/ystia/yorc/events"
-	"github.com/ystia/yorc/helper/consulutil"
 	"github.com/ystia/yorc/helper/stringutil"
 	"github.com/ystia/yorc/tasks"
 	"github.com/ystia/yorc/testutil"
@@ -276,10 +274,8 @@ func testLogAnsibleOutputInConsul(t *testing.T, kv *api.KV) {
 	t.Logf("%+v", err)
 	require.Nil(t, err)
 
-	kvps, _, err := kv.List(path.Join(consulutil.DeploymentKVPrefix, ec.deploymentID, "logs"), nil)
+	logs, _, err := events.LogsEvents(kv, deploymentID, 0, 5*time.Millisecond)
 	require.Nil(t, err)
-	require.Len(t, kvps, 1)
-
-	t.Log(string(kvps[0].Value))
+	require.Len(t, logs, 1)
 
 }

--- a/prov/kubernetes/execution.go
+++ b/prov/kubernetes/execution.go
@@ -389,14 +389,6 @@ func (e *executionCommon) checkNode(ctx context.Context) error {
 }
 
 func (e *executionCommon) checkPod(ctx context.Context, podName string) error {
-	// Fill log optional fields for log registration
-	wfName, _ := tasks.GetTaskData(e.kv, e.taskID, "workflowName")
-	logOptFields := events.LogOptionalFields{
-		events.NodeID:        e.NodeName,
-		events.WorkFlowID:    wfName,
-		events.InterfaceName: "delegate",
-		events.OperationName: e.Operation.Name,
-	}
 	clientset := ctx.Value("clientset")
 
 	namespace, err := getNamespace(e.kv, e.deploymentID, e.NodeName)
@@ -422,7 +414,7 @@ func (e *executionCommon) checkPod(ctx context.Context, podName string) error {
 				if reason != latestReason {
 					latestReason = reason
 					log.Printf(pod.Name + " : " + string(pod.Status.Phase) + "->" + reason)
-					events.WithOptionalFields(logOptFields).NewLogEntry(events.INFO, e.deploymentID).RegisterAsString("Pod status : " + pod.Name + " : " + string(pod.Status.Phase) + " -> " + reason)
+					events.WithContextOptionalFields(ctx).NewLogEntry(events.INFO, e.deploymentID).RegisterAsString("Pod status : " + pod.Name + " : " + string(pod.Status.Phase) + " -> " + reason)
 				}
 			}
 
@@ -451,7 +443,7 @@ func (e *executionCommon) checkPod(ctx context.Context, podName string) error {
 					message = pod.Status.ContainerStatuses[0].State.Terminated.Message
 				}
 
-				events.WithOptionalFields(logOptFields).NewLogEntry(events.INFO, e.deploymentID).RegisterAsString("Pod status : " + pod.Name + " : " + string(pod.Status.Phase) + " (" + state + ")")
+				events.WithContextOptionalFields(ctx).NewLogEntry(events.INFO, e.deploymentID).RegisterAsString("Pod status : " + pod.Name + " : " + string(pod.Status.Phase) + " (" + state + ")")
 				if reason == "RunContainerError" {
 					logs, err := (clientset.(*kubernetes.Clientset)).CoreV1().Pods(namespace).GetLogs(strings.ToLower(e.cfg.ResourcesPrefix+e.NodeName), &v1.PodLogOptions{}).Do().Raw()
 					if err != nil {

--- a/prov/terraform/commons/generator.go
+++ b/prov/terraform/commons/generator.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hashicorp/consul/api"
 	"github.com/ystia/yorc/config"
-	"github.com/ystia/yorc/events"
 )
 
 // A Generator is used to generate the Terraform infrastructure for a given TOSCA node
@@ -34,4 +33,4 @@ type Generator interface {
 }
 
 // PreDestroyInfraCallback is a function that is call before destroying an infrastructure. If it returns false the node will not be destroyed.
-type PreDestroyInfraCallback func(ctx context.Context, kv *api.KV, cfg config.Configuration, deploymentID, nodeName string, logOptFields events.LogOptionalFields) (bool, error)
+type PreDestroyInfraCallback func(ctx context.Context, kv *api.KV, cfg config.Configuration, deploymentID, nodeName string) (bool, error)

--- a/prov/terraform/openstack/init.go
+++ b/prov/terraform/openstack/init.go
@@ -33,7 +33,7 @@ func init() {
 	reg.RegisterDelegates([]string{`yorc\.nodes\.openstack\..*`}, terraform.NewExecutor(&osGenerator{}, preDestroyInfraCallback), registry.BuiltinOrigin)
 }
 
-func preDestroyInfraCallback(ctx context.Context, kv *api.KV, cfg config.Configuration, deploymentID, nodeName string, logOptFields events.LogOptionalFields) (bool, error) {
+func preDestroyInfraCallback(ctx context.Context, kv *api.KV, cfg config.Configuration, deploymentID, nodeName string) (bool, error) {
 	nodeType, err := deployments.GetNodeType(kv, deploymentID, nodeName)
 	if err != nil {
 		return false, err
@@ -50,7 +50,7 @@ func preDestroyInfraCallback(ctx context.Context, kv *api.KV, cfg config.Configu
 			// False by default
 			msg := fmt.Sprintf("Node %q is a BlockStorage without the property 'deletable' do not destroy it...", nodeName)
 			log.Debug(msg)
-			events.WithOptionalFields(logOptFields).NewLogEntry(events.INFO, deploymentID).RegisterAsString(msg)
+			events.WithContextOptionalFields(ctx).NewLogEntry(events.INFO, deploymentID).RegisterAsString(msg)
 			return false, nil
 		}
 	}

--- a/rest/deployments.go
+++ b/rest/deployments.go
@@ -160,7 +160,10 @@ func (s *Server) newDeploymentHandler(w http.ResponseWriter, r *http.Request) {
 		log.Debugf("ERROR: %+v", err)
 		log.Panic(err)
 	}
-	taskID, err := s.tasksCollector.RegisterTask(uid, tasks.Deploy)
+	data := map[string]string{
+		"workflowName": "install",
+	}
+	taskID, err := s.tasksCollector.RegisterTaskWithData(uid, tasks.Deploy, data)
 	if err != nil {
 		if ok, _ := tasks.IsAnotherLivingTaskAlreadyExistsError(err); ok {
 			writeError(w, r, newBadRequestError(err))
@@ -206,8 +209,10 @@ func (s *Server) deleteDeploymentHandler(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	}
-
-	if taskID, err := s.tasksCollector.RegisterTask(id, taskType); err != nil {
+	data := map[string]string{
+		"workflowName": "uninstall",
+	}
+	if taskID, err := s.tasksCollector.RegisterTaskWithData(id, taskType, data); err != nil {
 		log.Debugln("register task err" + err.Error())
 		if ok, _ := tasks.IsAnotherLivingTaskAlreadyExistsError(err); ok {
 			log.Debugln("another task is living")

--- a/tasks/workflow/workflow.go
+++ b/tasks/workflow/workflow.go
@@ -211,17 +211,16 @@ func setNodeStatus(kv *api.KV, taskID, deploymentID, nodeName, status string) er
 
 func (s *step) run(ctx context.Context, deploymentID string, kv *api.KV, ignoredErrsChan chan error, shutdownChan chan struct{}, cfg config.Configuration, bypassErrors bool, workflowName string, w worker) error {
 	// Fill log optional fields for log registration
-	var logOptFields events.LogOptionalFields
-	if s.Target != "" {
-		logOptFields = events.LogOptionalFields{
-			events.WorkFlowID: workflowName,
-			events.NodeID:     s.Target,
-		}
-	} else {
-		logOptFields = events.LogOptionalFields{
-			events.WorkFlowID: workflowName,
-		}
+	logOptFields, ok := events.FromContext(ctx)
+	if !ok {
+		logOptFields = make(events.LogOptionalFields)
 	}
+	logOptFields[events.WorkFlowID] = workflowName
+
+	if s.Target != "" {
+		logOptFields[events.NodeID] = s.Target
+	}
+	ctx = events.NewContext(ctx, logOptFields)
 
 	s.setStatus(tasks.TaskStepStatusINITIAL)
 	haveErr := false
@@ -252,7 +251,7 @@ func (s *step) run(ctx context.Context, deploymentID string, kv *api.KV, ignored
 		return err
 	} else if !runnable {
 		log.Debugf("Deployment %q: Skipping Step %q", deploymentID, s.Name)
-		events.WithOptionalFields(logOptFields).NewLogEntry(events.INFO, deploymentID).RegisterAsString(fmt.Sprintf("Skipping Step %q", s.Name))
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.INFO, deploymentID).RegisterAsString(fmt.Sprintf("Skipping Step %q", s.Name))
 		s.setStatus(tasks.TaskStepStatusDONE)
 		s.notifyNext()
 		return nil
@@ -261,7 +260,7 @@ func (s *step) run(ctx context.Context, deploymentID string, kv *api.KV, ignored
 	s.setStatus(tasks.TaskStepStatusRUNNING)
 
 	// Create a new context to handle gracefully current step termination when an error occurred during another step
-	wfCtx, cancelWf := context.WithCancel(context.Background())
+	wfCtx, cancelWf := context.WithCancel(events.NewContext(context.Background(), logOptFields))
 	waitDoneCh := make(chan struct{})
 	defer close(waitDoneCh)
 	go func() {


### PR DESCRIPTION
# Pull Request description

## Description of the change

Main feature is that logs of a failed Ansible execution will be logged as an error instead of an info previously.

### What I did

Check Ansible result to log the  with the proper level.

Also refactored log optional fields usage to carry them within context during the execution of a task.
This should result in log records having more context information 

### How to verify it

[This component](https://github.com/ystia/yorc-a4c-plugin/tree/feature/BRBDCF-1126_Refactor_ansible_errors_logs/tosca-samples/org/ystia/yorc/samples/tests/errors) could be used to failed on demand.
