### PR TITLE
Bugfix/brbdcf 1172 cannot get lock hosts pool deployment

### DIFF
--- a/prov/hostspool/consul_test.go
+++ b/prov/hostspool/consul_test.go
@@ -68,4 +68,7 @@ func TestRunConsulHostsPoolPackageTests(t *testing.T) {
 	t.Run("testConsulManagerApplyBadConnection", func(t *testing.T) {
 		testConsulManagerApplyBadConnection(t, client)
 	})
+	t.Run("testConsulManagerAllocateConcurrency", func(t *testing.T) {
+		testConsulManagerAllocateConcurrency(t, client)
+	})
 }

--- a/prov/hostspool/hostspool_mgr.go
+++ b/prov/hostspool/hostspool_mgr.go
@@ -37,7 +37,8 @@ import (
 const (
 	// CheckpointError is an error of checkpoint between the current Hosts Pool
 	// and an apply change request
-	CheckpointError = "Checkpoint for Hosts Pool error"
+	CheckpointError    = "Checkpoint for Hosts Pool error"
+	maxWaitTimeSeconds = 45
 )
 
 // A Manager is in charge of creating/updating/deleting hosts from the pool
@@ -88,7 +89,7 @@ type consulManager struct {
 }
 
 func (cm *consulManager) Add(hostname string, conn Connection, labels map[string]string) error {
-	return cm.addWait(hostname, conn, labels, 45*time.Second)
+	return cm.addWait(hostname, conn, labels, maxWaitTimeSeconds*time.Second)
 }
 func (cm *consulManager) addWait(hostname string, conn Connection, labels map[string]string, maxWaitTime time.Duration) error {
 
@@ -216,7 +217,7 @@ func getAddOperations(
 }
 
 func (cm *consulManager) UpdateConnection(hostname string, conn Connection) error {
-	return cm.updateConnWait(hostname, conn, 45*time.Second)
+	return cm.updateConnWait(hostname, conn, maxWaitTimeSeconds*time.Second)
 }
 func (cm *consulManager) updateConnWait(hostname string, conn Connection, maxWaitTime time.Duration) error {
 	if hostname == "" {
@@ -321,7 +322,7 @@ func (cm *consulManager) updateConnWait(hostname string, conn Connection, maxWai
 }
 
 func (cm *consulManager) Remove(hostname string) error {
-	return cm.removeWait(hostname, 45*time.Second)
+	return cm.removeWait(hostname, maxWaitTimeSeconds*time.Second)
 }
 func (cm *consulManager) removeWait(hostname string, maxWaitTime time.Duration) error {
 
@@ -389,7 +390,7 @@ func (cm *consulManager) getRemoveOperations(hostname string, checkStatus bool) 
 }
 
 func (cm *consulManager) AddLabels(hostname string, labels map[string]string) error {
-	return cm.addLabelsWait(hostname, labels, 45*time.Second)
+	return cm.addLabelsWait(hostname, labels, maxWaitTimeSeconds*time.Second)
 }
 func (cm *consulManager) addLabelsWait(hostname string, labels map[string]string, maxWaitTime time.Duration) error {
 	if hostname == "" {
@@ -445,7 +446,7 @@ func (cm *consulManager) addLabelsWait(hostname string, labels map[string]string
 }
 
 func (cm *consulManager) RemoveLabels(hostname string, labels []string) error {
-	return cm.removeLabelsWait(hostname, labels, 45*time.Second)
+	return cm.removeLabelsWait(hostname, labels, maxWaitTimeSeconds*time.Second)
 }
 func (cm *consulManager) removeLabelsWait(hostname string, labels []string, maxWaitTime time.Duration) error {
 	if hostname == "" {
@@ -511,9 +512,11 @@ func (cm *consulManager) lockKey(hostname, opType string, lockWaitTime time.Dura
 		Value:          []byte(fmt.Sprintf("locked for %s", sessionName)),
 		MonitorRetries: 2,
 		LockWaitTime:   lockWaitTime,
-		LockTryOnce:    true,
-		SessionName:    sessionName,
-		SessionTTL:     lockWaitTime.String(),
+		// Not setting LockTryOnce to true to workaround this Consul issue:
+		// https://github.com/hashicorp/consul/issues/4003
+		LockTryOnce: false,
+		SessionName: sessionName,
+		SessionTTL:  lockWaitTime.String(),
 		SessionOpts: &api.SessionEntry{
 			Behavior: api.SessionBehaviorDelete,
 		},
@@ -523,19 +526,33 @@ func (cm *consulManager) lockKey(hostname, opType string, lockWaitTime time.Dura
 		return
 	}
 
-	lockCh, err = lock.Lock(nil)
+	// To workaround Consul issue https://github.com/hashicorp/consul/issues/4003
+	// LockTryOnce was set to false.
+	// Now to avoid being blocked forever attempting to get the lock, arming a
+	// timer and closing a stopChannel if this timer expires to go out of the
+	// call to lock.Lock(stopChannel) below
+	stopChannel := make(chan struct{})
+	timerWaitLock := time.NewTimer(lockWaitTime)
+	go func() {
+		<-timerWaitLock.C
+		// Timer expired, closing stop channel to stop the blocking lovk below
+		close(stopChannel)
+	}()
+	lockCh, err = lock.Lock(stopChannel)
+	timerWaitLock.Stop()
+
 	if err != nil {
-		err = errors.Wrapf(err, "failed to acquire admin lock on hosts pool for host %q deletion", hostname)
+		err = errors.Wrapf(err, "failed to acquire admin lock on hosts pool for %s", sessionName)
 		return
 	}
 	if lockCh == nil {
-		err = errors.Errorf("failed to acquire admin lock on hosts pool for host %q deletion", hostname)
+		err = errors.Errorf("failed to acquire admin lock on Hosts Pool for %s", sessionName)
 		return
 	}
 
 	select {
 	case <-lockCh:
-		err = errors.Errorf("admin lock lost on hosts pool for host %q deletion", hostname)
+		err = errors.Errorf("admin lock lost on hosts pool for %s", sessionName)
 		return
 	default:
 	}
@@ -821,7 +838,7 @@ func (cm *consulManager) GetHost(hostname string) (Host, error) {
 }
 
 func (cm *consulManager) Allocate(message string, filters ...labelsutil.Filter) (string, []labelsutil.Warning, error) {
-	return cm.allocateWait(45*time.Second, message, filters...)
+	return cm.allocateWait(maxWaitTimeSeconds*time.Second, message, filters...)
 }
 func (cm *consulManager) allocateWait(maxWaitTime time.Duration, message string, filters ...labelsutil.Filter) (string, []labelsutil.Warning, error) {
 	lockCh, cleanupFn, err := cm.lockKey("", "allocation", maxWaitTime)
@@ -872,7 +889,7 @@ func (cm *consulManager) allocateWait(maxWaitTime time.Duration, message string,
 	return hostname, warnings, cm.setHostStatusWithMessage(hostname, HostStatusAllocated, message)
 }
 func (cm *consulManager) Release(hostname string) error {
-	return cm.releaseWait(hostname, 45*time.Second)
+	return cm.releaseWait(hostname, maxWaitTimeSeconds*time.Second)
 }
 func (cm *consulManager) releaseWait(hostname string, maxWaitTime time.Duration) error {
 	_, cleanupFn, err := cm.lockKey(hostname, "release", maxWaitTime)
@@ -955,7 +972,7 @@ func getSSHConfig(conn Connection) (*ssh.ClientConfig, error) {
 // If checkpoint is nil, the Hosts Pool configuration will be applied without
 // checkpoint verification.
 func (cm *consulManager) Apply(pool []Host, checkpoint *uint64) error {
-	return cm.applyWait(pool, checkpoint, 45*time.Second)
+	return cm.applyWait(pool, checkpoint, maxWaitTimeSeconds*time.Second)
 }
 
 func (cm *consulManager) applyWait(
@@ -1100,18 +1117,29 @@ func (cm *consulManager) applyWait(
 	default:
 	}
 
-	ok, response, _, err := cm.cc.KV().Txn(ops, nil)
-	if err != nil {
-		return errors.Wrap(err, "Failed to apply new Hosts Pool configuration")
-	}
-
-	if !ok {
-		// Check the response
-		var errs []string
-		for _, e := range response.Errors {
-			errs = append(errs, e.What)
+	// Need to split the transaction if there are more than 64 operations
+	// (hardcoded max value within Consul)
+	maxNbOps := 64
+	opsLength := len(ops)
+	for begin := 0; begin < opsLength; begin += maxNbOps {
+		end := begin + maxNbOps
+		if end > opsLength {
+			end = opsLength
 		}
-		err = errors.Errorf("Failed to apply new Hosts Pool configuration: %s", strings.Join(errs, ", "))
+
+		ok, response, _, err := cm.cc.KV().Txn(ops[begin:end], nil)
+		if err != nil {
+			return errors.Wrap(err, "Failed to apply new Hosts Pool configuration")
+		}
+
+		if !ok {
+			// Check the response
+			var errs []string
+			for _, e := range response.Errors {
+				errs = append(errs, e.What)
+			}
+			err = errors.Errorf("Failed to apply new Hosts Pool configuration: %s", strings.Join(errs, ", "))
+		}
 	}
 
 	// Update the connection status for each updated/created host


### PR DESCRIPTION
# Pull Request description

## Description of the change

Implemented a workaround for a Consul issue regarding the time to wait for a lock, issue https://github.com/hashicorp/consul/issues/4003
Added a unit test where 50 threads attempt to allocate one host in a Pool of 50 free hosts (test failing on error getting the lock before the workaround).
Increased the max timeout used in Yorc to manage more than 150 simultaneous requests.
For now the lock timeout is not accessible for change to the user, it may be needed depending on the size of deployments we expect to support with Hosts Pools.

Misc change: while doing a test with big hosts pool, noticed a limitation in Consul regarding the number of operations that can be performed in a transaction (64).
Had to split the apply transaction if it contains more operations than this limit in Consul implementation.

### What I did

The issue https://github.com/hashicorp/consul/issues/4003 created on Consul is that when a lock is taken with the property `LockTryOnce=true`, a call to `lock.Lock()` will attempt to get the lock for an expected duration of `LockWaitTime` before returning without having succeeded.
Actually with a `LockWaitTime` of 45 seconds, the unit test with 50 threads failed in around 5 seconds.

Modified our code to not use `LockTryOnce=true`, and instead as a workaround, arm a timer for a `LockWaitTime` duration, to  close a channel `stopChannel` after this duration.
This channel `stopChannel` is passed in argument to `lock.Lock()` that is blocking until it will detect that `stopChannel` has been closed.

### How to verify it

Initially a deployment of elk-basic with a pool of 4 hosts was reported to fail. Trying again a 4 hosts deployment in development environment.
As a yorc user, generate private/public keys in a directory, check the private key is read-only for your yorc user, add the public key content to a file authorized_keys,
Create a devenv.sh file containing your proxy settings:
```bash
HTTP_PROXY=http://1.2.3.4:8080
HTTPS_PROXY=http://1.2.3.4:8080
```
Then create 4 ssh servers :
```bash
docker run -p 8701:22 \
 -e "AUTH_KEY=$(cat $HOME/yorc/testhost_secrets/authorized_keys)" \
 --env-file devenv.sh \
 --rm -d --name host1 --hostname host1 laurentg/ystiahost

docker run -p 8702:22 \
 -e "AUTH_KEY=$(cat $HOME/yorc/testhost_secrets/authorized_keys)" \
 --env-file devenv.sh \
 --rm -d --name host2 --hostname host2 laurentg/ystiahost

docker run -p 8703:22 \
 -e "AUTH_KEY=$(cat $HOME/yorc/testhost_secrets/authorized_keys)" \
 --env-file devenv.sh \
 --rm -d --name host3 --hostname host3 laurentg/ystiahost
 
docker run -p 8704:22 \
 -e "AUTH_KEY=$(cat $HOME/yorc/testhost_secrets/authorized_keys)" \
 --env-file devenv.sh \
 --rm -d --name host4 --hostname host4 laurentg/ystiahost
```
Verify that as yorc user, you can connect to each host using the private key you generated :
```bash
ssh -i <path to secrets>/id_rsa test@myhost -p 8701
ssh -i <path to secrets>/id_rsa test@myhost -p 8702
ssh -i <path to secrets>/id_rsa test@myhost-p 8703
ssh -i <path to secrets>/id_rsa test@myhost-p 8703
```
Create a Hosts Pool made of these 4 hosts, using a yaml file like https://github.com/laurentganne/ystia-devenv/blob/master/testlab/pool4hosts.yaml
and running :
```bash
yorc hp apply pool4hosts.yaml
```

On a setup where the Yorc plugin was added to Alien4Cloud, Yorc was configured as an orchestrator, and a Hosts Pool location was configured.
From Alien4Cloud, Menu `Administration` > `Orchestrators`, select `Yorc`.
Then in the left-hand-side menu, select `Location`, `On demand resources`, and add the following resource : `yorc.nodes.hostspool.Compute`. No need to set credentials or any other property.

From Alien4Cloud, Menu `Catalog` > `Manage Archives` > `Git import`
add the following Git location:
  * Repository URL: https://github.com/alien4cloud/csar-public-library.git
  * Branch:  develop
  * Archive Folder:  org/ystia

From the Menu `Applications`
Create a new Application, Initializing the topology from Topology Template `welcome_basic`.
Select the `Environment`, `Topology`, Click on `Edit` to edit the topology.
Remove the Component `Network`.
Then add 3 new Components of type `Compute`.
And within each of these 3 new `Compute` components add a component `Welcome`.

So finally we have 4 compute nodes, with an application Welcome deployed on each.
Click on `Save` to save changes.
Then go back to `Environment`. At the `Location` step, select the Hosts Pool.
Then deploy the application.

When the deployement has started on Yorc, run this command to check the 4 hosts in the pool were allocated for this application :
```bash
yorc hp list
```
Wait until the deployment ends successfuly. Then undeploy the application, wait until it is undeployed successfuly.
Run again the command `yorc hp list` to check the 4 hosts are now free in the Hosts Pool.
