### PR TITLE
Remove not necessary job_name parameter and potentially not correctly…

### DIFF
--- a/helper/sshutil/sshutil.go
+++ b/helper/sshutil/sshutil.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/context"
 	"io"
+	"strings"
 )
 
 // Client is interface allowing running command
@@ -84,7 +85,7 @@ func (client *SSHClient) RunCommand(cmd string) (string, error) {
 
 	log.Debugf("[SSHSession] %q", cmd)
 	err = session.Run(cmd)
-	return b.String(), err
+	return strings.Trim(b.String(), "\x00"), err
 }
 
 func (client *SSHClient) newSession() (*ssh.Session, error) {

--- a/prov/slurm/helper.go
+++ b/prov/slurm/helper.go
@@ -130,8 +130,8 @@ func getAttributes(client sshutil.Client, key string, params ...string) ([]strin
 			if len(split) != 2 {
 				return nil, errors.Errorf("Slurm returned an unexpected stdout: %q with command:%q", out, cmd)
 			}
-			node := strings.Trim(split[0], "\" \t\n")
-			part := strings.Trim(split[1], "\" \t\n")
+			node := strings.Trim(split[0], "\" \t\n\x00")
+			part := strings.Trim(split[1], "\" \t\n\x00")
 			return []string{node, part}, nil
 		}
 	default:


### PR DESCRIPTION
## Description of the change

- Remove job_name parameter in slurm squeue command because job_id is sufficient for slurm to identify an unique job and job_name can contains unescaped characters for slurm CLI
- Refactor some code
- Add Tests

### How to verify it

Deploy a Compute node on Slurm location


