### PR TITLE
Changed DeploymentsCollection to get Deployments ID and status in one…

### DIFF
--- a/commands/deployments/dep_list.go
+++ b/commands/deployments/dep_list.go
@@ -65,16 +65,8 @@ var listCmd = &cobra.Command{
 
 		depsTable := tabutil.NewTable()
 		depsTable.AddHeaders("Id", "Status")
-		for _, depLink := range deps.Deployments {
-			if depLink.Rel == rest.LinkRelDeployment {
-				var dep rest.Deployment
-
-				err = httputil.GetJSONEntityFromAtomGetRequest(client, depLink, &dep)
-				if err != nil {
-					httputil.ErrExit(err)
-				}
-				depsTable.AddRow(dep.ID, getColoredDeploymentStatus(colorize, dep.Status))
-			}
+		for _, dep := range deps.Deployments {
+			depsTable.AddRow(dep.ID, getColoredDeploymentStatus(colorize, dep.Status))
 		}
 		if colorize {
 			defer color.Unset()

--- a/rest/http_api.md
+++ b/rest/http_api.md
@@ -59,7 +59,17 @@ Content-Type: application/json
 ```json
 {
   "deployments": [
-    {"rel":"deployment","href":"/deployments/55d54226-5ce5-4278-96e4-97dd4cbb4e62","type":"application/json"}
+    {
+      "id": "deployment1",
+      "status": "DEPLOYED",
+      "links": [
+        {
+          "rel": "deployment",
+          "href": "/deployments/deployment1",
+          "type": "application/json"
+        }
+      ]
+    }
   ]
 }
 ```

--- a/rest/structs.go
+++ b/rest/structs.go
@@ -88,11 +88,11 @@ type Output struct {
 	Value string `json:"value"`
 }
 
-// DeploymentsCollection is a collection of deployments links
+// DeploymentsCollection is a collection of Deployment
 //
 // Links are all of type LinkRelDeployment.
 type DeploymentsCollection struct {
-	Deployments []AtomLink `json:"deployments"`
+	Deployments []Deployment `json:"deployments"`
 }
 
 // EventsCollection is a collection of instances status change events


### PR DESCRIPTION
# Pull Request description

Fixed a latency issue in command `yorc deployments list` on a setup with many deployments (more than 500).
For example, using yorc in a docker container, the command `time yorc deployments list` in a setup with 560 deployments returned it took 3 minutes 30 seconds to complete.
With the fix, it takes around 1 second.

## Description of the change

The CLI was doing one HTTP GET request to retrieve a collection of links (struct `DeploymentsCollection`), one link for each deployment, then the CLI was doing one HTTP GET request for each link to get the deployment status.
	
Changed the struct `DeploymentsCollection` to be a collection of `Deployment`, that will provide the deployment ID, the deployment status, and also a link to the deployment resource as before.
So the CLI is now doing just one HTTP GET request.

### How to verify it

On a setup where you have already deployed one application, for example the sample at https://github.com/ystia/yorc-a4c-plugin/tree/develop/tosca-samples/org/ystia/yorc/samples/python, 
retrieve the corresponding archive that should be avaible in Yorc, for example in a Yorc container, it will be available at /var/yorc/work/deployments/application_name/deployment.zip 
Then get this script that will loop on deploying/undeploying the application : https://github.com/laurentganne/ystia-devenv/blob/master/scripts/deployloop.bash

And run this command to have 500 deployments (it will take time) :
```bash
bash deployloop.bash 500 testapp deployment.zip
```

Then run `yorc deployments list` to get the list of deployments and their status, and check you can get the status of all deployments in a matter of seconds.
