### PR TITLE
Feature/brbdcf 1043 hosts pool from file

### DIFF
--- a/commands/hostspool/hosts_pool.go
+++ b/commands/hostspool/hosts_pool.go
@@ -16,9 +16,25 @@ package hostspool
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/ystia/yorc/commands"
+	"github.com/ystia/yorc/helper/tabutil"
+	"github.com/ystia/yorc/prov/hostspool"
+)
+
+// Internal constants for operations on hosts pool
+const (
+	hostDeletion = iota
+	hostUpdate
+	hostCreation
+	hostError
+	hostList
+	hostNoOperation
 )
 
 func init() {
@@ -61,4 +77,131 @@ func setHostsPoolConfig() {
 	viper.SetDefault("yorc_api", "localhost:8800")
 	viper.SetDefault("secured", false)
 	viper.SetDefault("skip_tls_verify", false)
+}
+
+// getColoredText returns a text colored accroding to the operation in
+// argument :
+// - red for a deletion
+// - yellow for an update (bold for the new version, regular for the old one)
+// - green for a creation
+func getColoredText(colorize bool, text string, operation int) string {
+	if !colorize {
+		return text
+	}
+	switch operation {
+	case hostCreation:
+		return color.New(color.FgHiGreen, color.Bold).SprintFunc()(text)
+	case hostUpdate:
+		return color.New(color.FgHiYellow, color.Bold).SprintFunc()(text)
+	case hostDeletion:
+		return color.New(color.FgHiRed, color.Bold).SprintFunc()(text)
+	case hostError:
+		return color.New(color.FgHiRed, color.Bold).SprintFunc()(text)
+	default:
+		return text
+	}
+}
+
+// getColoredHostStatus returns a status colored according to its value,
+// used by 'hosts list' operations
+func getColoredHostStatus(colorize bool, status string) string {
+	if !colorize {
+		return status
+	}
+	switch {
+	case strings.ToLower(status) == "free":
+		return color.New(color.FgHiGreen, color.Bold).SprintFunc()(status)
+	case strings.ToLower(status) == "allocated":
+		return color.New(color.FgHiYellow, color.Bold).SprintFunc()(status)
+	default:
+		return color.New(color.FgHiRed, color.Bold).SprintFunc()(status)
+	}
+}
+
+// padSlices is padding as necessary slices in arguments so that both slices
+// have the same number of elements
+func padSlices(slice1 []string, slice2 []string) ([]string, []string) {
+	slice1Size := len(slice1)
+	slice2Size := len(slice2)
+
+	if slice1Size > slice2Size {
+		for i := 0; i < slice1Size-slice2Size; i++ {
+			slice2 = append(slice2, "")
+		}
+	} else {
+		for i := 0; i < slice2Size-slice1Size; i++ {
+			slice1 = append(slice1, "")
+		}
+	}
+
+	return slice1, slice2
+}
+
+// AaddRow adds a row to a table, with text colored according to the operation
+func addRow(table tabutil.Table, colorize bool, operation int,
+	name string,
+	connection hostspool.Connection,
+	status *hostspool.HostStatus,
+	message *string,
+	labels map[string]string) {
+
+	colNumber := 2
+	statusString := ""
+	if status != nil {
+		colNumber++
+		statusString = status.String()
+	}
+	messageString := ""
+	if message != nil {
+		colNumber++
+		messageString = *message
+	}
+	if labels != nil {
+		colNumber++
+	}
+
+	connectionSubRows := strings.Split(connection.String(), ",")
+	var labelSubRows []string
+	if labels != nil {
+		labelSubRows = strings.Split(toPrintableLabels(labels), ",")
+		sort.Strings(labelSubRows)
+	}
+
+	connectionSubRows, labelSubRows = padSlices(connectionSubRows, labelSubRows)
+	subRowsNumber := len(connectionSubRows)
+
+	// Add rows, one for each sub-column
+	for i := 0; i < subRowsNumber; i++ {
+		coloredColumns := make([]interface{}, colNumber)
+		coloredColumns[0] = getColoredText(colorize, name, operation)
+		coloredColumns[1] = getColoredText(colorize,
+			strings.TrimSpace(connectionSubRows[i]), operation)
+		j := 2
+		if status != nil {
+			// For a list operation, color the status according to its value
+			if operation == hostList {
+				coloredColumns[j] = getColoredHostStatus(colorize, statusString)
+			} else {
+				coloredColumns[j] = getColoredText(colorize, statusString, operation)
+			}
+
+			j++
+		}
+		if message != nil {
+			coloredColumns[j] = getColoredText(colorize, messageString, operation)
+			j++
+		}
+		if labels != nil {
+			coloredColumns[j] = getColoredText(colorize,
+				strings.TrimSpace(labelSubRows[i]), operation)
+		}
+
+		table.AddRow(coloredColumns...)
+		if i == 0 {
+			// Don't repeat single column values in sub-columns
+			name = ""
+			statusString = ""
+			messageString = ""
+		}
+	}
 }

--- a/commands/hostspool/hosts_pool_apply.go
+++ b/commands/hostspool/hosts_pool_apply.go
@@ -72,7 +72,7 @@ func init() {
 			}
 
 			// Organizing data per host name for easier use below
-			newPoolMap := make(map[string]rest.HostInPool)
+			newPoolMap := make(map[string]rest.HostConfig)
 			for i, host := range hostsPoolRequest.Hosts {
 				if host.Name == "" {
 					return errors.Errorf("A non-empty Name should be provided for Host number %d, defined with connection %q",

--- a/commands/hostspool/hosts_pool_apply.go
+++ b/commands/hostspool/hosts_pool_apply.go
@@ -302,7 +302,7 @@ func init() {
 						nil)
 				}
 			}
-			fmt.Println("New hosts pool definition applied successfully.")
+			fmt.Println("New hosts pool configuration applied successfully.")
 			if connectionFailure {
 				fmt.Println("Connection failures occured for the following hosts:")
 				fmt.Println("")

--- a/commands/hostspool/hosts_pool_apply.go
+++ b/commands/hostspool/hosts_pool_apply.go
@@ -43,6 +43,7 @@ const (
 )
 
 func init() {
+	var autoApprove bool
 	var applyCmd = &cobra.Command{
 		Use:   "apply <path to Hosts Pool description>",
 		Short: "Apply a Hosts Pool description",
@@ -191,46 +192,49 @@ func init() {
 			}
 
 			fmt.Println("\nThe following changes will be applied.")
-			if deletion {
-				fmt.Println("\n- Hosts to be deleted :")
+			if creation {
+				fmt.Println("\n- Hosts to be created :")
 				fmt.Println("")
-				fmt.Println(hostsToDeleteTable.Render())
+				fmt.Println(hostsToCreateTable.Render())
 			}
 			if update {
 				fmt.Println("\n- Hosts to be updated :")
 				fmt.Println("")
 				fmt.Println(hostsToUpdateTable.Render())
 			}
-			if creation {
-				fmt.Println("\n- Hosts to be created :")
+			if deletion {
+				fmt.Println("\n- Hosts to be deleted :")
 				fmt.Println("")
-				fmt.Println(hostsToCreateTable.Render())
+				fmt.Println(hostsToDeleteTable.Render())
 			}
 
-			// Ask for confirmation
-			badAnswer := true
-			var answer string
-			for badAnswer {
-				fmt.Printf("\nApply these settings [y/N]: ")
-				var inputText string
-				reader := bufio.NewReader(os.Stdin)
-				inputText, err := reader.ReadString('\n')
-				badAnswer = err != nil
-				if !badAnswer {
-					answer = strings.ToLower(strings.TrimSpace(inputText))
-					badAnswer = answer != "" &&
-						answer != "n" && answer != "no" &&
-						answer != "y" && answer != "yes"
+			if !autoApprove {
+
+				// Ask for confirmation
+				badAnswer := true
+				var answer string
+				for badAnswer {
+					fmt.Printf("\nApply these settings [y/N]: ")
+					var inputText string
+					reader := bufio.NewReader(os.Stdin)
+					inputText, err := reader.ReadString('\n')
+					badAnswer = err != nil
+					if !badAnswer {
+						answer = strings.ToLower(strings.TrimSpace(inputText))
+						badAnswer = answer != "" &&
+							answer != "n" && answer != "no" &&
+							answer != "y" && answer != "yes"
+					}
+
+					if badAnswer {
+						fmt.Println("Unexpected input. Please enter y or n.")
+					}
 				}
 
-				if badAnswer {
-					fmt.Println("Unexpected input. Please enter y or n.")
+				if answer != "y" && answer != "yes" {
+					fmt.Println("Changes not applied.")
+					return nil
 				}
-			}
-
-			if answer != "y" && answer != "yes" {
-				fmt.Println("Changes not applied.")
-				return nil
 			}
 
 			// Proceed to the change
@@ -254,6 +258,8 @@ func init() {
 			return nil
 		},
 	}
+	applyCmd.PersistentFlags().BoolVarP(&autoApprove, "auto-approve", "", false,
+		"Skip interactive approval before applying this new Hosts Pool description.")
 	hostsPoolCmd.AddCommand(applyCmd)
 }
 

--- a/commands/hostspool/hosts_pool_apply.go
+++ b/commands/hostspool/hosts_pool_apply.go
@@ -258,8 +258,17 @@ func init() {
 				httputil.ErrExit(err)
 			}
 
-			httputil.HandleHTTPStatusCode(
-				response, args[0], "host pool", http.StatusOK, http.StatusCreated)
+			// Handle the response
+			// This is a generic response management, except from the case where
+			// a checkpoint issue was detected.
+			// In this case, the REST API error message is overriden by a
+			// user-friendly message
+			customizedErrorMessages := map[string]string{
+				hostspool.CheckpointError: "New Hosts Pool configuration not applied, as a change occured since the above diff. Please re-apply your configuration to see actual changes.",
+			}
+
+			httputil.HandleHTTPStatusCodeWithCustomizedErrorMessage(
+				response, args[0], "host pool", customizedErrorMessages, http.StatusOK, http.StatusCreated)
 
 			// Verify the status of each updated/new host and log
 			// connection failures

--- a/commands/hostspool/hosts_pool_apply.go
+++ b/commands/hostspool/hosts_pool_apply.go
@@ -15,18 +15,31 @@
 package hostspool
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"reflect"
+	"strings"
 
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/ystia/yorc/commands/httputil"
+	"github.com/ystia/yorc/helper/tabutil"
 	"github.com/ystia/yorc/rest"
+)
+
+// Internal constants for operations on hosts pool
+const (
+	hostDeletion = iota
+	hostUpdate
+	hostCreation
 )
 
 func init() {
@@ -34,8 +47,9 @@ func init() {
 		Use:   "apply <path to Hosts Pool description>",
 		Short: "Apply a Hosts Pool description",
 		Long: `Apply a Hosts Pool description provided in the file passed in argument
-	This file should contain a YAML description.`,
+	This file should contain a YAML or a JSON description.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			colorize := !noColor
 			if len(args) != 1 {
 				return errors.Errorf("Expecting a path to a file (got %d parameters)", len(args))
 			}
@@ -60,30 +74,230 @@ func init() {
 			if err != nil {
 				log.Panic(err)
 			}
-			log.Println("LOLO", hostsPoolRequest)
+
+			// Organizing data per host name for easier use below
+			newPoolMap := make(map[string]rest.HostInPool)
+			for i, host := range hostsPoolRequest.Hosts {
+				if host.Name == "" {
+					return errors.Errorf("A non-empty Name should be provided for Host number %d, defined with connection %q",
+						i+1, host.Connection)
+				}
+
+				newPoolMap[host.Name] = host
+			}
+
+			// Get current Hosts Pool to output diffs and ask for user
+			// confirmation before proceeding to the change
 			client, err := httputil.GetClient()
 			if err != nil {
 				httputil.ErrExit(err)
 			}
 
+			request, err := client.NewRequest("GET", "/hosts_pool", nil)
+			if err != nil {
+				httputil.ErrExit(err)
+			}
+			request.Header.Add("Accept", "application/json")
+			response, err := client.Do(request)
+			defer response.Body.Close()
+			if err != nil {
+				httputil.ErrExit(err)
+			}
+			httputil.HandleHTTPStatusCode(response, "", "Hosts Pool", http.StatusOK)
+			var hostsColl rest.HostsCollection
+			body, err := ioutil.ReadAll(response.Body)
+			if err != nil {
+				httputil.ErrExit(err)
+			}
+			err = json.Unmarshal(body, &hostsColl)
+			if err != nil {
+				httputil.ErrExit(err)
+			}
+
+			// Find which hosts will be deleted, updated, created
+			var deletion, update, creation bool
+			hostsToDeleteTable := tabutil.NewTable()
+			hostsToDeleteTable.AddHeaders(
+				"Name", "Connection", "Status", "Message", "Labels")
+			hostsToCreateTable := tabutil.NewTable()
+			hostsToCreateTable.AddHeaders("Name", "Connection", "Labels")
+			hostsToUpdateTable := tabutil.NewTable()
+			hostsToUpdateTable.AddHeaders(
+				"Version", "Name", "Connection", "Status", "Message", "Labels")
+
+			for _, hostLink := range hostsColl.Hosts {
+				if hostLink.Rel == rest.LinkRelHost {
+					var host rest.Host
+
+					err = httputil.GetJSONEntityFromAtomGetRequest(
+						client, hostLink, &host)
+					if err != nil {
+						httputil.ErrExit(err)
+					}
+
+					if newDef, ok := newPoolMap[host.Name]; ok {
+						// This is an update
+						//  Check if there is any change before registering the
+						// need to update
+						if host.Connection != newDef.Connection ||
+							!reflect.DeepEqual(host.Labels, newDef.Labels) {
+							update = true
+							addRow(hostsToUpdateTable, colorize, hostUpdate,
+								"old",
+								host.Name,
+								host.Connection.String(),
+								host.Status.String(),
+								host.Message,
+								toPrintableLabels(host.Labels))
+
+							addRow(hostsToUpdateTable, colorize, hostUpdate,
+								"new",
+								newDef.Name,
+								newDef.Connection.String(),
+								host.Status.String(),
+								host.Message,
+								toPrintableLabels(newDef.Labels))
+						}
+
+						// This host is now computed, removing it from the map
+						// so that in the end, only hosts to create will be left
+						delete(newPoolMap, host.Name)
+					} else {
+						// host isn't in the new Pool, this is a deletion
+						deletion = true
+						addRow(hostsToDeleteTable, colorize, hostDeletion,
+							host.Name,
+							host.Connection.String(),
+							host.Status.String(),
+							host.Message,
+							toPrintableLabels(host.Labels))
+					}
+
+				}
+			}
+
+			// Hosts left in newPoolMap are hosts to create
+			for _, host := range newPoolMap {
+				creation = true
+				addRow(hostsToCreateTable, colorize, hostCreation,
+					host.Name,
+					host.Connection.String(),
+					toPrintableLabels(host.Labels))
+			}
+
+			if !deletion && !update && !creation {
+				fmt.Println("No change needed, Hosts Pool is up to date.")
+				return nil
+			}
+
+			fmt.Println("\nThe following changes will be applied.")
+			if deletion {
+				fmt.Println("\n- Hosts to be deleted :")
+				fmt.Println("")
+				fmt.Println(hostsToDeleteTable.Render())
+			}
+			if update {
+				fmt.Println("\n- Hosts to be updated :")
+				fmt.Println("")
+				fmt.Println(hostsToUpdateTable.Render())
+			}
+			if creation {
+				fmt.Println("\n- Hosts to be created :")
+				fmt.Println("")
+				fmt.Println(hostsToCreateTable.Render())
+			}
+
+			// Ask for confirmation
+			badAnswer := true
+			var answer string
+			for badAnswer {
+				fmt.Printf("\nApply these settings [y/N]: ")
+				var inputText string
+				reader := bufio.NewReader(os.Stdin)
+				inputText, err := reader.ReadString('\n')
+				badAnswer = err != nil
+				if !badAnswer {
+					answer = strings.ToLower(strings.TrimSpace(inputText))
+					badAnswer = answer != "" &&
+						answer != "n" && answer != "no" &&
+						answer != "y" && answer != "yes"
+				}
+
+				if badAnswer {
+					fmt.Println("Unexpected input. Please enter y or n.")
+				}
+			}
+
+			if answer != "y" && answer != "yes" {
+				fmt.Println("Changes not applied.")
+				return nil
+			}
+
+			// Proceed to the change
+
 			bArray, err := json.Marshal(&hostsPoolRequest)
-			request, err := client.NewRequest("PUT", "/hosts_pool",
+			request, err = client.NewRequest("PUT", "/hosts_pool",
 				bytes.NewBuffer(bArray))
 			if err != nil {
 				httputil.ErrExit(err)
 			}
 			request.Header.Add("Content-Type", "application/json")
 
-			response, err := client.Do(request)
+			response, err = client.Do(request)
 			defer response.Body.Close()
 			if err != nil {
 				httputil.ErrExit(err)
 			}
 
-			httputil.HandleHTTPStatusCode(response, args[0], "host pool", http.StatusOK)
-			fmt.Println("Command submitted.")
+			httputil.HandleHTTPStatusCode(
+				response, args[0], "host pool", http.StatusOK)
 			return nil
 		},
 	}
 	hostsPoolCmd.AddCommand(applyCmd)
+}
+
+// Returns a printable value of labels
+func toPrintableLabels(labels map[string]string) string {
+	var labelsList string
+	for k, v := range labels {
+		if labelsList != "" {
+			labelsList += ", "
+		}
+		labelsList += fmt.Sprintf("%s:%s", k, v)
+	}
+
+	return labelsList
+}
+
+// getColoredText returns a text colored accroding to the operation in
+// argument :
+// - red for a deletion
+// - yellow for an update (bold for the new version, regular for the old one)
+// - green for a creation
+func getColoredText(colorize bool, text string, operation int) string {
+	if !colorize {
+		return text
+	}
+	switch operation {
+	case hostCreation:
+		return color.New(color.FgHiGreen, color.Bold).SprintFunc()(text)
+	case hostUpdate:
+		return color.New(color.FgHiYellow, color.Bold).SprintFunc()(text)
+	case hostDeletion:
+		return color.New(color.FgHiRed, color.Bold).SprintFunc()(text)
+	default:
+		return text
+	}
+}
+
+// Add a row to a table, with text colored according to the operation
+func addRow(table tabutil.Table, colorize bool, operation int, columns ...string) {
+
+	coloredColumns := make([]interface{}, len(columns))
+	for i, text := range columns {
+		coloredColumns[i] = getColoredText(colorize, text, operation)
+	}
+
+	table.AddRow(coloredColumns...)
 }

--- a/commands/hostspool/hosts_pool_apply.go
+++ b/commands/hostspool/hosts_pool_apply.go
@@ -114,7 +114,7 @@ func init() {
 
 			// Unmarshal response content if any
 			var hostsColl rest.HostsCollection
-			var version uint64
+			var checkpoint uint64
 			if response.StatusCode != http.StatusNoContent {
 				body, err := ioutil.ReadAll(response.Body)
 				if err != nil {
@@ -124,7 +124,7 @@ func init() {
 				if err != nil {
 					httputil.ErrExit(err)
 				}
-				version = hostsColl.Version
+				checkpoint = hostsColl.Checkpoint
 			}
 
 			// Find which hosts will be deleted, updated, created
@@ -247,19 +247,19 @@ func init() {
 			// Proceed to the change
 
 			bArray, err := json.Marshal(&hostsPoolRequest)
-			request, err = client.NewRequest("PUT", "/hosts_pool",
+			request, err = client.NewRequest("POST", "/hosts_pool",
 				bytes.NewBuffer(bArray))
 			if err != nil {
 				httputil.ErrExit(err)
 			}
 			request.Header.Add("Content-Type", "application/json")
 
-			// Specify the version that was returned by the 'hosts pool list'
+			// Specify the checkpoint that was returned by the 'hosts pool list'
 			// request above, to ensure there was no change between the
 			// Hosts Pool that was returned by this request
 			// and the Hosts Pool to which changes will be applied
 			query := request.URL.Query()
-			query.Set("version", strconv.FormatUint(version, 10))
+			query.Set("checkpoint", strconv.FormatUint(checkpoint, 10))
 			request.URL.RawQuery = query.Encode()
 
 			response, err = client.Do(request)
@@ -269,7 +269,7 @@ func init() {
 			}
 
 			httputil.HandleHTTPStatusCode(
-				response, args[0], "host pool", http.StatusOK)
+				response, args[0], "host pool", http.StatusOK, http.StatusCreated)
 
 			// Verify the status of each updated/new host and log
 			// connection failures

--- a/commands/hostspool/hosts_pool_apply.go
+++ b/commands/hostspool/hosts_pool_apply.go
@@ -1,0 +1,89 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostspool
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/ystia/yorc/commands/httputil"
+	"github.com/ystia/yorc/rest"
+)
+
+func init() {
+	var applyCmd = &cobra.Command{
+		Use:   "apply <path to Hosts Pool description>",
+		Short: "Apply a Hosts Pool description",
+		Long: `Apply a Hosts Pool description provided in the file passed in argument
+	This file should contain a YAML description.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.Errorf("Expecting a path to a file (got %d parameters)", len(args))
+			}
+			fileInfo, err := os.Stat(args[0])
+			if err != nil {
+				return err
+			}
+			if fileInfo.IsDir() {
+				return errors.Errorf("Expecting a path to a file (%s is a directory)", args[0])
+			}
+
+			// Read config file, viper will accept indiferrently a yaml or json
+			// format
+			viper.SetConfigFile(args[0])
+			err = viper.ReadInConfig()
+			if err != nil {
+				log.Panic(err)
+			}
+
+			var hostsPoolRequest rest.HostsPoolRequest
+			err = viper.Unmarshal(&hostsPoolRequest)
+			if err != nil {
+				log.Panic(err)
+			}
+			log.Println("LOLO", hostsPoolRequest)
+			client, err := httputil.GetClient()
+			if err != nil {
+				httputil.ErrExit(err)
+			}
+
+			bArray, err := json.Marshal(&hostsPoolRequest)
+			request, err := client.NewRequest("PUT", "/hosts_pool",
+				bytes.NewBuffer(bArray))
+			if err != nil {
+				httputil.ErrExit(err)
+			}
+			request.Header.Add("Content-Type", "application/json")
+
+			response, err := client.Do(request)
+			defer response.Body.Close()
+			if err != nil {
+				httputil.ErrExit(err)
+			}
+
+			httputil.HandleHTTPStatusCode(response, args[0], "host pool", http.StatusOK)
+			fmt.Println("Command submitted.")
+			return nil
+		},
+	}
+	hostsPoolCmd.AddCommand(applyCmd)
+}

--- a/commands/hostspool/hosts_pool_apply.go
+++ b/commands/hostspool/hosts_pool_apply.go
@@ -40,9 +40,9 @@ import (
 func init() {
 	var autoApprove bool
 	var applyCmd = &cobra.Command{
-		Use:   "apply <path to Hosts Pool description>",
-		Short: "Apply a Hosts Pool description",
-		Long: `Apply a Hosts Pool description provided in the file passed in argument
+		Use:   "apply <path to Hosts Pool configuration>",
+		Short: "Apply a Hosts Pool configuration",
+		Long: `Apply a Hosts Pool configuration provided in the file passed in argument
 	This file should contain a YAML or a JSON description.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			colorize := !noColor
@@ -313,7 +313,7 @@ func init() {
 		},
 	}
 	applyCmd.PersistentFlags().BoolVarP(&autoApprove, "auto-approve", "", false,
-		"Skip interactive approval before applying this new Hosts Pool description.")
+		"Skip interactive approval before applying this new Hosts Pool configuration.")
 	hostsPoolCmd.AddCommand(applyCmd)
 }
 

--- a/commands/hostspool/hosts_pool_export.go
+++ b/commands/hostspool/hosts_pool_export.go
@@ -1,0 +1,110 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostspool
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/ystia/yorc/commands/httputil"
+	"github.com/ystia/yorc/rest"
+	"gopkg.in/yaml.v2"
+)
+
+func init() {
+	var outputFormat string
+	var filePath string
+	hpExportCmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export hosts pool",
+		Long:  `Export hosts pool as a YAML or JSON representation`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := httputil.GetClient()
+			if err != nil {
+				httputil.ErrExit(err)
+			}
+			request, err := client.NewRequest("GET", "/hosts_pool", nil)
+			if err != nil {
+				httputil.ErrExit(err)
+			}
+
+			request.Header.Add("Accept", "application/json")
+			response, err := client.Do(request)
+			defer response.Body.Close()
+			if err != nil {
+				httputil.ErrExit(err)
+			}
+			httputil.HandleHTTPStatusCode(response, "", "host pool", http.StatusOK)
+			var hostsColl rest.HostsCollection
+			body, err := ioutil.ReadAll(response.Body)
+			if err != nil {
+				httputil.ErrExit(err)
+			}
+			err = json.Unmarshal(body, &hostsColl)
+			if err != nil {
+				httputil.ErrExit(err)
+			}
+
+			pool := rest.HostsPoolRequest{}
+			for _, hostLink := range hostsColl.Hosts {
+				if hostLink.Rel == rest.LinkRelHost {
+					var restHost rest.Host
+					err = httputil.GetJSONEntityFromAtomGetRequest(client, hostLink, &restHost)
+					if err != nil {
+						httputil.ErrExit(err)
+					}
+
+					host := rest.HostInPool{
+						Name:       restHost.Name,
+						Connection: restHost.Connection,
+						Labels:     restHost.Labels,
+					}
+					pool.Hosts = append(pool.Hosts, host)
+				}
+			}
+
+			// Marshal according to the specified output format
+			outputFormat = strings.ToLower(strings.TrimSpace(outputFormat))
+			var bSlice []byte
+			if outputFormat == "json" {
+				bSlice, err = json.Marshal(pool)
+			} else {
+				bSlice, err = yaml.Marshal(pool)
+			}
+			if err != nil {
+				httputil.ErrExit(err)
+			}
+
+			if filePath != "" {
+				err = ioutil.WriteFile(filePath, bSlice, 0644)
+				if err != nil {
+					httputil.ErrExit(err)
+				}
+			} else {
+				output := string(bSlice)
+				fmt.Println(output)
+			}
+
+			return nil
+		},
+	}
+	hpExportCmd.Flags().StringVarP(&outputFormat, "output", "o", "yaml", "Output format: yaml, json")
+	hpExportCmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to a file where to store the output")
+	hostsPoolCmd.AddCommand(hpExportCmd)
+}

--- a/commands/hostspool/hosts_pool_export.go
+++ b/commands/hostspool/hosts_pool_export.go
@@ -32,8 +32,8 @@ func init() {
 	var filePath string
 	hpExportCmd := &cobra.Command{
 		Use:   "export",
-		Short: "Export hosts pool",
-		Long:  `Export hosts pool as a YAML or JSON representation`,
+		Short: "Export hosts pool configuration",
+		Long:  `Export hosts pool configuration as a YAML or JSON representation`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := httputil.GetClient()
 			if err != nil {
@@ -83,7 +83,7 @@ func init() {
 			outputFormat = strings.ToLower(strings.TrimSpace(outputFormat))
 			var bSlice []byte
 			if outputFormat == "json" {
-				bSlice, err = json.Marshal(pool)
+				bSlice, err = json.MarshalIndent(pool, "", "    ")
 			} else {
 				bSlice, err = yaml.Marshal(pool)
 			}

--- a/commands/hostspool/hosts_pool_export.go
+++ b/commands/hostspool/hosts_pool_export.go
@@ -70,7 +70,7 @@ func init() {
 						httputil.ErrExit(err)
 					}
 
-					host := rest.HostInPool{
+					host := rest.HostConfig{
 						Name:       restHost.Name,
 						Connection: restHost.Connection,
 						Labels:     restHost.Labels,

--- a/commands/hostspool/hosts_pool_list.go
+++ b/commands/hostspool/hosts_pool_list.go
@@ -75,7 +75,11 @@ func init() {
 					if err != nil {
 						httputil.ErrExit(err)
 					}
-
+					// If no label was defined, define an empty map
+					// to still consider there is a column to display
+					if host.Labels == nil {
+						host.Labels = map[string]string{}
+					}
 					addRow(hostsTable, colorize, hostList,
 						host.Name,
 						host.Connection,

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -370,4 +370,74 @@ Gets the description of a host of the hosts pool managed by this Yorc cluster.
 
      yorc hostspool info <hostname>
 
+Apply a Hosts Pool configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Applies a Hosts Pool configuration provided in a YAML or JSON file.
+This command will compare and display the differences between the current Hosts Pool configuration and the configuration specified in the file.
+A user confirmation will be asked before proceeding.
+The command will fail if the new configuration would result in the removal of a host currently allocated for a deployment.
+
+.. code-block:: bash
+
+     yorc hostspool apply <filename>
+
+Flags:
+  * ``--auto-approve``: Skip interactive approval before applying the new Hosts Pool configuration.
+
+
+YAML and JSON formats are accepted. The following properties are supported :
+
+  * ``hosts``: List of hosts configuration. A host configuration supports the following properties,
+     - ``name``: mandatory string identifying the host, no other host entry can have the same name value in the file
+     - ``connection``: Connection configuration,
+        + ``host``: Hostname or ip address used to connect to the host (defaults to the ``name`` described above)
+        + ``user``: name of the user used to connect to the host (default "root")
+        + ``password``: either a password or a private key should be provided
+        + ``private_key``: Path to a private key file (or private key file content), either a password or a private key should be provided
+        + ``port``: Port used to connect to the host (default 22)
+     - ``labels``: key/value pairs (see :ref:`yorc_infras_hostspool_filters_section` for more details on labels)
+
+
+Exanple of a YAML Hosts Pool configuration file :
+
+.. code-block:: YAML
+
+    hosts:
+    - name: host1
+      connection:
+        host: host1.example.com
+        user: test
+        private_key: /path/to/secrets/id_rsa
+        port: 22
+      labels:
+        environment: dev
+        testlabel: hello
+        host.cpu_frequency: 3 GHz
+        host.disk_size: 50 GB
+        host.mem_size: 4GB
+        host.num_cpus: "4"
+        os.architecture: x86_64
+        os.distribution: ubuntu
+        os.type: linux
+        os.version: "17.1"
+    - name: host2
+      connection:
+        host: host2.example.com
+        user: test
+        password: test
+
+Export a Hosts Pool configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Exports a Hosts Pool configuration as a YAML or JSON representation, to the standard output or a file.
+
+.. code-block:: bash
+
+     yorc hostspool export [<filename>]
+
+Flags:
+  * ``--output`` or ``-o``: Output format, ``yaml`` or ``json`` (default ``yaml``)
+  * ``--file`` or ``-f``: Path to a file where to store the output (default standard output)
+
 

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -434,7 +434,7 @@ Exports a Hosts Pool configuration as a YAML or JSON representation, to the stan
 
 .. code-block:: bash
 
-     yorc hostspool export [<filename>]
+     yorc hostspool export
 
 Flags:
   * ``--output`` or ``-o``: Output format, ``yaml`` or ``json`` (default ``yaml``)

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -399,7 +399,7 @@ YAML and JSON formats are accepted. The following properties are supported :
      - ``labels``: key/value pairs (see :ref:`yorc_infras_hostspool_filters_section` for more details on labels)
 
 
-Exanple of a YAML Hosts Pool configuration file :
+Example of a YAML Hosts Pool configuration file :
 
 .. code-block:: YAML
 

--- a/helper/consulutil/prefix.go
+++ b/helper/consulutil/prefix.go
@@ -36,3 +36,7 @@ const LogsPrefix = yorcPrefix + "/logs"
 
 // HostsPoolPrefix is the prefix on KV store for the hosts pool service
 const HostsPoolPrefix = yorcPrefix + "/hosts_pool"
+
+// YorcManagementPrefix is the prefix on KV store for the orchestrator
+// own management
+const YorcManagementPrefix = yorcPrefix + "/.yorc_management"

--- a/prov/hostspool/consul_test.go
+++ b/prov/hostspool/consul_test.go
@@ -54,18 +54,18 @@ func TestRunConsulHostsPoolPackageTests(t *testing.T) {
 		testConsulManagerApply(t, client)
 	})
 	t.Run("testConsulManagerApplyErrorNoName", func(t *testing.T) {
-		testConsulManagerApply(t, client)
+		testConsulManagerApplyErrorNoName(t, client)
 	})
 	t.Run("testConsulManagerApplyErrorDuplicateName", func(t *testing.T) {
-		testConsulManagerApply(t, client)
+		testConsulManagerApplyErrorDuplicateName(t, client)
 	})
 	t.Run("testConsulManagerApplyErrorDeleteAllocatedHost", func(t *testing.T) {
-		testConsulManagerApply(t, client)
+		testConsulManagerApplyErrorDeleteAllocatedHost(t, client)
 	})
 	t.Run("testConsulManagerApplyErrorOutdatedCheckpoint", func(t *testing.T) {
-		testConsulManagerApply(t, client)
+		testConsulManagerApplyErrorOutdatedCheckpoint(t, client)
 	})
 	t.Run("testConsulManagerApplyBadConnection", func(t *testing.T) {
-		testConsulManagerApply(t, client)
+		testConsulManagerApplyBadConnection(t, client)
 	})
 }

--- a/prov/hostspool/consul_test.go
+++ b/prov/hostspool/consul_test.go
@@ -50,4 +50,7 @@ func TestRunConsulHostsPoolPackageTests(t *testing.T) {
 	t.Run("TestConsulManagerGetHost", func(t *testing.T) {
 		testConsulManagerGetHost(t, client)
 	})
+	t.Run("TestConsulManagerApply", func(t *testing.T) {
+		testConsulManagerApply(t, client)
+	})
 }

--- a/prov/hostspool/consul_test.go
+++ b/prov/hostspool/consul_test.go
@@ -53,4 +53,19 @@ func TestRunConsulHostsPoolPackageTests(t *testing.T) {
 	t.Run("TestConsulManagerApply", func(t *testing.T) {
 		testConsulManagerApply(t, client)
 	})
+	t.Run("testConsulManagerApplyErrorNoName", func(t *testing.T) {
+		testConsulManagerApply(t, client)
+	})
+	t.Run("testConsulManagerApplyErrorDuplicateName", func(t *testing.T) {
+		testConsulManagerApply(t, client)
+	})
+	t.Run("testConsulManagerApplyErrorDeleteAllocatedHost", func(t *testing.T) {
+		testConsulManagerApply(t, client)
+	})
+	t.Run("testConsulManagerApplyErrorOutdatedCheckpoint", func(t *testing.T) {
+		testConsulManagerApply(t, client)
+	})
+	t.Run("testConsulManagerApplyBadConnection", func(t *testing.T) {
+		testConsulManagerApply(t, client)
+	})
 }

--- a/prov/hostspool/hostspool_mgr.go
+++ b/prov/hostspool/hostspool_mgr.go
@@ -35,6 +35,8 @@ import (
 )
 
 const (
+	// CheckpointError is an error of checkpoint between the current Hosts Pool
+	// and an apply change request
 	CheckpointError = "Checkpoint for Hosts Pool error"
 )
 

--- a/prov/hostspool/hostspool_mgr.go
+++ b/prov/hostspool/hostspool_mgr.go
@@ -1096,7 +1096,7 @@ func (cm *consulManager) applyWait(
 
 	ok, response, _, err := cm.cc.KV().Txn(ops, nil)
 	if err != nil {
-		return errors.Wrap(err, "Failed to apply new Hosts Pool definition")
+		return errors.Wrap(err, "Failed to apply new Hosts Pool configuration")
 	}
 
 	if !ok {
@@ -1105,7 +1105,7 @@ func (cm *consulManager) applyWait(
 		for _, e := range response.Errors {
 			errs = append(errs, e.What)
 		}
-		err = errors.Errorf("Failed to apply new Hosts Pool definition: %s", strings.Join(errs, ", "))
+		err = errors.Errorf("Failed to apply new Hosts Pool configuration: %s", strings.Join(errs, ", "))
 	}
 
 	// Update the connection status for each updated/created host

--- a/prov/hostspool/hostspool_mgr.go
+++ b/prov/hostspool/hostspool_mgr.go
@@ -34,6 +34,10 @@ import (
 	"github.com/ystia/yorc/helper/sshutil"
 )
 
+const (
+	CheckpointError = "Checkpoint for Hosts Pool error"
+)
+
 // A Manager is in charge of creating/updating/deleting hosts from the pool
 type Manager interface {
 	Add(hostname string, connection Connection, labels map[string]string) error
@@ -1001,8 +1005,8 @@ func (cm *consulManager) applyWait(
 		((*checkpoint == 0 && len(registeredHosts) > 0) ||
 			(*checkpoint > 0 && *checkpoint < runtimeCheckpoint)) {
 		return errors.WithStack(badRequestError{
-			fmt.Sprintf("Checkpoint for Hosts Pool: value provided %d lower than expected checkpoint %d",
-				*checkpoint, runtimeCheckpoint)})
+			fmt.Sprintf("%s: value provided %d lower than expected checkpoint %d",
+				CheckpointError, *checkpoint, runtimeCheckpoint)})
 	}
 
 	hostsToUnregisterCheckAllocatedStatus := make(map[string]bool)

--- a/prov/hostspool/hostspool_mgr.go
+++ b/prov/hostspool/hostspool_mgr.go
@@ -1069,8 +1069,6 @@ func (cm *consulManager) applyWait(
 		}
 	}
 
-	// TODO: add logs
-
 	// Update the connection status for each updated/created host
 	var waitGroup sync.WaitGroup
 	for _, name := range hostChanged {

--- a/prov/hostspool/hostspool_mgr_test.go
+++ b/prov/hostspool/hostspool_mgr_test.go
@@ -684,6 +684,12 @@ func testConsulManagerApplyErrorNoName(t *testing.T, cc *api.Client) {
 
 	var hostpool = createHosts(3)
 
+	// Apply this definition
+	var checkpoint uint64
+	err := cm.Apply(hostpool, &checkpoint)
+	require.NoError(t, err, "Unexpected failure applying host pool configuration")
+	assert.NotEqual(t, uint64(0), checkpoint, "Expected checkpoint to be > 0 after apply")
+
 	// Error case: entry with no name
 	oldName := hostpool[0].Name
 	hostpool[0].Name = "newName"
@@ -714,6 +720,12 @@ func testConsulManagerApplyErrorDuplicateName(t *testing.T, cc *api.Client) {
 
 	var hostpool = createHosts(3)
 
+	// Apply this definition
+	var checkpoint uint64
+	err := cm.Apply(hostpool, &checkpoint)
+	require.NoError(t, err, "Unexpected failure applying host pool configuration")
+	assert.NotEqual(t, uint64(0), checkpoint, "Expected checkpoint to be > 0 after apply")
+
 	// Error case: duplicate names
 	oldName := hostpool[len(hostpool)-1].Name
 	hostpool[len(hostpool)-1].Name = hostpool[0].Name
@@ -728,7 +740,7 @@ func testConsulManagerApplyErrorDuplicateName(t *testing.T, cc *api.Client) {
 	hosts, warnings, ckpt2, err := cm.List()
 	require.NoError(t, err, "Unexpected error getting list of hosts in pool")
 	assert.Len(t, warnings, 0)
-	assert.Len(t, hosts, 4)
+	assert.Len(t, hosts, 3)
 	assert.Contains(t, hosts, oldName,
 		"Hosts Pool unexpectedly changed after an apply error using duplicates")
 	assert.Equal(t, ckpt1, ckpt, "Expected no checkpoint change after apply error")
@@ -772,7 +784,7 @@ func testConsulManagerApplyErrorDeleteAllocatedHost(t *testing.T, cc *api.Client
 	hosts2, warnings, ckpt2, err := cm.List()
 	require.NoError(t, err, "Unexpected error getting list of hosts in pool")
 	assert.Len(t, warnings, 0)
-	assert.Len(t, hosts2, 4)
+	assert.Len(t, hosts2, 3)
 	assert.Equal(t, hosts1, hosts2, "Expected no change in hosts pool after deletion error")
 	assert.Equal(t, checkpoint, ckpt2, "Expected no checkpoint change after deletion error")
 }

--- a/prov/hostspool/hostspool_mgr_test.go
+++ b/prov/hostspool/hostspool_mgr_test.go
@@ -548,7 +548,7 @@ func testConsulManagerApply(t *testing.T, cc *api.Client) {
 	// Apply this definition
 	var checkpoint uint64
 	err := cm.Apply(hostpool, &checkpoint)
-	require.NoError(t, err, "Unexpected failure applying host pool definition")
+	require.NoError(t, err, "Unexpected failure applying host pool configuration")
 	assert.NotEqual(t, uint64(0), checkpoint, "Expected checkpoint to be > 0 after apply")
 	// Check the pool now
 	hosts, warnings, newCkpt, err := cm.List()
@@ -633,7 +633,7 @@ func testConsulManagerApply(t *testing.T, cc *api.Client) {
 	oldcheckpoint := checkpoint
 	err = cm.Apply(hostpool, &checkpoint)
 	require.NoError(t, err,
-		"Unexpected failure applying new host pool definition")
+		"Unexpected failure applying new host pool configuration")
 
 	assert.NotEqual(t, oldcheckpoint, checkpoint, "Expected a checkpoint change")
 

--- a/prov/hostspool/hostspool_structs.go
+++ b/prov/hostspool/hostspool_structs.go
@@ -60,7 +60,8 @@ type Connection struct {
 	// The Password that we should use for the connection. One of Password or PrivateKey is required. PrivateKey takes the precedence.
 	Password string `json:"password,omitempty"`
 	// The SSH Private Key that we should use for the connection. One of Password or PrivateKey is required. PrivateKey takes the precedence.
-	PrivateKey string `json:"private_key,omitempty"`
+	// The mapstructure tag is needed for viper unmarshalling
+	PrivateKey string `json:"private_key,omitempty" mapstructure:"private_key"`
 	// The address of the Host to connect to. Defaults to the hostname specified during the registration.
 	Host string `json:"host,omitempty"`
 	// The Port to connect to. Defaults to 22 if set to 0.

--- a/prov/hostspool/hostspool_structs.go
+++ b/prov/hostspool/hostspool_structs.go
@@ -56,16 +56,16 @@ func (hs *HostStatus) UnmarshalJSON(b []byte) error {
 // A Connection holds info used to connect to a host using SSH
 type Connection struct {
 	// The User that we should use for the connection. Defaults to root.
-	User string `json:"user,omitempty"`
+	User string `json:"user,omitempty" yaml:"user,omitempty"`
 	// The Password that we should use for the connection. One of Password or PrivateKey is required. PrivateKey takes the precedence.
-	Password string `json:"password,omitempty"`
+	Password string `json:"password,omitempty" yaml:"password,omitempty"`
 	// The SSH Private Key that we should use for the connection. One of Password or PrivateKey is required. PrivateKey takes the precedence.
 	// The mapstructure tag is needed for viper unmarshalling
-	PrivateKey string `json:"private_key,omitempty" mapstructure:"private_key"`
+	PrivateKey string `json:"private_key,omitempty"  yaml:"private_key,omitempty" mapstructure:"private_key"`
 	// The address of the Host to connect to. Defaults to the hostname specified during the registration.
-	Host string `json:"host,omitempty"`
+	Host string `json:"host,omitempty" yaml:"host,omitempty"`
 	// The Port to connect to. Defaults to 22 if set to 0.
-	Port uint64 `json:"port,omitempty"`
+	Port uint64 `json:"port,omitempty" yaml:"port,omitempty"`
 }
 
 // String allows to stringify a connection

--- a/rest/hosts_pool.go
+++ b/rest/hosts_pool.go
@@ -257,5 +257,5 @@ func (s *Server) applyHostsPool(w http.ResponseWriter, r *http.Request) {
 		}
 		log.Panic(err)
 	}
-	w.WriteHeader(http.StatusCreated)
+	w.WriteHeader(http.StatusOK)
 }

--- a/rest/http.go
+++ b/rest/http.go
@@ -181,6 +181,7 @@ func (s *Server) registerHandlers() {
 	s.router.Put("/hosts_pool/:host", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.newHostInPool))
 	s.router.Patch("/hosts_pool/:host", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.updateHostInPool))
 	s.router.Delete("/hosts_pool/:host", commonHandlers.ThenFunc(s.deleteHostInPool))
+	s.router.Post("/hosts_pool", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.applyHostsPool))
 	s.router.Get("/hosts_pool", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listHostsInPool))
 	s.router.Get("/hosts_pool/:host", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getHostInPool))
 

--- a/rest/http.go
+++ b/rest/http.go
@@ -181,7 +181,7 @@ func (s *Server) registerHandlers() {
 	s.router.Put("/hosts_pool/:host", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.newHostInPool))
 	s.router.Patch("/hosts_pool/:host", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.updateHostInPool))
 	s.router.Delete("/hosts_pool/:host", commonHandlers.ThenFunc(s.deleteHostInPool))
-	s.router.Put("/hosts_pool", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.applyHostsPool))
+	s.router.Post("/hosts_pool", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.applyHostsPool))
 	s.router.Get("/hosts_pool", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listHostsInPool))
 	s.router.Get("/hosts_pool/:host", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getHostInPool))
 

--- a/rest/http.go
+++ b/rest/http.go
@@ -181,6 +181,7 @@ func (s *Server) registerHandlers() {
 	s.router.Put("/hosts_pool/:host", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.newHostInPool))
 	s.router.Patch("/hosts_pool/:host", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.updateHostInPool))
 	s.router.Delete("/hosts_pool/:host", commonHandlers.ThenFunc(s.deleteHostInPool))
+	s.router.Post("/hosts_pool", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.applyHostsPool))
 	s.router.Put("/hosts_pool", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.applyHostsPool))
 	s.router.Get("/hosts_pool", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listHostsInPool))
 	s.router.Get("/hosts_pool/:host", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getHostInPool))

--- a/rest/http.go
+++ b/rest/http.go
@@ -181,7 +181,7 @@ func (s *Server) registerHandlers() {
 	s.router.Put("/hosts_pool/:host", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.newHostInPool))
 	s.router.Patch("/hosts_pool/:host", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.updateHostInPool))
 	s.router.Delete("/hosts_pool/:host", commonHandlers.ThenFunc(s.deleteHostInPool))
-	s.router.Post("/hosts_pool", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.applyHostsPool))
+	s.router.Put("/hosts_pool", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.applyHostsPool))
 	s.router.Get("/hosts_pool", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listHostsInPool))
 	s.router.Get("/hosts_pool/:host", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getHostInPool))
 

--- a/rest/http_api.md
+++ b/rest/http_api.md
@@ -887,6 +887,7 @@ Content-Type: application/json
 
 ```json
 {
+  "checkpoint": 123,
   "hosts": [
     {"rel":"host","href":"/hosts_pool/host1","type":"application/json"},
     {"rel":"host","href":"/hosts_pool/host2","type":"application/json"}
@@ -934,6 +935,110 @@ Content-Type: application/json
   ]
 }
 ```
+### Apply Hosts Pool configuration in the pool <a name="hostspool-apply"></a>
+
+Applies a Hosts Pool configuration. The checkpoint query parameter value is provided in the result of a previous call to the [Hosts Pool List API](#hostspool-list).
+
+'Content-Type' header should be set to 'application/json'.
+
+`POST /hosts_pool?checkpoint=<uint64>`
+
+**Request body**:
+
+```json
+{
+    "hosts": [
+        {
+            "Name": "host1",
+            "connection": {
+                "user": "test",
+                "private_key": "/path/to/secrets/id_rsa",
+                "host": "host1.example.com",
+                "port": 22
+            },
+            "labels": {
+                "environment": "dev",
+                "host.cpu_frequency": "3 GHz",
+                "host.disk_size": "150 GB",
+                "host.mem_size": "4GB",
+                "host.num_cpus": "8",
+                "os.architecture": "x86_64",
+                "os.distribution": "ubuntu",
+                "os.type": "linux",
+                "os.version": "17.1"
+            }
+        },
+        {
+            "Name": "host2",
+            "connection": {
+                "user": "test",
+                "private_key": "/path/to/secrets/id_rsa",
+                "host": "host2.example.com"
+            }
+        }
+    ]
+}
+```
+
+**Response**:
+
+```HTTP
+HTTP/1.1 201 Created
+Content-Length: 0
+
+```
+
+To bypass checkpoint verification, the following request can be performed :
+
+'Content-Type' header should be set to 'application/json'.
+
+`PUT /hosts_pool`
+
+**Request body**:
+
+```json
+{
+    "hosts": [
+        {
+            "Name": "host1",
+            "connection": {
+                "user": "test",
+                "private_key": "/path/to/secrets/id_rsa",
+                "host": "host1.example.com",
+                "port": 22
+            },
+            "labels": {
+                "environment": "dev",
+                "host.cpu_frequency": "3 GHz",
+                "host.disk_size": "150 GB",
+                "host.mem_size": "4GB",
+                "host.num_cpus": "8",
+                "os.architecture": "x86_64",
+                "os.distribution": "ubuntu",
+                "os.type": "linux",
+                "os.version": "17.1"
+            }
+        },
+        {
+            "Name": "host2",
+            "connection": {
+                "user": "test",
+                "private_key": "/path/to/secrets/id_rsa",
+                "host": "host2.example.com"
+            }
+        }
+    ]
+}
+```
+
+**Response**:
+
+```HTTP
+HTTP/1.1 200 OK
+Content-Length: 0
+```
+
+Another possible response response code is `400` if the requets body is not correct.
 
 ## Infrastructure Usage
 

--- a/rest/http_api.md
+++ b/rest/http_api.md
@@ -935,7 +935,7 @@ Content-Type: application/json
   ]
 }
 ```
-### Apply Hosts Pool configuration in the pool <a name="hostspool-apply"></a>
+### Apply Hosts Pool configuration <a name="hostspool-apply"></a>
 
 Applies a Hosts Pool configuration. The checkpoint query parameter value is provided in the result of a previous call to the [Hosts Pool List API](#hostspool-list).
 
@@ -988,7 +988,7 @@ Content-Length: 0
 
 ```
 
-To bypass checkpoint verification, the following request can be performed :
+To bypass checkpoint verification, the following request can be executed:
 
 'Content-Type' header should be set to 'application/json'.
 

--- a/rest/structs.go
+++ b/rest/structs.go
@@ -218,9 +218,9 @@ type MapEntry struct {
 
 // HostInPool represents a host in the Hosts Pool
 type HostInPool struct {
-	Name       string               `json:"name"`
-	Connection hostspool.Connection `json:"connection"`
-	Labels     map[string]string    `json:"labels,omitempty"`
+	Name       string
+	Connection hostspool.Connection `json:"connection,omitempty" yaml:"connection,omitempty"`
+	Labels     map[string]string    `json:"labels,omitempty" yaml:"labels,omitempty"`
 }
 
 // HostsPoolRequest represents a request for applying a Hosts Pool definition

--- a/rest/structs.go
+++ b/rest/structs.go
@@ -238,6 +238,7 @@ type HostRequest struct {
 //
 // Links are all of type LinkRelHost.
 type HostsCollection struct {
+	Version  uint64     `json:"warnings,omitempty"`
 	Hosts    []AtomLink `json:"hosts"`
 	Warnings []string   `json:"warnings,omitempty"`
 }

--- a/rest/structs.go
+++ b/rest/structs.go
@@ -238,9 +238,9 @@ type HostRequest struct {
 //
 // Links are all of type LinkRelHost.
 type HostsCollection struct {
-	Version  uint64     `json:"warnings,omitempty"`
-	Hosts    []AtomLink `json:"hosts"`
-	Warnings []string   `json:"warnings,omitempty"`
+	Checkpoint uint64     `json:"checkpoint,omitempty"`
+	Hosts      []AtomLink `json:"hosts"`
+	Warnings   []string   `json:"warnings,omitempty"`
 }
 
 // Host is a host in the host pool representation

--- a/rest/structs.go
+++ b/rest/structs.go
@@ -216,6 +216,18 @@ type MapEntry struct {
 	Value string `json:"value,omitempty"`
 }
 
+// HostInPool represents a host in the Hosts Pool
+type HostInPool struct {
+	Name       string               `json:"name"`
+	Connection hostspool.Connection `json:"connection"`
+	Labels     map[string]string    `json:"labels,omitempty"`
+}
+
+// HostsPoolRequest represents a request for applying a Hosts Pool definition
+type HostsPoolRequest struct {
+	Hosts []HostInPool `json:"hosts"`
+}
+
 // HostRequest represents a request for creating or updating a host in the hosts pool
 type HostRequest struct {
 	Connection *hostspool.Connection `json:"connection,omitempty"`

--- a/rest/structs.go
+++ b/rest/structs.go
@@ -216,16 +216,16 @@ type MapEntry struct {
 	Value string `json:"value,omitempty"`
 }
 
-// HostInPool represents a host in the Hosts Pool
-type HostInPool struct {
+// HostConfig represents the configuration of a host in the Hosts Pool
+type HostConfig struct {
 	Name       string
 	Connection hostspool.Connection `json:"connection,omitempty" yaml:"connection,omitempty"`
 	Labels     map[string]string    `json:"labels,omitempty" yaml:"labels,omitempty"`
 }
 
-// HostsPoolRequest represents a request for applying a Hosts Pool definition
+// HostsPoolRequest represents a request for applying a Hosts Pool configuration
 type HostsPoolRequest struct {
-	Hosts []HostInPool `json:"hosts"`
+	Hosts []HostConfig `json:"hosts"`
 }
 
 // HostRequest represents a request for creating or updating a host in the hosts pool


### PR DESCRIPTION
# Pull Request description

## Description of the change

Added a command to apply a Hosts Pool configuration provided in a YAML or JSON file :
```bash
yorc hostspool apply [--auto-approve] <filename>
```
And a command to export the Hosts Pool configuration as a YAML or JSON representation, to the standard output or a file:
```bash
yorc hostspool export [--output yaml|json] [--file <filename>]
```

The apply command  accepts YAML or JSON files. The following properties are supported :

  * ``hosts``: List of hosts configuration. A host configuration supports the following properties,
     - ``name``: mandatory string identifying the host, no other host entry can have the same name value in the file
     - ``connection``: Connection configuration,
        + ``host``: Hostname or ip address used to connect to the host (defaults to the ``name`` described above)
        + ``user``: name of the user used to connect to the host (default "root")
        + ``password``: either a password or a private key should be provided
        + ``private_key``: Path to a private key file (or private key file content), either a password or a private key should be provided
        + ``port``: Port used to connect to the host (default 22)
     - ``labels``: key/value pairs

Example of a YAML Hosts Pool configuration file :

```YAML

    hosts:
    - name: host1
      connection:
        host: host1.example.com
        user: test
        private_key: /path/to/secrets/id_rsa
        port: 22
      labels:
        environment: dev
        testlabel: hello
        host.cpu_frequency: 3 GHz
        host.disk_size: 50 GB
        host.mem_size: 4GB
        host.num_cpus: "4"
        os.architecture: x86_64
        os.distribution: ubuntu
        os.type: linux
        os.version: "17.1"
    - name: host2
      connection:
        host: host2.example.com
        user: test
        password: test
```

The apply will compare and display the differences between the current Hosts Pool configuration and the configuration specified in the file. A user confirmation will be asked before proceeding, except if --auto-approve option is specified.

### How I did it

In prov/hostspool/hostspool_mgr.go, added a new function Apply(pool []Host, checkpoint *uint64)
This function will compare the current Hosts Pool configuration with the Hosts Pool in argument and apply changes. The checkpoint in argument, if not nil, will be used to verify the changes are applied to the expected Hosts Pool configuration. The checkpoint value for the current Hosts Pool configuration is returned by the function List() implemented in the same file.
Internally, this checkpoint corresponds to a consul ModifyIndex. 
As a consequence the lock key kvLocckKey initially created under the hosts_pool subtree had to be moved outside of this subtree, or the command apply by just locking this lock was changing the ModifyIndex, making the checkpoint in argument invalid.

Factorized the code already existing for CRUD operations on one host, to have common code computing necessary  operations that the new Apply function will apply in a single transaction.

### How to verify it

Preliminary step: environment setup

To test a Hosts Pool in a development environment, you can use a dockerized ssh server.
First as a yorc user, generate private/public keys in a <path to secrets>/ directory, check the private key is read-only for your yorc user,
then run the following commands to have 3 test hosts host1, host2, host3 that can be added to a Hosts Pool :
(--privileged option below is needed because the container has also docker-in-docker capability, although it is not used here)
```bash
docker run --privileged -p 8701:22 \
 -e "AUTH_KEY=$(cat <path to secrets>/id_rsa.pub)" \
 --rm -d --name host1 --hostname host1 laurentg/testhost

docker run --privileged -p 8702:22 \
 -e "AUTH_KEY=$(cat <path to secrets>/id_rsa.pub)" \
 --rm -d --name host2 --hostname host2 laurentg/testhost

docker run --privileged -p 8703:22 \
 -e "AUTH_KEY=$(cat <path to secrets>/id_rsa.pub)" \
 --rm -d --name host3 --hostname host3 laurentg/testhost
```

Verify that as yorc user, you can connect to each host using the private key you generated :
```bash
ssh -i <path to secrets>/id_rsa test@myhost -p 8701
ssh -i <path to secrets>/id_rsa test@myhost -p 8702
ssh -i <path to secrets>/id_rsa test@myhost-p 8703
```

Hosts Pool apply tests

You can get examples of yaml/json files already created and update connection settings to use your host:

Configuration with 1 host : https://github.com/laurentganne/ystia-devenv/blob/master/testlab/pool1host.yaml
Configuration with an additional host and label changes for the existing host : https://github.com/laurentganne/ystia-devenv/blob/master/testlab/pool2hosts.yaml
Same configuration with label diffs, in json : https://github.com/laurentganne/ystia-devenv/blob/master/testlab/pool2hosts.json
Configuration with an additional host : https://github.com/laurentganne/ystia-devenv/blob/master/testlab/pool3hosts.yaml

First apply pool1host.yaml :

```bash
yorc hp apply pool1host.yaml
```

Check you get a confirmation message showing host1 will be added.
Enter y

Check you have 1 host now in the pool, running :

```bash
yorc hp list
```

Then apply pool2host.yaml

```bash
yorc hp apply pool2host.yaml
```

Check the confirmation message shows host2 will be added, and 2 host1 labels will be updated and 1 host1 label will be removed
Enter y

Then apply pool2host.json

```bash
yorc hp apply pool2host.json
```

Check there will be label changes on host1 and host2

Then apply pool3host.yaml but don't answer to the confirmation question.
Just stay in this interactive step.

```bash
yorc hp apply pool3host.yaml
```

Instead of accepting the change, launch another window, and form this new window, launch a command to used the first configuration with 1 host :


```bash
yorc hp apply pool1host.yaml
```

Check you are warned that host2 will be removed. Enter y.

Go back to the first window where you attempted to add a third host to the pool that had 2 hosts at that time.
Enter y
Check you get an error message that detected a Hosts Pool checkpoint issue, as the Hosts Pool configuration has changed since, and the operation is refused.

Try again the command :

```bash
yorc hp apply pool3host.yaml
```

Check the confirmation message correctly states that host2 and host3 will be added.
Enter n (or nothing) to refuse the change.

Stop the host2 running this command :

```bash
docker stop host2
```

Try to add host2 to the pool :

```bash
yorc hp apply pool2host.yaml
```
Enter y

Check you get a message that the apply was done successfully but that a connection failure was detected for host2.

Start again host2 :

```bash
docker run --privileged -p 8702:22 \
 -e "AUTH_KEY=$(cat <path to secrets>/id_rsa.pub)" \
 --rm -d --name host2 --hostname host2 laurentg/testhost
```

Verify that as yorc user, you can connect to host2: 
```bash
ssh -i <path to secrets>/id_rsa test@myhost -p 8702
```

Apply the json hosts pool configuration that just updated labels :

```bash
yorc hp apply pool2hosts.json
```

Run yorc hp list and check host2 is back online with no connection error

Export checks :

Run this command to see the Hosts Pool configuration exported in YAML representation :

```bash
yorc hp export
```

Run this command to have a json output :

```bash
yorc hp export -o json
```

Run this command to save the Hosts Pool configuration in a yaml file :

```bash
yorc hp export -f tmp.yaml
```
