### PR TITLE
Ansible doesn't handle SSH connection with port different than 22

### DIFF
--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -344,7 +344,7 @@ func (e *executionCommon) setHostConnection(kv *api.KV, host, instanceID, capTyp
 		if found && port != "" {
 			conn.port, err = strconv.Atoi(port)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "[Warning] failed to convert port value:%q to int", port)
 			}
 		}
 	}

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -344,7 +344,7 @@ func (e *executionCommon) setHostConnection(kv *api.KV, host, instanceID, capTyp
 		if found && port != "" {
 			conn.port, err = strconv.Atoi(port)
 			if err != nil {
-				return errors.Wrapf(err, "[Warning] failed to convert port value:%q to int", port)
+				return errors.Wrapf(err,"Failed to convert port value:%q to int", port)
 			}
 		}
 	}

--- a/prov/ansible/execution_test.go
+++ b/prov/ansible/execution_test.go
@@ -237,7 +237,7 @@ func compareStringsIgnoreWhitespace(t *testing.T, expected, actual string) {
 func testExecutionGenerateOnNode(t *testing.T, kv *api.KV, deploymentID, nodeName, operation string) {
 	op, err := operations.GetOperation(kv, deploymentID, nodeName, operation, "", "")
 	require.Nil(t, err)
-	execution, err := newExecution(kv, GetConfig(), "taskIDNotUsedForNow", deploymentID, nodeName, op)
+	execution, err := newExecution(context.Background(), kv, GetConfig(), "taskIDNotUsedForNow", deploymentID, nodeName, op)
 	require.Nil(t, err)
 
 	// This is bad.... Hopefully it will be temporary
@@ -379,7 +379,7 @@ func testExecutionResolveInputsOnRelationshipSource(t *testing.T, kv *api.KV, de
 func testExecutionGenerateOnRelationshipSource(t *testing.T, kv *api.KV, deploymentID, nodeName, operation, requirementName, operationHost string) {
 	op, err := operations.GetOperation(kv, deploymentID, nodeName, operation, requirementName, operationHost)
 	require.Nil(t, err)
-	execution, err := newExecution(kv, GetConfig(), "taskIDNotUsedForNow", deploymentID, nodeName, op)
+	execution, err := newExecution(context.Background(), kv, GetConfig(), "taskIDNotUsedForNow", deploymentID, nodeName, op)
 	require.Nil(t, err)
 
 	// This is bad.... Hopefully it will be temporary
@@ -509,7 +509,7 @@ func testExecutionResolveInputOnRelationshipTarget(t *testing.T, kv *api.KV, dep
 func testExecutionGenerateOnRelationshipTarget(t *testing.T, kv *api.KV, deploymentID, nodeName, operation, requirementName, operationHost string) {
 	op, err := operations.GetOperation(kv, deploymentID, nodeName, operation, requirementName, operationHost)
 	require.Nil(t, err)
-	execution, err := newExecution(kv, GetConfig(), "taskIDNotUsedForNow", deploymentID, nodeName, op)
+	execution, err := newExecution(context.Background(), kv, GetConfig(), "taskIDNotUsedForNow", deploymentID, nodeName, op)
 	require.Nil(t, err)
 	// This is bad.... Hopefully it will be temporary
 	execution.(*executionScript).OperationRemoteBaseDir = "tmp"

--- a/prov/ansible/executor.go
+++ b/prov/ansible/executor.go
@@ -53,7 +53,7 @@ func (e *defaultExecutor) ExecOperation(ctx context.Context, conf config.Configu
 	logOptFields[events.InterfaceName] = stringutil.GetAllExceptLastElement(operation.Name, ".")
 	ctx = events.NewContext(ctx, logOptFields)
 
-	exec, err := newExecution(kv, conf, taskID, deploymentID, nodeName, operation)
+	exec, err := newExecution(ctx, kv, conf, taskID, deploymentID, nodeName, operation)
 	if err != nil {
 		if IsOperationNotImplemented(err) {
 			log.Debugf("Voluntary bypassing error: %s.", err.Error())

--- a/prov/hostspool/executor.go
+++ b/prov/hostspool/executor.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ystia/yorc/events"
 	"github.com/ystia/yorc/tasks"
 	"github.com/ystia/yorc/tosca"
+	"strconv"
 )
 
 type defaultExecutor struct{}
@@ -168,6 +169,12 @@ func (e *defaultExecutor) hostsPoolCreate(originalCtx context.Context, cc *api.C
 
 		if publicAddress, ok := host.Labels["public_address"]; ok {
 			err = deployments.SetInstanceAttribute(deploymentID, nodeName, instance, "public_address", publicAddress)
+			if err != nil {
+				return err
+			}
+		}
+		if host.Connection.Port != 0 {
+			err = deployments.SetInstanceCapabilityAttribute(deploymentID, nodeName, instance, "endpoint", "port", strconv.FormatUint(host.Connection.Port, 10))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description of the change
Set capability endpoint attribute port for host pool
Handle port different than 22 for Ansible for playbook execution

### How to verify it
Create a host pool specifying a port different than 22
Use a dockerized ssh server as laurentg/testhost image
docker run --privileged -p 8701:22 \
 -e "AUTH_KEY=$(cat <path to secrets>/id_rsa.pub)" \
 --rm -d --name host1 --hostname host1 laurentg/testhost

Deploy a topology with A4C with a simple component on this host pool and check Ansible use the defined port to SSH the host for installation

