### PR TITLE
Bugfix/brbdcf 1092 hostspool update default values

### DIFF
--- a/commands/hostspool/hosts_pool_update.go
+++ b/commands/hostspool/hosts_pool_update.go
@@ -95,9 +95,9 @@ func init() {
 		},
 	}
 	updCmd.Flags().StringVarP(&jsonParam, "data", "d", "", "Need to provide the JSON format of the updated host pool")
-	updCmd.Flags().StringVarP(&user, "user", "", "root", "User used to connect to the host")
+	updCmd.Flags().StringVarP(&user, "user", "", "", "User used to connect to the host")
 	updCmd.Flags().StringVarP(&host, "host", "", "", "Hostname or ip address used to connect to the host. (defaults to the hostname in the hosts pool)")
-	updCmd.Flags().Uint64VarP(&port, "port", "", 22, "Port used to connect to the host.")
+	updCmd.Flags().Uint64VarP(&port, "port", "", 0, "Port used to connect to the host.")
 	updCmd.Flags().StringVarP(&privateKey, "key", "k", "", `At any time a host of the pool should have at least one of private key or password. To delete a registered password use the "-" character.`)
 	updCmd.Flags().StringVarP(&password, "password", "p", "", `At any time a host of the pool should have at least one of private key or password. To delete a registered private key use the "-" character.`)
 	updCmd.Flags().StringSliceVarP(&labelsAdd, "add-label", "", nil, "Add a label in form 'key=value' to the host. May be specified several time.")

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -344,7 +344,7 @@ func (e *executionCommon) setHostConnection(kv *api.KV, host, instanceID, capTyp
 		if found && port != "" {
 			conn.port, err = strconv.Atoi(port)
 			if err != nil {
-				return errors.Wrapf(err,"Failed to convert port value:%q to int", port)
+				return errors.Wrapf(err, "Failed to convert port value:%q to int", port)
 			}
 		}
 	}


### PR DESCRIPTION
# Pull Request description

## Description of the change

In `yorc hostspool update`, changed default values for user and port, used when no `--user` or `--port` options were specified. In this case, the HostsPoolMgr implementing the required updates expects to receive an empty string when there is no change to the user name, and the value 0 when there is no change to the port.

### How to verify it

Create a Hosts Pool, using a yaml file like https://github.com/laurentganne/ystia-devenv/blob/master/testlab/pool1host.yaml where one host at least has a connection using a non-root user and a non-default port for its ssh connection, running :
```bash
yorc hp apply pool1hosts.yaml
```
Run `yorc hp list` and verify this host shows a connection with a non-root user and non-default port.

Run this command to add a label to this host:
```bash
yorc hp update host1 --add-label newlabel=value
```
Check no connection error was reported by this command.
Run again `yorc hp list` and verify the host connection didn't change, it should still be using a non-root user and non-default port.
Check the new label was also added.

