### PR TITLE
Implement support of slurm constraint for allocations

### DIFF
--- a/data/tosca/yorc-slurm-types.yml
+++ b/data/tosca/yorc-slurm-types.yml
@@ -17,6 +17,9 @@ node_types:
       constraint:
         type: string
         required: false
+      cuda_visible_devices:
+        type: string
+        description: Coma separated list of visibles GPU devices for the compute.
       partition:
         type: string
         required: false

--- a/data/tosca/yorc-slurm-types.yml
+++ b/data/tosca/yorc-slurm-types.yml
@@ -14,6 +14,9 @@ node_types:
       gres:
         type: string
         required: false
+      constraint:
+        type: string
+        required: false
       partition:
         type: string
         required: false

--- a/data/tosca/yorc-slurm-types.yml
+++ b/data/tosca/yorc-slurm-types.yml
@@ -17,9 +17,6 @@ node_types:
       constraint:
         type: string
         required: false
-      cuda_visible_devices:
-        type: string
-        description: Coma separated list of visibles GPU devices for the compute.
       partition:
         type: string
         required: false

--- a/helper/sshutil/sshutil.go
+++ b/helper/sshutil/sshutil.go
@@ -87,8 +87,10 @@ func (client *SSHClient) RunCommand(cmd string) (string, error) {
 	session.Stderr = &b
 	session.Stdout = &b
 
-	log.Debugf("[SSHSession] %q", cmd)
+	log.Debugf("[SSHSession] cmd:%q", cmd)
 	err = session.Run(cmd)
+
+	log.Debugf("[SSHSession] stdout/stderr:%q", b.String())
 	return strings.Trim(b.String(), "\x00"), err
 }
 

--- a/prov/slurm/executor.go
+++ b/prov/slurm/executor.go
@@ -277,15 +277,17 @@ func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, 
 	}
 
 	// Get cuda_visible_device attribute
-	var cudaVisibleDeviceAttrs []string
-	if cudaVisibleDeviceAttrs, err = getAttributes(e.client, "cuda_visible_devices", allocResponse.jobID, nodeName); err != nil {
-		// cuda_visible_device attribute is not mandatory : just log the error
+	var cudaVisibleDevice string
+	if cudaVisibleDeviceAttrs, err := getAttributes(e.client, "cuda_visible_devices", allocResponse.jobID, nodeName); err != nil {
+		// cuda_visible_device attribute is not mandatory : just log the error and set the attribute to an empty string
 		log.Println("[Warning]: " + err.Error())
 	} else {
-		err = deployments.SetInstanceAttribute(deploymentID, nodeName, nodeAlloc.instanceName, "cuda_visible_devices", cudaVisibleDeviceAttrs[0])
-		if err != nil {
-			return errors.Wrapf(err, "Failed to set attribute (cuda_visible_devices) for node name:%q, instance name:%q", nodeName, nodeAlloc.instanceName)
-		}
+		cudaVisibleDevice = cudaVisibleDeviceAttrs[0]
+	}
+
+	err = deployments.SetInstanceAttribute(deploymentID, nodeName, nodeAlloc.instanceName, "cuda_visible_devices", cudaVisibleDevice)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to set attribute (cuda_visible_devices) for node name:%q, instance name:%q", nodeName, nodeAlloc.instanceName)
 	}
 
 	// Update the instance state

--- a/prov/slurm/executor.go
+++ b/prov/slurm/executor.go
@@ -187,7 +187,7 @@ func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, 
 		sallocGresFlag = fmt.Sprintf(" --gres=%s", nodeAlloc.gres)
 	}
 	if nodeAlloc.constraint != "" {
-		sallocConstraintFlag = fmt.Sprintf(" --constraint==%q", nodeAlloc.constraint)
+		sallocConstraintFlag = fmt.Sprintf(" --constraint=%q", nodeAlloc.constraint)
 	}
 
 	// salloc command can potentially be a long synchronous command according to the slurm cluster state

--- a/prov/slurm/executor.go
+++ b/prov/slurm/executor.go
@@ -173,7 +173,7 @@ func (e *defaultExecutor) destroyInfrastructure(ctx context.Context, kv *api.KV,
 func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, nodeAlloc *nodeAllocation, deploymentID, nodeName string) error {
 	events.WithContextOptionalFields(ctx).NewLogEntry(events.INFO, deploymentID).RegisterAsString(fmt.Sprintf("Creating node allocation for: deploymentID:%q, node name:%q", deploymentID, nodeName))
 	// salloc cmd
-	var sallocCPUFlag, sallocMemFlag, sallocPartitionFlag, sallocGresFlag string
+	var sallocCPUFlag, sallocMemFlag, sallocPartitionFlag, sallocGresFlag, sallocConstraintFlag string
 	if nodeAlloc.cpu != "" {
 		sallocCPUFlag = fmt.Sprintf(" -c %s", nodeAlloc.cpu)
 	}
@@ -185,6 +185,9 @@ func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, 
 	}
 	if nodeAlloc.gres != "" {
 		sallocGresFlag = fmt.Sprintf(" --gres=%s", nodeAlloc.gres)
+	}
+	if nodeAlloc.constraint != "" {
+		sallocConstraintFlag = fmt.Sprintf(" --constraint==%q", nodeAlloc.constraint)
 	}
 
 	// salloc command can potentially be a long synchronous command according to the slurm cluster state
@@ -249,7 +252,7 @@ func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, 
 	}()
 
 	// Run the salloc command
-	sallocCmd := strings.TrimSpace(fmt.Sprintf("salloc --no-shell -J %s%s%s%s%s", nodeAlloc.jobName, sallocCPUFlag, sallocMemFlag, sallocPartitionFlag, sallocGresFlag))
+	sallocCmd := strings.TrimSpace(fmt.Sprintf("salloc --no-shell -J %s%s%s%s%s%s", nodeAlloc.jobName, sallocCPUFlag, sallocMemFlag, sallocPartitionFlag, sallocGresFlag, sallocConstraintFlag))
 	err = sessionWrapper.RunCommand(ctxAlloc, sallocCmd)
 	if err != nil {
 		return errors.Wrap(err, "Failed to allocate Slurm resource")

--- a/prov/slurm/executor.go
+++ b/prov/slurm/executor.go
@@ -102,10 +102,7 @@ func (e *defaultExecutor) installNode(ctx context.Context, kv *api.KV, cfg confi
 	if err != nil {
 		return err
 	}
-	if err = e.createInfrastructure(ctx, kv, cfg, deploymentID, nodeName, infra); err != nil {
-		return err
-	}
-	return nil
+	return e.createInfrastructure(ctx, kv, cfg, deploymentID, nodeName, infra)
 }
 
 func (e *defaultExecutor) uninstallNode(ctx context.Context, kv *api.KV, cfg config.Configuration, deploymentID, nodeName string, instances []string, logOptFields events.LogOptionalFields, operation string) error {
@@ -120,10 +117,7 @@ func (e *defaultExecutor) uninstallNode(ctx context.Context, kv *api.KV, cfg con
 		return err
 	}
 
-	if err = e.destroyInfrastructure(ctx, kv, cfg, deploymentID, nodeName, infra); err != nil {
-		return err
-	}
-	return nil
+	return e.destroyInfrastructure(ctx, kv, cfg, deploymentID, nodeName, infra)
 }
 
 func (e *defaultExecutor) createInfrastructure(ctx context.Context, kv *api.KV, cfg config.Configuration, deploymentID, nodeName string, infra *infrastructure) error {

--- a/prov/slurm/slurm_node.go
+++ b/prov/slurm/slurm_node.go
@@ -16,12 +16,13 @@ package slurm
 
 import (
 	"context"
+	"regexp"
+	"strings"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/pkg/errors"
 	"github.com/ystia/yorc/config"
 	"github.com/ystia/yorc/deployments"
-	"regexp"
-	"strings"
 )
 
 func (g *slurmGenerator) generateNodeAllocation(ctx context.Context, kv *api.KV, cfg config.Configuration, deploymentID string, nodeName, instanceName string, infra *infrastructure) error {
@@ -73,6 +74,13 @@ func (g *slurmGenerator) generateNodeAllocation(ctx context.Context, kv *api.KV,
 		return err
 	}
 	node.gres = gres
+
+	// Set the node constraint property from Tosca slurm.Compute property
+	_, constraint, err := deployments.GetNodeProperty(kv, deploymentID, nodeName, "constraint")
+	if err != nil {
+		return err
+	}
+	node.constraint = constraint
 
 	// Set the node partition property from Tosca slurm.Compute property
 	_, partition, err := deployments.GetNodeProperty(kv, deploymentID, nodeName, "partition")

--- a/prov/slurm/slurm_node_test.go
+++ b/prov/slurm/slurm_node_test.go
@@ -16,13 +16,14 @@ package slurm
 
 import (
 	"context"
+	"path"
+	"strconv"
+	"testing"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	"github.com/ystia/yorc/config"
 	"github.com/ystia/yorc/deployments"
-	"path"
-	"strconv"
-	"testing"
 )
 
 func loadTestYaml(t *testing.T, kv *api.KV) string {
@@ -45,6 +46,7 @@ func testSimpleSlurmNodeAllocation(t *testing.T, kv *api.KV, cfg config.Configur
 	require.Len(t, infrastructure.nodes, 1)
 	require.Equal(t, "0", infrastructure.nodes[0].instanceName)
 	require.Equal(t, "gpu:1", infrastructure.nodes[0].gres)
+	require.Equal(t, "[rack1|rack2|rack3|rack4]", infrastructure.nodes[0].constraint)
 	require.Equal(t, "debug", infrastructure.nodes[0].partition)
 	require.Equal(t, "2G", infrastructure.nodes[0].memory)
 	require.Equal(t, "4", infrastructure.nodes[0].cpu)
@@ -63,6 +65,7 @@ func testSimpleSlurmNodeAllocationWithoutProps(t *testing.T, kv *api.KV, cfg con
 	require.Len(t, infrastructure.nodes, 1)
 	require.Equal(t, "0", infrastructure.nodes[0].instanceName)
 	require.Equal(t, "", infrastructure.nodes[0].gres)
+	require.Equal(t, "", infrastructure.nodes[0].constraint)
 	require.Equal(t, "", infrastructure.nodes[0].partition)
 	require.Equal(t, "", infrastructure.nodes[0].memory)
 	require.Equal(t, "", infrastructure.nodes[0].cpu)
@@ -87,6 +90,7 @@ func testMultipleSlurmNodeAllocation(t *testing.T, kv *api.KV, cfg config.Config
 		require.Len(t, infrastructure.nodes, i+1)
 		require.Equal(t, istr, infrastructure.nodes[i].instanceName)
 		require.Equal(t, "gpu:1", infrastructure.nodes[i].gres)
+		require.Equal(t, "[rack1*2&rack2*4]", infrastructure.nodes[i].constraint)
 		require.Equal(t, "debug", infrastructure.nodes[i].partition)
 		require.Equal(t, "2G", infrastructure.nodes[i].memory)
 		require.Equal(t, "4", infrastructure.nodes[i].cpu)

--- a/prov/slurm/structs.go
+++ b/prov/slurm/structs.go
@@ -22,6 +22,7 @@ type nodeAllocation struct {
 	cpu          string
 	memory       string
 	gres         string
+	constraint   string
 	partition    string
 	jobName      string
 	instanceName string

--- a/prov/slurm/testdata/multipleSlurmNodeAllocation.yaml
+++ b/prov/slurm/testdata/multipleSlurmNodeAllocation.yaml
@@ -18,6 +18,7 @@ topology_template:
         partition: debug
         user: root
         gres: gpu:1
+        constraint: "[rack1*2&rack2*4]"
         job_name: xyz
       capabilities:
         host:

--- a/prov/slurm/testdata/simpleSlurmNodeAllocation.yaml
+++ b/prov/slurm/testdata/simpleSlurmNodeAllocation.yaml
@@ -18,6 +18,7 @@ topology_template:
         partition: debug
         user: root
         gres: gpu:1
+        constraint: "[rack1|rack2|rack3|rack4]"
         job_name: xyz
       capabilities:
         host:


### PR DESCRIPTION
# Pull Request description

## Description of the change

Added support of the constraint feature of slurm

### How to verify it

Use docker container 
```bash
docker run ystia-docker-yorc.bintray.io/ystia/yorc:PR-24
```
The alien plugin corresponding to this [PR is downloadable here](https://bintray.com/ystia/yorc-a4c-plugin/download_file?file_path=snapshots%2Ffeature%BRBDCF-1279-use-slurm-node-features-to-allocate-resource%2Falien4cloud-yorc-plugin-3.0.0-SNAPSHOT.zip).