### PR TITLE
Using session.CombinedOutput() instead of session.Run()

### DIFF
--- a/data/tosca/normative-types.yml
+++ b/data/tosca/normative-types.yml
@@ -1,8 +1,9 @@
 tosca_definitions_version: yorc_tosca_simple_yaml_1_0
 
-template_name: tosca-normative-types
-template_author: TOSCA TC
-template_version: 1.0.0
+metadata:
+  template_name: tosca-normative-types
+  template_author: TOSCA TC
+  template_version: 1.0.0
 
 description: >
   Contains the normative types definition as currently supported in yorc.

--- a/data/tosca/yorc-aws-types.yml
+++ b/data/tosca/yorc-aws-types.yml
@@ -1,8 +1,9 @@
 tosca_definitions_version: yorc_tosca_simple_yaml_1_0
 
-template_name: yorc-aws-types
-template_author: yorc
-template_version: 1.0.0
+metadata:
+  template_name: yorc-aws-types
+  template_author: yorc
+  template_version: 1.0.0
 
 imports:
   - yorc: <yorc-types.yml>

--- a/data/tosca/yorc-docker-types.yml
+++ b/data/tosca/yorc-docker-types.yml
@@ -1,8 +1,9 @@
 tosca_definitions_version: yorc_tosca_simple_yaml_1_0
 
-template_name: yorc-docker-types
-template_author: yorc
-template_version: 1.0.0
+metadata:
+  template_name: yorc-docker-types
+  template_author: yorc
+  template_version: 1.0.0
 
 imports:
   - normative: <normative-types.yml>

--- a/data/tosca/yorc-hostspool-types.yml
+++ b/data/tosca/yorc-hostspool-types.yml
@@ -1,8 +1,9 @@
 tosca_definitions_version: yorc_tosca_simple_yaml_1_0
 
-template_name: yorc-hostspool-types
-template_author: yorc
-template_version: 1.0.0
+metadata:
+  template_name: yorc-hostspool-types
+  template_author: yorc
+  template_version: 1.0.0
 
 imports:
   - yorc: <yorc-types.yml>

--- a/data/tosca/yorc-kubernetes-types.yml
+++ b/data/tosca/yorc-kubernetes-types.yml
@@ -1,8 +1,9 @@
 tosca_definitions_version: yorc_tosca_simple_yaml_1_0
 
-template_name: yorc-kubernetes-types
-template_author: yorc
-template_version: 1.0.0
+metadata:
+  template_name: yorc-kubernetes-types
+  template_author: yorc
+  template_version: 1.0.0
 
 imports:
   - normative: <yorc-docker-types.yml>

--- a/data/tosca/yorc-openstack-types.yml
+++ b/data/tosca/yorc-openstack-types.yml
@@ -1,8 +1,9 @@
 tosca_definitions_version: yorc_tosca_simple_yaml_1_0
 
-template_name: yorc-openstack-types
-template_author: yorc
-template_version: 1.0.0
+metadata:
+  template_name: yorc-openstack-types
+  template_author: yorc
+  template_version: 1.0.0
 
 imports:
   - yorc: <yorc-types.yml>

--- a/data/tosca/yorc-slurm-types.yml
+++ b/data/tosca/yorc-slurm-types.yml
@@ -14,6 +14,9 @@ node_types:
       gres:
         type: string
         required: false
+      constraint:
+        type: string
+        required: false
       partition:
         type: string
         required: false

--- a/data/tosca/yorc-slurm-types.yml
+++ b/data/tosca/yorc-slurm-types.yml
@@ -1,8 +1,9 @@
 tosca_definitions_version: yorc_tosca_simple_yaml_1_0
 
-template_name: yorc-slurm-types
-template_author: yorc
-template_version: 1.0.0
+metadata:
+  template_name: yorc-slurm-types
+  template_author: yorc
+  template_version: 1.0.0
 
 imports:
   - yorc: <yorc-types.yml>

--- a/data/tosca/yorc-types.yml
+++ b/data/tosca/yorc-types.yml
@@ -1,8 +1,9 @@
 tosca_definitions_version: yorc_tosca_simple_yaml_1_0
 
-template_name: yorc-types
-template_author: yorc
-template_version: 1.0.0
+metadata:
+  template_name: yorc-types
+  template_author: yorc
+  template_version: 1.0.0
 
 imports:
   - normative: <normative-types.yml>

--- a/deployments/capabilities.go
+++ b/deployments/capabilities.go
@@ -17,10 +17,13 @@ package deployments
 import (
 	"context"
 	"path"
+	"strings"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/pkg/errors"
 	"github.com/ystia/yorc/helper/consulutil"
+	"github.com/ystia/yorc/log"
+	"github.com/ystia/yorc/tosca"
 )
 
 // HasScalableCapability check if the given nodeName in the specified deployment, has in this capabilities a Key named scalable
@@ -211,6 +214,24 @@ func GetInstanceCapabilityAttribute(kv *api.KV, deploymentID, nodeName, instance
 		}
 	}
 
+	// Capability attributes of a Service referencing an application in another
+	// deployment are actually available as attributes of the node template
+	substitutionInstance, err := isSubstitutionNodeInstance(kv, deploymentID, nodeName, instanceName)
+	if err != nil {
+		return false, "", err
+	}
+	if substitutionInstance {
+
+		found, result, err := getSubstitutionInstanceCapabilityAttribute(kv, deploymentID, nodeName, instanceName, capabilityName, attrDataType, attributeName, nestedKeys...)
+		if err != nil || found {
+			// If there is an error or attribute was found, returning
+			// else going back to the generic behavior
+			return found, result, errors.Wrapf(err,
+				"Failed to get attribute %q for capability %q on substitutable node %q",
+				attributeName, capabilityName, nodeName)
+		}
+	}
+
 	// First look at instance scoped attributes
 	capAttrPath := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/instances", nodeName, instanceName, "capabilities", capabilityName, "attributes", attributeName)
 	found, result, err := getValueAssignmentWithDataType(kv, deploymentID, capAttrPath, nodeName, instanceName, "", attrDataType, nestedKeys...)
@@ -244,20 +265,81 @@ func GetInstanceCapabilityAttribute(kv *api.KV, deploymentID, nodeName, instance
 
 	// No default found in type hierarchy
 	// then traverse HostedOn relationships to find the value
-	host, err := GetHostedOnNode(kv, deploymentID, nodeName)
+	host, hostInstance, err := GetHostedOnNodeInstance(kv, deploymentID, nodeName, instanceName)
 	if err != nil {
 		return false, "", err
 	}
 	if host != "" {
-		found, result, err = GetInstanceCapabilityAttribute(kv, deploymentID, host, instanceName, capabilityName, attributeName, nestedKeys...)
+		found, result, err = GetInstanceCapabilityAttribute(kv, deploymentID, host, hostInstance, capabilityName, attributeName, nestedKeys...)
 		if err != nil || found {
 			// If there is an error or attribute was found
 			return found, result, err
 		}
 	}
 
+	isEndpoint, err := IsTypeDerivedFrom(kv, deploymentID, capabilityType,
+		tosca.EndpointCapability)
+	if err != nil {
+		return false, "", err
+	}
+
+	// TOSCA specification at :
+	// http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.2/TOSCA-Simple-Profile-YAML-v1.2.html#DEFN_TYPE_CAPABILITIES_ENDPOINT
+	// describes that the ip_address attribute of an endpoint is the IP address
+	// as propagated up by the associated node’s host (Compute) container.
+	if isEndpoint && attributeName == "ip_address" && host != "" {
+		found, result, err = getIPAddressFromHost(kv, deploymentID, host,
+			hostInstance, nodeName, instanceName, capabilityName)
+		if err != nil || found {
+			return found, result, err
+		}
+	}
+
 	// If still not found check properties as the spec states "TOSCA orchestrators will automatically reflect (i.e., make available) any property defined on an entity making it available as an attribute of the entity with the same name as the property."
 	return GetCapabilityProperty(kv, deploymentID, nodeName, capabilityName, attributeName, nestedKeys...)
+}
+
+func getIPAddressFromHost(kv *api.KV, deploymentID, hostName, hostInstance,
+	nodeName, instanceName, capabilityName string) (bool, string, error) {
+
+	// First check the network name in the capability property to find the right
+	// IP address attribute (default: private address)
+	ipAddressAttrName := "private_address"
+
+	found, netName, err := GetCapabilityProperty(kv, deploymentID, nodeName, capabilityName, "network_name")
+	if err != nil {
+		return false, "", err
+	}
+
+	if found && strings.ToLower(netName) == "public" {
+		ipAddressAttrName = "public_address"
+	}
+
+	found, result, err := GetInstanceAttribute(kv, deploymentID, hostName, hostInstance,
+		ipAddressAttrName)
+
+	if err == nil && found {
+		log.Debugf("Found IP address %s for %s %s %s %s on network %s from host %s %s",
+			result, deploymentID, nodeName, instanceName, capabilityName, netName, hostName, hostInstance)
+	} else {
+		log.Debugf("Found no IP address for %s %s %s %s on network %s from host %s %s",
+			deploymentID, nodeName, instanceName, capabilityName, netName, hostName, hostInstance)
+	}
+
+	return found, result, err
+
+}
+
+// GetNodeCapabilityAttributeNames retrieves the names for all capability attributes
+// of a capability on a given node name
+func GetNodeCapabilityAttributeNames(kv *api.KV, deploymentID, nodeName, capabilityName string, exploreParents bool) ([]string, error) {
+
+	capabilityType, err := GetNodeCapabilityType(kv, deploymentID, nodeName, capabilityName)
+	if err != nil {
+		return nil, err
+	}
+	return GetTypeAttributes(kv, deploymentID, capabilityType, exploreParents)
+
 }
 
 // SetInstanceCapabilityAttribute sets a capability attribute for a given node instance

--- a/deployments/consul_test.go
+++ b/deployments/consul_test.go
@@ -75,6 +75,21 @@ func TestRunConsulDeploymentsPackageTests(t *testing.T) {
 		t.Run("testImportTopologyTemplate", func(t *testing.T) {
 			testImportTopologyTemplate(t, kv)
 		})
+		t.Run("testTopologyTemplateMetadata", func(t *testing.T) {
+			testTopologyTemplateMetadata(t, kv)
+		})
+		t.Run("testSubstitutionServiceCapabilityMappings", func(t *testing.T) {
+			testSubstitutionServiceCapabilityMappings(t, kv)
+		})
+		t.Run("testSubstitutionServiceRequirementMappings", func(t *testing.T) {
+			testSubstitutionServiceRequirementMappings(t, kv)
+		})
+		t.Run("testSubstitutionClientDirective", func(t *testing.T) {
+			testSubstitutionClientDirective(t, kv)
+		})
+		t.Run("testSubstitutionClientServiceInstance", func(t *testing.T) {
+			testSubstitutionClientServiceInstance(t, kv)
+		})
 		t.Run("TestOperationImplementationArtifact", func(t *testing.T) {
 			testOperationImplementationArtifact(t, kv)
 		})

--- a/deployments/definition_store_test.go
+++ b/deployments/definition_store_test.go
@@ -614,16 +614,24 @@ func testValueAssignments(t *testing.T, kv *api.KV) {
 	}
 	for _, tt := range capAttrTests {
 		t.Run(tt.name, func(t *testing.T) {
-			found, got, err := GetInstanceCapabilityAttribute(kv, deploymentID, tt.args.nodeName, tt.args.instanceName, tt.args.capability, tt.args.attributeName, tt.args.nestedKeys...)
+			found, got, err := GetInstanceCapabilityAttribute(kv, deploymentID,
+				tt.args.nodeName, tt.args.instanceName, tt.args.capability,
+				tt.args.attributeName, tt.args.nestedKeys...)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GetInstanceCapabilityAttribute() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetInstanceCapabilityAttribute(%s, %s, %s, %s) error = %v, wantErr %v",
+					tt.args.nodeName, tt.args.instanceName, tt.args.capability, tt.args.attributeName,
+					err, tt.wantErr)
 				return
 			}
 			if err == nil && found != tt.wantFound {
-				t.Errorf("GetInstanceCapabilityAttribute() found result = %v, want %v", found, tt.wantFound)
+				t.Errorf("GetInstanceCapabilityAttribute(%s, %s, %s, %s) found result = %v, want %v",
+					tt.args.nodeName, tt.args.instanceName, tt.args.capability, tt.args.attributeName,
+					found, tt.wantFound)
 			}
 			if err == nil && got != tt.want {
-				t.Errorf("GetInstanceCapabilityAttribute() = %q, want %q", got, tt.want)
+				t.Errorf("GetInstanceCapabilityAttribute(%s, %s, %s, %s) = %q, want %q",
+					tt.args.nodeName, tt.args.instanceName, tt.args.capability, tt.args.attributeName,
+					got, tt.want)
 			}
 		})
 	}
@@ -920,4 +928,35 @@ func testImportTopologyTemplate(t *testing.T, kv *api.KV) {
 		require.NotNil(t, kvp, "Unexpected null value for key %s", consulKey)
 		assert.Equal(t, string(kvp.Value), expectedValue, "Wrong value for key %s", key)
 	}
+}
+
+// Testing topology template metadata
+func testTopologyTemplateMetadata(t *testing.T, kv *api.KV) {
+	t.Parallel()
+
+	// Storing the Deployment definition
+	deploymentID := strings.Replace(t.Name(), "/", "_", -1)
+	err := StoreDeploymentDefinition(context.Background(), kv, deploymentID, "testdata/test_topology.yml")
+	require.NoError(t, err, "Failed to store test topology deployment definition")
+
+	// Check the stored template metadata
+	// This topology template imports a tempologuy template with metatadata
+	// Checking the imported template metadata
+	expectedKeyValuePairs := map[string]string{
+		"topology/metadata/template_name":              "topotest-Environment",
+		"topology/metadata/template_version":           "0.1.0-SNAPSHOT",
+		"topology/metadata/template_author":            "yorcTester",
+		"topology/imports/3/metadata/template_name":    "test-component",
+		"topology/imports/3/metadata/template_version": "2.0.0-SNAPSHOT",
+		"topology/imports/3/metadata/template_author":  "yorcTester",
+	}
+
+	for key, expectedValue := range expectedKeyValuePairs {
+		consulKey := path.Join(consulutil.DeploymentKVPrefix, deploymentID, key)
+		kvp, _, err := kv.Get(consulKey, nil)
+		require.NoError(t, err, "Error getting value for key %s", consulKey)
+		require.NotNil(t, kvp, "Unexpected null value for key %s", consulKey)
+		assert.Equal(t, string(kvp.Value), expectedValue, "Wrong value for key %s", key)
+	}
+
 }

--- a/deployments/instances.go
+++ b/deployments/instances.go
@@ -69,6 +69,34 @@ func DeleteInstance(kv *api.KV, deploymentID, nodeName, instanceName string) err
 // If the attribute is still not found then it will explore the HostedOn hierarchy.
 // If still not found then it will check node properties as the spec states "TOSCA orchestrators will automatically reflect (i.e., make available) any property defined on an entity making it available as an attribute of the entity with the same name as the property."
 func GetInstanceAttribute(kv *api.KV, deploymentID, nodeName, instanceName, attributeName string, nestedKeys ...string) (bool, string, error) {
+
+	substitutionInstance, err := isSubstitutionNodeInstance(kv, deploymentID, nodeName, instanceName)
+	if err != nil {
+		return false, "", err
+	}
+	if isSubstitutionMappingAttribute(attributeName) {
+
+		// Alien4Cloud did not yet implement the management of capability attributes
+		// in substitution mappings. It is using node attributes names with a
+		// capabilities prefix.
+		// These attributes will be available :
+		// - in the case of the source application providing this attribute,
+		//   the call here should be redirected to the call getting
+		//   instance capability attribute
+		// - in the case of a substitutable node, the attribute is available in
+		//   the node attributes (managed in a later block in this function)
+		if !substitutionInstance {
+			found, result, err := getSubstitutionMappingAttribute(kv, deploymentID, nodeName, instanceName, attributeName, nestedKeys...)
+			if err != nil {
+				return false, "", err
+			}
+
+			if found {
+				return true, result, nil
+			}
+		}
+	}
+
 	nodeType, err := GetNodeType(kv, deploymentID, nodeName)
 	if err != nil {
 		return false, "", err
@@ -87,16 +115,28 @@ func GetInstanceAttribute(kv *api.KV, deploymentID, nodeName, instanceName, attr
 	}
 
 	// First look at instance-scoped attributes
-	found, result, err := getValueAssignmentWithDataType(kv, deploymentID, path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/instances", nodeName, instanceName, "attributes", attributeName), nodeName, instanceName, "", attrDataType, nestedKeys...)
-	if err != nil {
-		return false, "", errors.Wrapf(err, "Failed to get attribute %q for node %q (instance %q)", attributeName, nodeName, instanceName)
-	}
-	if found {
-		return true, result, nil
+	// except if this is a substitutable node instance, in which case
+	// attributes are stored at the node level
+	if substitutionInstance {
+		found, result := getSubstitutionInstanceAttribute(deploymentID, nodeName, instanceName, attributeName)
+		if found {
+			return true, result, nil
+		}
+	} else {
+		found, result, err := getValueAssignmentWithDataType(kv, deploymentID,
+			path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/instances", nodeName, instanceName, "attributes", attributeName),
+			nodeName, instanceName, "", attrDataType, nestedKeys...)
+		if err != nil {
+			return false, "", errors.Wrapf(err, "Failed to get attribute %q for node %q (instance %q)",
+				attributeName, nodeName, instanceName)
+		}
+		if found {
+			return true, result, nil
+		}
 	}
 
 	// Then look at global node level (not instance-scoped)
-	found, result, err = getValueAssignmentWithDataType(kv, deploymentID, path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/nodes", nodeName, "attributes", attributeName), nodeName, instanceName, "", attrDataType, nestedKeys...)
+	found, result, err := getValueAssignmentWithDataType(kv, deploymentID, path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/nodes", nodeName, "attributes", attributeName), nodeName, instanceName, "", attrDataType, nestedKeys...)
 	if err != nil {
 		return false, "", errors.Wrapf(err, "Failed to get attribute %q for node %q", attributeName, nodeName, instanceName)
 	}

--- a/deployments/operations.go
+++ b/deployments/operations.go
@@ -493,6 +493,7 @@ func GetOperationInput(kv *api.KV, deploymentID, nodeName string, operation prov
 		if err != nil {
 			return nil, err
 		}
+
 		for _, ins := range instances {
 			res, err = resolver(kv, deploymentID).context(withNodeName(nodeName), withInstanceName(ins), withRequirementIndex(operation.RelOp.RequirementIndex)).resolveFunction(f)
 			if err != nil {

--- a/deployments/substitution_mappings.go
+++ b/deployments/substitution_mappings.go
@@ -1,0 +1,568 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployments
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/pkg/errors"
+	"github.com/ystia/yorc/helper/consulutil"
+	"github.com/ystia/yorc/log"
+	"github.com/ystia/yorc/tosca"
+)
+
+const (
+	// Alien4Cloud is managing capability attributes of Managed serviced
+	// referenced in a deployment as node templates attributes with
+	// the format capabilities.<capability name>.<attribute name>
+	// See http://alien4cloud.github.io/#/documentation/2.0.0/user_guide/services_management.html
+	capabilityFormat = "capabilities.%s.%s"
+
+	// directiveSubstitutable is a directive to the Orchestrator that a node
+	// type is substitutable, ie. this node type is either abstract or a
+	// reference to another topology template providing substitution mappings
+	directiveSubstitutable = "substitutable"
+
+	// Name of a fake instance for a substitutable node
+	// Using an integer value as this is expected by the Alien4cloud Yorc
+	// Orchestrator plugin, and it is has to be 0 so that the plugin can manage
+	// a state change event started and display the instance as started.
+	substitutableNodeInstance = "0"
+)
+
+// isSubstitutableNode returns true if a node contains an Orchestrator directive
+// that it is substitutable
+func isSubstitutableNode(kv *api.KV, deploymentID, nodeName string) (bool, error) {
+	kvp, _, err := kv.Get(path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/nodes", nodeName, "directives"), nil)
+	if err != nil {
+		return false, errors.Wrapf(err, "Can't get directives for node %q", nodeName)
+	}
+
+	substitutable := false
+	if kvp != nil && kvp.Value != nil {
+		values := strings.Split(string(kvp.Value), ",")
+		for _, value := range values {
+			if value == directiveSubstitutable {
+				substitutable = true
+				break
+			}
+		}
+	}
+	return substitutable, nil
+}
+
+func storeSubstitutionMappings(ctx context.Context, topology tosca.Topology, topologyPrefix string) {
+	consulStore := ctx.Value(consulStoreKey).(consulutil.ConsulStore)
+	substitutionPrefix := path.Join(topologyPrefix, "substitution_mappings")
+	substitution := topology.TopologyTemplate.SubstitionMappings
+	if substitution != nil {
+		consulStore.StoreConsulKeyAsString(path.Join(substitutionPrefix, "node_type"),
+			substitution.NodeType)
+		storePropAttrMappings(consulStore, path.Join(substitutionPrefix, "properties"),
+			substitution.Properties)
+		storePropAttrMappings(consulStore, path.Join(substitutionPrefix, "attributes"),
+			substitution.Attributes)
+		storeCapReqMappings(consulStore, path.Join(substitutionPrefix, "capabilities"),
+			substitution.Capabilities)
+		storeCapReqMappings(consulStore, path.Join(substitutionPrefix, "requirements"),
+			substitution.Requirements)
+		storeInterfaceMappings(consulStore, path.Join(substitutionPrefix, "interfaces"),
+			substitution.Interfaces)
+	}
+}
+
+func storePropAttrMappings(
+	consulStore consulutil.ConsulStore,
+	prefix string,
+	mappings map[string]tosca.PropAttrMapping) {
+
+	if mappings != nil {
+
+		for name, propAttrMapping := range mappings {
+
+			propAttrPrefix := path.Join(prefix, name)
+			if propAttrMapping.Mapping != nil {
+				consulStore.StoreConsulKeyAsString(
+					path.Join(propAttrPrefix, "mapping"),
+					strings.Join(propAttrMapping.Mapping, ","))
+			} else {
+				storeValueAssignment(consulStore, path.Join(propAttrPrefix, "value"), propAttrMapping.Value)
+			}
+		}
+	}
+}
+
+func storeCapReqMappings(
+	consulStore consulutil.ConsulStore,
+	prefix string,
+	mappings map[string]tosca.CapReqMapping) {
+
+	if mappings != nil {
+
+		for name, capReqMapping := range mappings {
+
+			capReqPrefix := path.Join(prefix, name)
+
+			if capReqMapping.Mapping != nil {
+				consulStore.StoreConsulKeyAsString(
+					path.Join(capReqPrefix, "mapping"),
+					strings.Join(capReqMapping.Mapping, ","))
+			}
+
+			if capReqMapping.Properties != nil {
+				propPrefix := path.Join(capReqPrefix, "properties")
+				for name, value := range capReqMapping.Properties {
+					storeValueAssignment(
+						consulStore, path.Join(propPrefix, name),
+						value)
+				}
+			}
+
+			if capReqMapping.Attributes != nil {
+				attrPrefix := path.Join(capReqPrefix, "attributes")
+				for name, value := range capReqMapping.Attributes {
+					storeValueAssignment(
+						consulStore, path.Join(attrPrefix, name),
+						value)
+				}
+			}
+		}
+	}
+}
+
+func storeInterfaceMappings(
+	consulStore consulutil.ConsulStore,
+	prefix string,
+	mappings map[string]string) {
+
+	if mappings != nil {
+		for operationName, workflowName := range mappings {
+			consulStore.StoreConsulKeyAsString(path.Join(prefix, operationName), workflowName)
+		}
+	}
+}
+
+func getDeploymentSubstitutionMapping(kv *api.KV, deploymentID string) (tosca.SubstitutionMapping, error) {
+	return getSubstitutionMappingFromStore(kv,
+		path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology"))
+}
+
+func getSubstitutionMappingFromStore(kv *api.KV, prefix string) (tosca.SubstitutionMapping, error) {
+	substitutionPrefix := path.Join(prefix, "substitution_mappings")
+	var substitutionMapping tosca.SubstitutionMapping
+
+	kvp, _, err := kv.Get(path.Join(substitutionPrefix, "node_type"), nil)
+	if err != nil {
+		return substitutionMapping,
+			errors.Wrapf(err, "Can't get node type for substitution at %q", substitutionPrefix)
+	}
+	if kvp == nil || len(kvp.Value) == 0 {
+		// No mapping defined
+		return substitutionMapping, nil
+	}
+	substitutionMapping.NodeType = string(kvp.Value)
+	substitutionMapping.Capabilities, err = getCapReqMappingFromStore(
+		kv, path.Join(substitutionPrefix, "capabilities"))
+	if err != nil {
+		return substitutionMapping, err
+	}
+
+	substitutionMapping.Requirements, err = getCapReqMappingFromStore(
+		kv, path.Join(substitutionPrefix, "requirements"))
+	if err != nil {
+		return substitutionMapping, err
+	}
+
+	substitutionMapping.Properties, err = getPropAttrMappingFromStore(
+		kv, path.Join(substitutionPrefix, "properties"))
+	if err != nil {
+		return substitutionMapping, err
+	}
+
+	substitutionMapping.Attributes, err = getPropAttrMappingFromStore(
+		kv, path.Join(substitutionPrefix, "attributes"))
+	if err != nil {
+		return substitutionMapping, err
+	}
+
+	substitutionMapping.Interfaces, err = getInterfaceMappingFromStore(
+		kv, path.Join(substitutionPrefix, "interfaces"))
+
+	return substitutionMapping, err
+}
+
+func getCapReqMappingFromStore(kv *api.KV, prefix string) (map[string]tosca.CapReqMapping, error) {
+
+	capabilityPaths, _, err := kv.Keys(prefix+"/", "/", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	capabilities := make(map[string]tosca.CapReqMapping)
+
+	for _, capPath := range capabilityPaths {
+
+		capName := path.Base(capPath)
+
+		kvp, _, err := kv.Get(path.Join(capPath, "mapping"), nil)
+		if err != nil {
+			return capabilities,
+				errors.Wrapf(err, "Can't get mapping for capability at %q", capPath)
+		}
+		var capMapping tosca.CapReqMapping
+		if kvp != nil && len(kvp.Value) != 0 {
+			capMapping.Mapping = strings.Split(string(kvp.Value), ",")
+			// When a mapping is defined, there is no property/attribute
+			// definition, so the capability definition is complete at this point
+			capabilities[capName] = capMapping
+			continue
+		}
+
+		capMapping.Properties, err = getPropertiesOrAttributesFromStore(kv,
+			path.Join(capPath, "properties"))
+		if err != nil {
+			return capabilities, err
+		}
+
+		capMapping.Attributes, err = getPropertiesOrAttributesFromStore(kv,
+			path.Join(capPath, "attributes"))
+		if err != nil {
+			return capabilities, err
+		}
+
+		capabilities[capName] = capMapping
+	}
+
+	return capabilities, nil
+}
+
+func getPropertiesOrAttributesFromStore(kv *api.KV, prefix string) (map[string]*tosca.ValueAssignment, error) {
+	propPaths, _, err := kv.Keys(prefix+"/", "/", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	props := make(map[string]*tosca.ValueAssignment)
+
+	for _, propPath := range propPaths {
+
+		propName := path.Base(propPath)
+
+		val, err := getValueAssignmentFromStore(kv, propPath)
+		if err != nil {
+			return props,
+				errors.Wrapf(err, "Can't get value for property or attribute at %q", propPath)
+		}
+		if val != nil {
+			props[propName] = val
+		}
+	}
+
+	return props, nil
+}
+
+func getPropAttrMappingFromStore(kv *api.KV, prefix string) (map[string]tosca.PropAttrMapping, error) {
+
+	propPaths, _, err := kv.Keys(prefix+"/", "/", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	props := make(map[string]tosca.PropAttrMapping)
+
+	for _, propPath := range propPaths {
+
+		propName := path.Base(propPath)
+
+		var propMapping tosca.PropAttrMapping
+		kvp, _, err := kv.Get(path.Join(propPath, "mapping"), nil)
+		if err != nil {
+			return props,
+				errors.Wrapf(err, "Can't get mapping for properties or attributes at %q", propPath)
+		}
+		if kvp != nil && len(kvp.Value) != 0 {
+			propMapping.Mapping = strings.Split(string(kvp.Value), ",")
+		} else {
+			propMapping.Value, err = getValueAssignmentFromStore(
+				kv, path.Join(propPath, "value"))
+			if err != nil {
+				return props,
+					errors.Wrapf(err, "Can't get mapping for properties or attributes at %q", propPath)
+			}
+		}
+		props[propName] = propMapping
+	}
+
+	return props, nil
+}
+
+func getValueAssignmentFromStore(kv *api.KV, valPath string) (*tosca.ValueAssignment, error) {
+	kvp, _, err := kv.Get(valPath, nil)
+	if err != nil {
+		return nil, err
+	}
+	var val tosca.ValueAssignment
+	if kvp != nil {
+		val.Type = tosca.ValueAssignmentType(kvp.Flags)
+		if err != nil {
+			return nil, err
+		}
+
+		switch val.Type {
+		case tosca.ValueAssignmentLiteral, tosca.ValueAssignmentFunction:
+			val.Value = kvp.Value
+		case tosca.ValueAssignmentList, tosca.ValueAssignmentMap:
+			val.Value, err = readComplexVA(kv, val.Type, "", valPath, "")
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return &val, nil
+}
+
+func getInterfaceMappingFromStore(kv *api.KV, prefix string) (map[string]string, error) {
+
+	opPaths, _, err := kv.Keys(prefix+"/", "/", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	itfs := make(map[string]string)
+
+	for _, opPath := range opPaths {
+
+		opName := path.Base(opPath)
+
+		kvp, _, err := kv.Get(path.Join(opPath), nil)
+		if err != nil {
+			return itfs,
+				errors.Wrapf(err, "Can't get mapping for interface at %q", opPath)
+		}
+		if kvp != nil && len(kvp.Value) != 0 {
+			itfs[opName] = string(kvp.Value)
+		}
+	}
+
+	return itfs, nil
+}
+
+// storeSubstitutionMappingAttributeNamesInSet gets capability attributes for capabilities
+// exposed in the deployment through substitution mappings, and stores these
+// capability attributes as node attributes prefixed by capabilities.<capability name>
+// as expected by Alien4Cloud until it implements the mapping of capability attributes
+// See http://alien4cloud.github.io/#/documentation/2.0.0/user_guide/services_management.html
+func storeSubstitutionMappingAttributeNamesInSet(kv *api.KV, deploymentID, nodeName string, set map[string]struct{}) error {
+
+	substMapping, err := getDeploymentSubstitutionMapping(kv, deploymentID)
+	if err != nil {
+		return err
+	}
+
+	capabilityToAttrNames := make(map[string][]string)
+	exploreParents := true
+	// Get the capabilities exposed for this node
+	for _, capMapping := range substMapping.Capabilities {
+
+		capability := capMapping.Mapping[1]
+		var attributeNames []string
+
+		if capMapping.Mapping[0] == nodeName {
+			if capMapping.Attributes != nil {
+				attributeNames := make([]string, len(capMapping.Attributes))
+				i := 0
+				for name := range capMapping.Attributes {
+					attributeNames[i] = name
+					i++
+				}
+			} else {
+				// Expose all attributes
+				attributeNames, err = GetNodeCapabilityAttributeNames(
+					kv, deploymentID, nodeName, capability, exploreParents)
+				if err != nil {
+					return err
+				}
+			}
+
+			capabilityToAttrNames[capability] = attributeNames
+		}
+	}
+
+	// See http://alien4cloud.github.io/#/documentation/2.0.0/user_guide/services_management.html
+	// Alien4Cloud is managing capability attributes  as node template attributes with
+	// the format capabilities.<capability name>.<attribute name>
+	for capability, names := range capabilityToAttrNames {
+		for _, attr := range names {
+			set[fmt.Sprintf(capabilityFormat, capability, attr)] = struct{}{}
+		}
+	}
+
+	return nil
+}
+
+func isSubstitutionMappingAttribute(attributeName string) bool {
+	items := strings.Split(attributeName, ".")
+	return len(items) == 3 && items[0] == "capabilities"
+}
+
+// getSubstitutionMappingAttribute retrieves the given attribute for a capability
+//
+// It returns true if a value is found false otherwise as first return parameter.
+// If the attribute is a substitution mapping capability attribute as provided
+// by Alien4Cloud, using the format capabilities.<capability name>.<attributr name>,
+// this function returns the the vqlue of the corresponding instance capability
+// attribute
+func getSubstitutionMappingAttribute(kv *api.KV, deploymentID, nodeName, instanceName, attributeName string, nestedKeys ...string) (bool, string, error) {
+
+	if !isSubstitutionMappingAttribute(attributeName) {
+		return false, "", nil
+	}
+
+	log.Debugf("Attempting to substitute attribute %s in %s %s %s", attributeName, deploymentID, nodeName, instanceName)
+
+	items := strings.Split(attributeName, ".")
+	capabilityName := items[1]
+	capAttrName := items[2]
+
+	// Check this capability attribute is really exposed before returning its
+	// value
+	attributesSet := make(map[string]struct{})
+	err := storeSubstitutionMappingAttributeNamesInSet(kv, deploymentID, nodeName, attributesSet)
+	if err != nil {
+		return false, "", err
+	}
+
+	if _, ok := attributesSet[attributeName]; ok {
+		// This attribute is exposed, returning its value
+		log.Debugf("Substituting attribute %s by its instance capability attribute in %s %s %s %s", attributeName, deploymentID, nodeName, instanceName)
+		return GetInstanceCapabilityAttribute(
+			kv, deploymentID, nodeName, instanceName, capabilityName, capAttrName, nestedKeys...)
+	}
+
+	return false, "", nil
+}
+
+// getSubstitutionNodeInstancesIds returns for a substitutable node, a fake
+// instance ID, all necessary infos are stored and retrieved at the node level.
+func getSubstitutionNodeInstancesIds(kv *api.KV, deploymentID, nodeName string) ([]string, error) {
+
+	var names []string
+	substitutable, err := isSubstitutableNode(kv, deploymentID, nodeName)
+	if err == nil && substitutable {
+		names = []string{substitutableNodeInstance}
+	}
+	return names, err
+}
+
+func isSubstitutionNodeInstance(kv *api.KV, deploymentID, nodeName, nodeInstance string) (bool, error) {
+	if nodeInstance != substitutableNodeInstance {
+		return false, nil
+	}
+
+	return isSubstitutableNode(kv, deploymentID, nodeName)
+}
+
+// getSubstitutableNodeType returns the node type of a substitutable node.
+// There are 2 cases :
+// - either this node a reference to an external service, and the node type
+//   here is a real node type (abstract)
+// - or this is a reference to a managed service, and the node type here
+//   does not exist, it is the name of a template whose import contains the
+//    real node type
+func getSubstitutableNodeType(kv *api.KV, deploymentID, nodeName, nodeType string) (string, error) {
+	_, err := GetParentType(kv, deploymentID, nodeType)
+	if err == nil {
+		// Reference to an external service, this node type is a real abstract
+		// node type
+		return nodeType, nil
+	} else if !IsTypeMissingError(err) {
+		// Unexpected error
+		return nodeType, err
+	}
+
+	// The node type does not exist. This is the  reference to an application
+	// from another deployment.
+	// The real node type has to be found in subsitution mappings of an imported
+	// file whose metadata template name is the nodeType here.
+	importsPath := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/imports")
+	imports, _, err := kv.Keys(importsPath+"/", "/", nil)
+	if err != nil {
+		return "", errors.Wrap(err, "Consul communication error")
+	}
+
+	var importTemplatePath string
+	for _, importPath := range imports {
+		kvp, _, err := kv.Get(path.Join(importPath, "metadata/template_name"), nil)
+		if err == nil && kvp != nil && len(kvp.Value) != 0 && string(kvp.Value) == nodeType {
+			// Found the import
+			importTemplatePath = importPath
+			break
+		}
+	}
+
+	if importTemplatePath == "" {
+		// No such template found
+		return nodeType, nil
+	}
+
+	// Check subsitution mappings in this import
+	mappings, err := getSubstitutionMappingFromStore(kv, importTemplatePath)
+	if err == nil && mappings.NodeType != "" {
+		log.Debugf("Substituting type %s by type %s for %s %s", nodeType, mappings.NodeType, deploymentID, nodeName)
+		return mappings.NodeType, err
+	}
+	// Found no substitution type
+	return nodeType, nil
+
+}
+
+// getSubstitutionInstanceAttribute returns the value of generic attributes
+// associated to any instance, here a fake instance for a substitutable node
+func getSubstitutionInstanceAttribute(deploymentID, nodeName, instanceName, attributeName string) (bool, string) {
+	switch attributeName {
+	case "tosca_name":
+		return true, nodeName
+	case "tosca_id":
+		return true, nodeName + "-" + instanceName
+	default:
+		return false, ""
+	}
+}
+
+// getSubstitutionInstanceCapabilityAttribute returns the value of a capability
+// attribute for a Service Instance not deployed in this deployment.
+// In this case, the capability attribute is provided as an attribute in the Node
+// template, the attribute having this format:
+// capabilities.<capability name>.<attribute name>
+// See http://alien4cloud.github.io/#/documentation/2.0.0/user_guide/services_management.html
+func getSubstitutionInstanceCapabilityAttribute(kv *api.KV, deploymentID, nodeName,
+	instanceName, capabilityName, attributeType, attributeName string, nestedKeys ...string) (bool, string, error) {
+
+	nodeAttrName := fmt.Sprintf(capabilityFormat, capabilityName, attributeName)
+	found, result, err := getValueAssignmentWithDataType(kv, deploymentID,
+		path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/nodes",
+			nodeName, "attributes", nodeAttrName),
+		nodeName, instanceName, "", attributeType, nestedKeys...)
+	if err != nil {
+		return false, "", errors.Wrapf(err, "Failed to get attribute %q for node %q", nodeAttrName, nodeName)
+	}
+
+	return found, result, nil
+}

--- a/deployments/substitution_mappings_test.go
+++ b/deployments/substitution_mappings_test.go
@@ -1,0 +1,159 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployments
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Testing a topology template defining capabilities substitution mappings
+func testSubstitutionServiceCapabilityMappings(t *testing.T, kv *api.KV) {
+	t.Parallel()
+
+	// Storing the Deployment definition
+	deploymentID := strings.Replace(t.Name(), "/", "_", -1)
+	err := StoreDeploymentDefinition(context.Background(), kv, deploymentID,
+		"testdata/test_topology_service.yml")
+	require.NoError(t, err, "Failed to store test topology service deployment definition")
+
+	mapping, err := getDeploymentSubstitutionMapping(kv, deploymentID)
+	require.NoError(t, err, "Failed to get substitution mappings")
+
+	assert.Equal(t, "org.ystia.yorc.test.pub.AppAType", mapping.NodeType,
+		"Unexpected node type in substitution mappings")
+
+	require.Equal(t, 2, len(mapping.Capabilities),
+		"Wrong number of capability mappings")
+	capName := "appA_capA"
+	capMap := mapping.Capabilities[capName].Mapping
+	require.Equal(t, 2, len(capMap), "Wrong number of elements in mapping %v", capMap)
+	assert.Equal(t, "AppAInstance", capMap[0], "Wrong node template name in mapping %v", capMap)
+	assert.Equal(t, capName, capMap[1], "Wrong capability name in mapping %v", capMap)
+
+	props := mapping.Properties
+	assert.Equal(t, 1, len(props), "Wrong number of elements in properties mapping %v", props)
+	value := props["aProp"]
+	require.Equal(t, 2, len(value.Mapping), "Wrong number of elements in properties mapping value %v", value)
+	assert.Equal(t, "AppAInstance", value.Mapping[0], "Wrong node template name in properties mapping value %v", value)
+	assert.Equal(t, "appA_propBString", value.Mapping[1], "Wrong property name in properties mapping value %v", value)
+
+	attrs := mapping.Attributes
+	require.Equal(t, 1, len(attrs), "Wrong number of elements in properties mapping %v", attrs)
+	value = attrs["addrAttr"]
+	require.Equal(t, 2, len(value.Mapping), "Wrong number of elements in attributes mapping value %v", value)
+	assert.Equal(t, "AppAInstance", value.Mapping[0], "Wrong node template name in attributes mapping value %v", value)
+	assert.Equal(t, "join_address", value.Mapping[1], "Wrong property name in attributes mapping value %v", value)
+
+}
+
+// Testing a topology template defining reauirements substitution mappings
+func testSubstitutionServiceRequirementMappings(t *testing.T, kv *api.KV) {
+	t.Parallel()
+
+	// Storing the Deployment definition
+	deploymentID := strings.Replace(t.Name(), "/", "_", -1)
+	err := StoreDeploymentDefinition(context.Background(), kv, deploymentID,
+		"testdata/test_topology_service.yml")
+	require.NoError(t, err, "Failed to store test topology service deployment definition")
+
+	mapping, err := getDeploymentSubstitutionMapping(kv, deploymentID)
+	require.NoError(t, err, "Failed to get substitution mappings")
+
+	assert.Equal(t, "org.ystia.yorc.test.pub.AppAType", mapping.NodeType,
+		"Unexpected node type in substitution mappings")
+
+	assert.Equal(t, 1, len(mapping.Requirements),
+		"Wrong number of capability mappings")
+	reqName := "hosted"
+	reqMap := mapping.Requirements[reqName].Mapping
+	assert.Equal(t, 2, len(reqMap), "Wrong number of elements in mapping %v", reqMap)
+	assert.Equal(t, "AppAInstance", reqMap[0], "Wrong node template name in mapping %v", reqMap)
+	assert.Equal(t, "hostedOnComputeHost", reqMap[1], "Wrong requirement name in mapping %v", reqMap)
+}
+
+// Testing the topology template of a client using a service
+func testSubstitutionClientDirective(t *testing.T, kv *api.KV) {
+	t.Parallel()
+
+	// Storing the Deployment definition
+	deploymentID := strings.Replace(t.Name(), "/", "_", -1)
+	err := StoreDeploymentDefinition(context.Background(), kv, deploymentID,
+		"testdata/test_topology_client_service.yml")
+	require.NoError(t, err, "Failed to store test topology service deployment definition")
+
+	serviceName := "AppAService"
+	substitutable, err := isSubstitutableNode(kv, deploymentID, serviceName)
+	require.NoError(t, err, "Failed to check substitutability of %s", serviceName)
+	assert.True(t, substitutable, "Node template %s should be substitutable", serviceName)
+
+	clientName := "AppBInstance"
+	substitutable, err = isSubstitutableNode(kv, deploymentID, clientName)
+	require.NoError(t, err, "Failed to check substitutability of %s", clientName)
+	assert.False(t, substitutable, "Node template %s should not be substitutable", clientName)
+}
+
+// Testing requests on a service instance referenced by a client topology
+func testSubstitutionClientServiceInstance(t *testing.T, kv *api.KV) {
+	t.Parallel()
+
+	// Storing the Deployment definition
+	deploymentID := strings.Replace(t.Name(), "/", "_", -1)
+	err := StoreDeploymentDefinition(context.Background(), kv, deploymentID,
+		"testdata/test_topology_client_service.yml")
+	require.NoError(t, err, "Failed to store test topology service deployment definition")
+
+	serviceName := "AppAService"
+	substitutable, err := isSubstitutableNode(kv, deploymentID, serviceName)
+	require.NoError(t, err, "Failed to check substitutability of %s", serviceName)
+	assert.True(t, substitutable, "Node template %s should be substitutable", serviceName)
+
+	clientName := "AppBInstance"
+	substitutable, err = isSubstitutableNode(kv, deploymentID, clientName)
+	require.NoError(t, err, "Failed to check substitutability of %s", clientName)
+	assert.False(t, substitutable, "Node template %s should not be substitutable", clientName)
+
+	// Get the node type of the service node template
+	// provided in an import generated from the Application Deployment
+	nodeType, err := GetNodeType(kv, deploymentID, serviceName)
+	require.NoError(t, err, "Failed to get the node type of service of %s", clientName)
+	assert.Equal(t, "org.ystia.yorc.test.pub.AppAType", nodeType, "Wrong node type for service %s", serviceName)
+
+	// Get instances of the service node template (fake instance)
+	instances, err := GetNodeInstancesIds(kv, deploymentID, serviceName)
+	require.NoError(t, err, "Failed to get service nod einstance id for %s", serviceName)
+
+	assert.Equal(t, 1, len(instances), "Expected to get one node instance, go %v", instances)
+
+	assert.Equal(t, substitutableNodeInstance, instances[0], "Unexpected instance for service %s", serviceName)
+
+	substitionInstance, err := isSubstitutionNodeInstance(kv, deploymentID, serviceName, instances[0])
+	assert.True(t, substitionInstance, "Expected %s %s %s to be a substitutin instance",
+		deploymentID, serviceName, instances[0])
+
+	// Get a capability attribute for the capability exposed by this service
+	// here the ip_adress attribute exists as the capability derives from an
+	// endpoint capability
+	found, value, err := GetInstanceCapabilityAttribute(kv, deploymentID, serviceName,
+		substitutableNodeInstance, "appA_capA", "ip_address")
+	require.NoError(t, err, "Failed to get service capability attribute")
+	assert.True(t, found, "Found no ip_address attribute in capability appA_capA exposed by the service")
+	assert.Equal(t, "10.0.0.2", value, "Wrong ip_address attribute in capability appA_capA exposed by the service")
+}

--- a/deployments/testdata/artifacts_ext_duplicate.yaml
+++ b/deployments/testdata/artifacts_ext_duplicate.yaml
@@ -1,8 +1,9 @@
 tosca_definitions_version: alien_dsl_1_3_0
 description: Alien4Cloud generated service template
-template_name: Test2
-template_version: 0.1.0-SNAPSHOT
-template_author: admin
+metadata:
+  template_name: Test2
+  template_version: 0.1.0-SNAPSHOT
+  template_author: admin
 
 imports:
   - normative-types: <yorc-types.yml>

--- a/deployments/testdata/get_op_output.yaml
+++ b/deployments/testdata/get_op_output.yaml
@@ -1,8 +1,9 @@
 tosca_definitions_version: alien_dsl_1_3_0
 description: Alien4Cloud generated service template
-template_name: Test2
-template_version: 0.1.0-SNAPSHOT
-template_author: admin
+metadata:
+  template_name: Test2
+  template_version: 0.1.0-SNAPSHOT
+  template_author: admin
 
 imports:
   - normative-types: <yorc-types.yml>

--- a/deployments/testdata/get_op_output_real.yaml
+++ b/deployments/testdata/get_op_output_real.yaml
@@ -1,8 +1,9 @@
 tosca_definitions_version: alien_dsl_1_3_0
 description: Alien4Cloud generated service template
-template_name: GetOpOutputTest2
-template_version: 0.1.0-SNAPSHOT
-template_author: admin
+metadata:
+  template_name: GetOpOutputTest2
+  template_version: 0.1.0-SNAPSHOT
+  template_author: admin
 
 imports:
   - type-types: <normative-types.yml>

--- a/deployments/testdata/global_interfaces_inputs.yaml
+++ b/deployments/testdata/global_interfaces_inputs.yaml
@@ -1,8 +1,9 @@
 tosca_definitions_version: alien_dsl_2_0_0
 description: Alien4Cloud generated service template
-template_name: GetOpOutputTest2
-template_version: 0.1.0-SNAPSHOT
-template_author: admin
+metadata:
+  template_name: GetOpOutputTest2
+  template_version: 0.1.0-SNAPSHOT
+  template_author: admin
 
 imports:
   - type-types: <normative-types.yml>

--- a/deployments/testdata/operation_implementation_artifact.yaml
+++ b/deployments/testdata/operation_implementation_artifact.yaml
@@ -1,8 +1,9 @@
 tosca_definitions_version: alien_dsl_2_0_0
 description: Alien4Cloud generated service template
-template_name: GetOpOutputTest2
-template_version: 0.1.0-SNAPSHOT
-template_author: admin
+metadata:
+  template_name: GetOpOutputTest2
+  template_version: 0.1.0-SNAPSHOT
+  template_author: admin
 
 imports:
   - <normative-types.yml>

--- a/deployments/testdata/test_client_service_generated_topology.yml
+++ b/deployments/testdata/test_client_service_generated_topology.yml
@@ -1,0 +1,68 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: TestService
+  template_version: 0.1.0
+  template_author: ${template_author}
+
+description: ""
+
+topology_template:
+  substitution_mappings:
+    node_type: org.ystia.yorc.test.pub.AppAType
+    capabilities:
+      appA_capA: [ AppAInstance, appA_capA ]
+      appA_capA: [ AppAInstance, appA_capA ]
+    requirements:
+      hosted: [ AppAInstance, hostedOnComputeHost ]
+  node_templates:
+    Compute:
+      type: yorc.nodes.hostspool.Compute
+      properties:
+        shareable: false
+      capabilities:
+        endpoint:
+          properties:
+            credentials: 
+              user: "not significant, will be set by Yorc itself"
+            secure: true
+            protocol: tcp
+            network_name: PRIVATE
+            initiator: source
+        scalable:
+          properties:
+            min_instances: 1
+            max_instances: 1
+            default_instances: 1
+    AppAInstance:
+      type: org.ystia.yorc.test.implem.AppAType
+      properties:
+        appA_propABool: true
+        appA_propBString: test1
+        appA_propCInt: 123
+      requirements:
+        - hostedOnComputeHost:
+            type_requirement: host
+            node: Compute
+            capability: tosca.capabilities.Container
+            relationship: tosca.relationships.HostedOn
+      capabilities:
+        appA_capA:
+          properties:
+            api_port: 1234
+            protocol: tcp
+            secure: false
+            network_name: PRIVATE
+            initiator: source
+        appA_capB:
+          properties:
+            api_port: 5678
+            protocol: tcp
+            secure: false
+            network_name: PRIVATE
+            initiator: source
+  outputs:
+    AppAInstance_join_address:
+      value: { get_attribute: [ AppAInstance, join_address ] }
+    AppAInstance_web_ui_url:
+      value: { get_attribute: [ AppAInstance, web_ui_url ] }

--- a/deployments/testdata/test_client_service_private_types.yml
+++ b/deployments/testdata/test_client_service_private_types.yml
@@ -1,0 +1,58 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: testClientPrivateTypes
+  template_version: 1.0.2
+  template_author: yorcTester
+
+imports:
+  - <yorc-types.yml>
+  - test_service_public_types.yml
+
+description: >
+  This component exposes private implementations for Test types
+
+node_types:
+  org.ystia.yorc.test.implem.AppBType:
+    derived_from: org.ystia.yorc.test.pub.AppBType
+    description: Test Application B
+    requirements:
+      - appB_capA:
+          capability: org.ystia.yorc.test.pub.AppBCapAType
+          relationship: org.ystia.yorc.test.implem.JoinAppARelType
+          occurrences: [1, 1]
+    interfaces:
+      Standard:
+        create:
+          description: App B installation step
+          implementation: test_playbook.yml
+        configure:
+          implementation: test_playbook.yml
+        start:
+          implementation: test_playbook.yml
+        stop:
+          implementation: test_playbook.yml
+      custom:
+        inputs:
+          INSTALL_DIR: "/install"
+        maintenance_on:
+          inputs:
+            MAINT_MODE: "on"
+          implementation: test_playbook.yml
+        maintenance_off:
+          inputs:
+            MAINT_MODE: "off"
+          implementation: test_playbook.yml
+
+relationship_types:
+  org.ystia.yorc.test.implem.JoinAppARelType:
+    derived_from: tosca.relationships.ConnectsTo
+    description: >
+      Connects to an App A instance
+    valid_target_types: [org.ystia.yorc.test.pub.AppACapAType ]
+    interfaces:
+      Configure:
+        pre_configure_source:
+          inputs:
+            SERVER_IP: { get_attribute: [TARGET, private_address] }
+          implementation: test_playbook.yml

--- a/deployments/testdata/test_component.yml
+++ b/deployments/testdata/test_component.yml
@@ -1,5 +1,8 @@
 tosca_definitions_version: alien_dsl_2_0_0
-metadata: {template_name: test-component, template_version: 2.0.0-SNAPSHOT, template_author: yorcTester}
+metadata:
+  template_name: test-component
+  template_version: 2.0.0-SNAPSHOT
+  template_author: yorcTester
 imports: []
 description: |
   Test Component definition. Contains types as well as a template definition

--- a/deployments/testdata/test_container.yml
+++ b/deployments/testdata/test_container.yml
@@ -1,6 +1,9 @@
 tosca_definitions_version: alien_dsl_2_0_0
-metadata: {template_name: testcontainer-type, template_version: 2.0.0-SNAPSHOT, template_author: yorcTester}
-description: This archive contains a containe tosca node type used in tests
+metadata:
+  template_name: testcontainer-type
+  template_version: 2.0.0-SNAPSHOT
+  template_author: yorcTester
+description: This archive contains a container tosca node type used in tests
 imports: []
 node_types:
   yorc.test.nodes.TestContainer:

--- a/deployments/testdata/test_service_private_types.yml
+++ b/deployments/testdata/test_service_private_types.yml
@@ -1,0 +1,73 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: org.ystia.yorc.test.implem
+  template_version: 1.0.2
+  template_author: yorcTester
+
+imports:
+  - <yorc-types.yml>
+  - test_service_public_types.yml
+
+description: >
+  This component exposes privtae implementations for Test types
+
+node_types:
+  org.ystia.yorc.test.implem.AppAType:
+    derived_from: org.ystia.yorc.test.pub.AppAType
+    description: Test Application A
+    properties:
+      appA_propDInt:
+        type: integer
+        description: Integer property
+        required: true
+        default: 2
+    attributes:
+      web_ui_url: { concat: [ "http://", get_attribute: [ HOST, public_address ], ":", get_property: [ SELF, consul_agent, api_port ] ] }
+      join_address: { get_attribute: [ HOST, private_address ] }
+    requirements:
+      - appA_capB:
+          capability: org.ystia.yorc.test.pub.AppACapBType
+          relationship: org.ystia.yorc.test.implem.AppAJoinAppARelType
+          occurrences: [0, 1]
+    interfaces:
+      Standard:
+        inputs:
+          PROPC: { get_property: [SELF, appA_propCInt] }
+          PROPD: { get_property: [SELF, appA_propDInt] }
+        create:
+          description: App A installation step
+          inputs:
+            PROPA: { get_property: [SELF, appA_propABool] }
+          implementation: test_playbook.yml
+        configure:
+          inputs:
+            PROPB: { get_property: [SELF, appA_propBString] }
+          implementation: test_playbook.yml
+        start:
+          implementation: test_playbook.yml
+        stop:
+          implementation: test_playbook.yml
+        inputs:
+          INSTALL_DIR: "/install"
+        maintenance_on:
+          inputs:
+            MAINT_MODE: "on"
+          implementation: test_playbook.yml
+        maintenance_off:
+          inputs:
+            MAINT_MODE: "off"
+          implementation: test_playbook.yml
+
+relationship_types:
+  org.ystia.yorc.test.implem.AppAJoinAppARelType:
+    derived_from: tosca.relationships.ConnectsTo
+    description: >
+      Connects an App A to another App A using its public address 
+    valid_target_types: [ org.ystia.yorc.test.pub.AppACapBType ]
+    interfaces:
+      Configure:
+        pre_configure_source:
+          inputs:
+            SERVER_IP: { get_attribute: [TARGET, public_address] }
+          implementation: test_playbook.yml

--- a/deployments/testdata/test_service_public_types.yml
+++ b/deployments/testdata/test_service_public_types.yml
@@ -1,0 +1,99 @@
+metadata:
+  template_name: org.ystia.yorc.test.pub
+  template_version: 1.0.1
+  template_author: yorcTester2
+
+imports:
+  - <yorc-types.yml>
+
+description: >
+  This component exposes public interfaces for Test types
+node_types:
+  org.ystia.yorc.test.pub.AppAType:
+    derived_from: tosca.nodes.SoftwareComponent
+    abstract: true
+    properties:
+      appA_propABool:
+        description: >
+          Boolean property
+        type: boolean
+        required: false
+        default: false
+      appA_propBString:
+        description: >
+          String property
+        type: string
+        required: false
+        default: test
+      appA_propCInt:
+        type: integer
+        description: Integer property
+        required: true
+        default: 0
+      appA_propDInt:
+        type: integer
+        description: Integer property
+        required: true
+        default: 1
+    attributes:
+      web_ui_url:
+        description: >
+          App A Web UI URL
+        type: string
+      join_address:
+        description: >
+          Address clients can use to join this App A
+        type: string
+    capabilities:
+      appA_capA:
+        type: org.ystia.yorc.test.pub.AppACapAType
+      appA_capB:
+        type: org.ystia.yorc.test.pub.AppACapBType
+    requirements:
+      - appATOAppA:
+          capability: org.ystia.yorc.test.pub.AppACapBType
+          occurrences: [0, 1]
+
+  org.ystia.yorc.test.pub.AppBType:
+    derived_from: tosca.nodes.SoftwareComponent
+    abstract: true
+    properties:
+      appB_propAString:
+        description: >
+          String property
+        type: string
+        required: false
+        default: test
+    capabilities:
+      appB_capA:
+        type: org.ystia.yorc.test.pub.AppBCapAType
+    requirements:
+      - appA_capA:
+          capability: org.ystia.yorc.test.pub.AppACapAType
+          occurrences: [1, 1]
+
+capability_types:
+  org.ystia.yorc.test.pub.AppACapAType:
+    derived_from: tosca.capabilities.Endpoint
+    description: >
+      A capability allowing to bind to AppA.
+  org.ystia.yorc.test.pub.AppACapBType:
+    derived_from: tosca.capabilities.Endpoint
+    description: >
+      Another capability allowing to bind to AppA.
+  org.ystia.yorc.test.pub.AppBCapAType:
+    derived_from: tosca.capabilities.Endpoint
+    description: >
+      A capability allowing to bind to AppB.
+    properties:
+      api_port:
+        type: integer
+        description: Port of the Consul HTTP API.
+        required: true
+        default: 8001
+relationship_types:
+  org.ystia.yorc.test.pub.relationships.JoinAppA:
+    derived_from: tosca.relationships.ConnectsTo
+    description: >
+      Joins AppA
+valid_target_types: [ org.ystia.yorc.test.pub.AppAType ]

--- a/deployments/testdata/test_topology.yml
+++ b/deployments/testdata/test_topology.yml
@@ -1,5 +1,8 @@
 tosca_definitions_version: alien_dsl_2_0_0
-metadata: {template_name: topotest-Environment, template_version: 0.1.0-SNAPSHOT, template_author: yorcTester}
+metadata:
+  template_name: topotest-Environment
+  template_version: 0.1.0-SNAPSHOT
+  template_author: yorcTester
 description: ''
 imports:
 - file: test_container.yml

--- a/deployments/testdata/test_topology_client_service.yml
+++ b/deployments/testdata/test_topology_client_service.yml
@@ -1,0 +1,239 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: sampleClient1-Environment
+  template_version: 0.1.1
+  template_author: yorcTester
+
+description: ""
+
+imports:
+  - <yorc-types.yml>
+  - <yorc-hostspool-types.yml>
+  - test_service_public_types.yml
+  - test_client_service_private_types.yml
+  - test_client_service_generated_topology.yml
+
+topology_template:
+  node_templates:
+    ComputeInstance:
+      type: yorc.nodes.hostspool.Compute
+      properties:
+        shareable: false
+      capabilities:
+        endpoint:
+          properties:
+            credentials: 
+              user: "not significant, will be set by Yorc itself"
+            secure: true
+            protocol: tcp
+            network_name: PRIVATE
+            initiator: source
+        scalable:
+          properties:
+            min_instances: 1
+            max_instances: 1
+            default_instances: 1
+    AppBInstance:
+      type: org.ystia.yorc.test.implem.AppBType
+      requirements:
+        - hostedOnComputeHost:
+            type_requirement: host
+            node: ComputeInstance
+            capability: tosca.capabilities.Container
+            relationship: tosca.relationships.HostedOn
+        - joinServiceAppACapA:
+            type_requirement: appA_capA
+            node: AppAService
+            capability: org.ystia.yorc.test.pub.AppACapAType
+            relationship: org.ystia.yorc.test.implem.JoinAppARelType
+      capabilities:
+        appB_capA:
+          properties:
+            api_port: 8500
+            network_name: PUBLIC
+            protocol: tcp
+            secure: false
+            initiator: source
+    AppAService:
+      directives: [substitutable]
+      type: TestService
+      properties:
+        appA_propABool: true
+        appA_propBString: test1
+        appA_propCInt: 123
+      attributes:
+        join_address: "10.0.0.36"
+        state: started
+        web_ui_url: "http://10.1.2.3:8500"
+        capabilities.appA_capA.ip_address: "10.0.0.2"
+      capabilities:
+        appA_capA:
+          properties:
+            protocol: tcp
+            secure: false
+            network_name: PRIVATE
+            initiator: source
+workflows:
+    install:
+      steps:
+        AppBInstance_configured:
+          target: AppBInstance
+          activities:
+            - set_state: configured
+          on_success:
+            - AppBInstance_starting
+        AppBInstance_joinServiceAppACapA_pre_configure_source:
+          target: AppBInstance
+          target_relationship: joinServiceAppACapA
+          operation_host: SOURCE
+          activities:
+            - call_operation: Configure.pre_configure_source
+          on_success:
+            - AppBInstance_configure
+        AppBInstance_initial:
+          target: AppBInstance
+          activities:
+            - set_state: initial
+          on_success:
+            - AppBInstance_creating
+        AppBInstance_configure:
+          target: AppBInstance
+          activities:
+            - call_operation: Standard.configure
+          on_success:
+            - AppBInstance_configured
+        AppBInstance_start:
+          target: AppBInstance
+          activities:
+            - call_operation: Standard.start
+          on_success:
+            - AppBInstance_started
+        AppBInstance_create:
+          target: AppBInstance
+          activities:
+            - call_operation: Standard.create
+          on_success:
+            - AppBInstance_created
+        AppBInstance_created:
+          target: AppBInstance
+          activities:
+            - set_state: created
+          on_success:
+            - AppBInstance_configuring
+        AppBInstance_started:
+          target: AppBInstance
+          activities:
+            - set_state: started
+        AppBInstance_creating:
+          target: AppBInstance
+          activities:
+            - set_state: creating
+          on_success:
+            - AppBInstance_create
+        ComputeInstance_install:
+          target: AppBInstance
+          activities:
+            - delegate: install
+          on_success:
+            - AppBInstance_initial
+        AppBInstance_starting:
+          target: AppBInstance
+          activities:
+            - set_state: starting
+          on_success:
+            - AppBInstance_start
+        AppBInstance_configuring:
+          target: AppBInstance
+          activities:
+            - set_state: configuring
+          on_success:
+            - AppBInstance_joinServiceAppACapA_server_pre_configure_source
+        AppAService_started:
+          target: AppAService
+          activities:
+            - set_state: started
+    uninstall:
+      steps:
+        AppBInstance_stop:
+          target: AppBInstance
+          activities:
+            - call_operation: Standard.stop
+          on_success:
+            - AppBInstance_stopped
+        ComputeInstance_uninstall:
+          target: ComputeInstance
+          activities:
+            - delegate: uninstall
+        AppBInstance_stopping:
+          target: AppBInstance
+          activities:
+            - set_state: stopping
+          on_success:
+            - AppBInstance_stop
+        AppBInstance_deleted:
+          target: AppBInstance
+          activities:
+            - set_state: deleted
+          on_success:
+            - ComputeInstance_uninstall
+        AppBInstance_deleting:
+          target: AppBInstance
+          activities:
+            - set_state: deleting
+          on_success:
+            - AppBInstance_deleted
+        AppBInstance_stopped:
+          target: AppBInstance
+          activities:
+            - set_state: stopped
+          on_success:
+            - AppBInstance_deleting
+    start:
+      steps:
+        AppBInstance_started:
+          target: AppBInstance
+          activities:
+            - set_state: started
+        ComputeInstance_start:
+          target: ComputeInstance
+          activities:
+            - delegate: start
+          on_success:
+            - AppBInstance_starting
+        AppBInstance_starting:
+          target: AppBInstance
+          activities:
+            - set_state: starting
+          on_success:
+            - AppBInstance_start
+        AppBInstance_start:
+          target: AppBInstance
+          activities:
+            - call_operation: Standard.start
+          on_success:
+            - AppBInstance_started
+    stop:
+      steps:
+        AppBInstance_stop:
+          target: AppBInstance
+          activities:
+            - call_operation: Standard.stop
+          on_success:
+            - AppBInstance_stopped
+        AppBInstance_stopping:
+          target: AppBInstance
+          activities:
+            - set_state: stopping
+          on_success:
+            - AppBInstance_stop
+        AppBInstance_stopped:
+          target: AppBInstance
+          activities:
+            - set_state: stopped
+          on_success:
+            - ComputeInstance_stop
+        ComputeInstance_stop:
+          target: ComputeInstance
+          activities:
+            - delegate: stop

--- a/deployments/testdata/test_topology_service.yml
+++ b/deployments/testdata/test_topology_service.yml
@@ -1,0 +1,231 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: testService-Environment
+  template_version: 1.0.0
+  template_author: yorcTester
+
+description: "Test topology with substitution mappings"
+
+imports:
+  - <yorc-hostspool-types.yml>
+  - <yorc-types.yml>
+  - test_service_public_types.yml
+  - test_service_private_types.yml
+
+topology_template:
+  substitution_mappings:
+    node_type: org.ystia.yorc.test.pub.AppAType
+    capabilities:
+      appA_capA: [ AppAInstance, appA_capA ]
+      appA_capB:
+        properties:
+          network_name: PRIVATE
+    requirements:
+      hosted: [ AppAInstance, hostedOnComputeHost ]
+    properties:
+      aProp: [ AppAInstance, appA_propBString ]
+    attributes:
+      addrAttr: [ AppAInstance, join_address ]
+  node_templates:
+    Compute:
+      type: yorc.nodes.hostspool.Compute
+      properties:
+        shareable: false
+      capabilities:
+        endpoint:
+          properties:
+            credentials: 
+              user: "not significant, will be set by Yorc itself"
+            secure: true
+            protocol: tcp
+            network_name: PRIVATE
+            initiator: source
+        scalable:
+          properties:
+            min_instances: 1
+            max_instances: 1
+            default_instances: 1
+    AppAInstance:
+      type: org.ystia.yorc.test.implem.AppAType
+      properties:
+        appA_propABool: true
+        appA_propBString: test1
+        appA_propCInt: 123
+      requirements:
+        - hostedOnComputeHost:
+            type_requirement: host
+            node: Compute
+            capability: tosca.capabilities.Container
+            relationship: tosca.relationships.HostedOn
+      capabilities:
+        appA_capA:
+          properties:
+            api_port: 1234
+            protocol: tcp
+            secure: false
+            network_name: PRIVATE
+            initiator: source
+        appA_capB:
+          properties:
+            api_port: 5678
+            protocol: tcp
+            secure: false
+            network_name: PRIVATE
+            initiator: source
+  outputs:
+    AppAInstance_join_address:
+      value: { get_attribute: [ AppAInstance, join_address ] }
+    AppAInstance_web_ui_url:
+      value: { get_attribute: [ AppAInstance, web_ui_url ] }
+  workflows:
+    install:
+      steps:
+        AppAInstance_start:
+          target: AppAInstance
+          activities:
+            - call_operation: Standard.start
+          on_success:
+            - AppAInstance_started
+        AppAInstance_create:
+          target: AppAInstance
+          activities:
+            - call_operation: Standard.create
+          on_success:
+            - AppAInstance_created
+        AppAInstance_initial:
+          target: AppAInstance
+          activities:
+            - set_state: initial
+          on_success:
+            - AppAInstance_creating
+        AppAInstance_configure:
+          target: AppAInstance
+          activities:
+            - call_operation: Standard.configure
+          on_success:
+            - AppAInstance_configured
+        AppAInstance_started:
+          target: AppAInstance
+          activities:
+            - set_state: started
+        Compute_install:
+          target: Compute
+          activities:
+            - delegate: install
+          on_success:
+            - AppAInstance_initial
+        AppAInstance_created:
+          target: AppAInstance
+          activities:
+            - set_state: created
+          on_success:
+            - AppAInstance_configuring
+        AppAInstance_configuring:
+          target: AppAInstance
+          activities:
+            - set_state: configuring
+          on_success:
+            - AppAInstance_configure
+        AppAInstance_starting:
+          target: AppAInstance
+          activities:
+            - set_state: starting
+          on_success:
+            - AppAInstance_start
+        AppAInstance_configured:
+          target: AppAInstance
+          activities:
+            - set_state: configured
+          on_success:
+            - AppAInstance_starting
+        AppAInstance_creating:
+          target: AppAInstance
+          activities:
+            - set_state: creating
+          on_success:
+            - AppAInstance_create
+    uninstall:
+      steps:
+        AppAInstance_deleting:
+          target: AppAInstance
+          activities:
+            - set_state: deleting
+          on_success:
+            - AppAInstance_deleted
+        Compute_uninstall:
+          target: Compute
+          activities:
+            - delegate: uninstall
+        AppAInstance_deleted:
+          target: AppAInstance
+          activities:
+            - set_state: deleted
+          on_success:
+            - Compute_uninstall
+        AppAInstance_stop:
+          target: AppAInstance
+          activities:
+            - call_operation: Standard.stop
+          on_success:
+            - AppAInstance_stopped
+        AppAInstance_stopping:
+          target: AppAInstance
+          activities:
+            - set_state: stopping
+          on_success:
+            - AppAInstance_stop
+        AppAInstance_stopped:
+          target: AppAInstance
+          activities:
+            - set_state: stopped
+          on_success:
+            - AppAInstance_deleting
+    start:
+      steps:
+        AppAInstance_start:
+          target: AppAInstance
+          activities:
+            - call_operation: Standard.start
+          on_success:
+            - AppAInstance_started
+        Compute_start:
+          target: Compute
+          activities:
+            - delegate: start
+          on_success:
+            - AppAInstance_starting
+        AppAInstance_starting:
+          target: AppAInstance
+          activities:
+            - set_state: starting
+          on_success:
+            - AppAInstance_start
+        AppAInstance_started:
+          target: AppAInstance
+          activities:
+            - set_state: started
+    stop:
+      steps:
+        AppAInstance_stop:
+          target: AppAInstance
+          activities:
+            - call_operation: Standard.stop
+          on_success:
+            - AppAInstance_stopped
+        AppAInstance_stopping:
+          target: AppAInstance
+          activities:
+            - set_state: stopping
+          on_success:
+            - AppAInstance_stop
+        Compute_stop:
+          target: Compute
+          activities:
+            - delegate: stop
+        AppAInstance_stopped:
+          target: AppAInstance
+          activities:
+            - set_state: stopped
+          on_success:
+            - Compute_stop

--- a/deployments/testdata/value_assignments.yaml
+++ b/deployments/testdata/value_assignments.yaml
@@ -1,8 +1,9 @@
 tosca_definitions_version: alien_dsl_1_4_0
 description: Alien4Cloud generated service template
-template_name: ValueAssignment
-template_version: 0.1.0-SNAPSHOT
-template_author: admin
+metadata:
+  template_name: ValueAssignment
+  template_version: 0.1.0-SNAPSHOT
+  template_author: admin
 
 imports:
   - tosca-normative-types: <normative-types.yml>

--- a/helper/sshutil/sshutil.go
+++ b/helper/sshutil/sshutil.go
@@ -87,8 +87,10 @@ func (client *SSHClient) RunCommand(cmd string) (string, error) {
 	session.Stderr = &b
 	session.Stdout = &b
 
-	log.Debugf("[SSHSession] %q", cmd)
+	log.Debugf("[SSHSession] cmd:%q", cmd)
 	err = session.Run(cmd)
+
+	log.Debugf("[SSHSession] stdout/stderr:%q", b.String())
 	return strings.Trim(b.String(), "\x00"), err
 }
 

--- a/plugin/testdata/plugin-sample/main.go
+++ b/plugin/testdata/plugin-sample/main.go
@@ -53,9 +53,10 @@ func (d *myOperationExecutor) ExecOperation(ctx context.Context, cfg config.Conf
 func main() {
 	def := []byte(`tosca_definitions_version: yorc_tosca_simple_yaml_1_0
 
-template_name: yorc-my-types
-template_author: Yorc
-template_version: 1.0.0
+metadata:
+  template_name: yorc-my-types
+  template_author: Yorc
+  template_version: 1.0.0
 
 imports:
   - yorc: <yorc-types.yml>

--- a/plugin/testdata/plugin-sample/tosca/topology.yml
+++ b/plugin/testdata/plugin-sample/tosca/topology.yml
@@ -1,7 +1,9 @@
 tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
-template_name: TestPlugins
-template_version: 0.1.0-SNAPSHOT
-template_author: admin
+
+metadata:
+  template_name: TestPlugins
+  template_version: 0.1.0-SNAPSHOT
+  template_author: admin
 
 imports:
   - my-types: <my-def.yaml>

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -497,7 +497,11 @@ func (e *executionCommon) resolveContext() error {
 		execContext["TARGET_INSTANCES"] = strings.Join(targetNames, ",")
 
 		if !e.isRelationshipTargetNode && !e.isPerInstanceOperation {
-			execContext["TARGET_INSTANCE"] = targetNames[0]
+			if len(targetNames) == 0 {
+				log.Debugf("No target instance defined in context %+v", e)
+			} else {
+				execContext["TARGET_INSTANCE"] = targetNames[0]
+			}
 		} else {
 			e.VarInputsNames = append(e.VarInputsNames, "TARGET_INSTANCE")
 		}

--- a/prov/ansible/testdata/execTemplate.yml
+++ b/prov/ansible/testdata/execTemplate.yml
@@ -1,8 +1,9 @@
 tosca_definitions_version: alien_dsl_1_4_0
 description: Alien4Cloud generated service template
-template_name: ValueAssignment
-template_version: 0.1.0-SNAPSHOT
-template_author: admin
+metadata:
+  template_name: ValueAssignment
+  template_version: 0.1.0-SNAPSHOT
+  template_author: admin
 
 imports:
   - tosca-normative-types: <normative-types.yml>

--- a/prov/kubernetes/execution.go
+++ b/prov/kubernetes/execution.go
@@ -283,6 +283,16 @@ func (e *executionCommon) deployNode(ctx context.Context, nbInstances int32) err
 			log.Printf("%s : %s: %d:%d mapped to %s", serv.Name, val.Name, val.Port, val.TargetPort.IntVal, str)
 
 			s = fmt.Sprintf("%s %d ==> %s \n", s, val.Port, str)
+
+			if val.NodePort != 0 {
+				// The service is accessible to an external IP address through
+				// this port. Updating the corresponding public endpoints
+				// kubernetes port mapping
+				err := e.updatePortMappingPublicEndpoints(val.Port, h[0], val.NodePort)
+				if err != nil {
+					return errors.Wrap(err, "Failed to update endpoint capabilities port mapping")
+				}
+			}
 		}
 		err = deployments.SetAttributeForAllInstances(e.kv, e.deploymentID, e.NodeName, "k8s_service_url", s)
 		if err != nil {

--- a/prov/kubernetes/execution_service.go
+++ b/prov/kubernetes/execution_service.go
@@ -1,0 +1,102 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/ystia/yorc/deployments"
+	"github.com/ystia/yorc/log"
+	"github.com/ystia/yorc/tosca"
+)
+
+const (
+	// KubernetesServicePortMapping is the capability attribute of a public
+	// endpoint specifying the the port provided by Kubernetes to expose to
+	// external clients a docker host port.
+	// This is a capability attribute set at runtime, while the container port
+	// is a property attribute
+	KubernetesServicePortMapping = "port"
+
+	// DockerBridgePortMapping is the capability property of a endpoint
+	// specifying the docker host port associated to a container port
+	DockerBridgePortMapping = "docker_bridge_port_mapping"
+)
+
+// updatePortMappingPublicEndpoints updates public endpoint capabilities
+// referencing a given port with the Kubernetes service Port Mapping infos
+// so that this endpoint can be used by clients outside of the cluster
+func (e *executionCommon) updatePortMappingPublicEndpoints(port int32, ipAddress string, k8sPort int32) error {
+	// Get endpoint capabilities for the node
+
+	capNames, _ := deployments.GetCapabilitiesOfType(e.kv, e.deploymentID, e.NodeType, tosca.PublicEndpointCapability)
+
+	if len(capNames) == 0 {
+		// Nothing to update
+		return nil
+	}
+
+	instances, err := deployments.GetNodeInstancesIds(e.kv, e.deploymentID, e.NodeName)
+	if err != nil || len(instances) == 0 {
+		return err
+	}
+
+	// Keep instances exposing the port
+	instancesToUpdate := make([]string, 0)
+	for _, instance := range instances {
+		found, ports, err := deployments.GetInstanceAttribute(e.kv, e.deploymentID, e.NodeName, instance, "docker_ports")
+		if err != nil {
+			return err
+		}
+		if found && strings.Contains(ports, strconv.Itoa(int(port))) {
+			instancesToUpdate = append(instancesToUpdate, instance)
+		}
+
+	}
+
+	for _, instance := range instancesToUpdate {
+		for _, capName := range capNames {
+
+			// First check this is an endpoint declaring this port
+			// the port provided here is the docker mapping port, not
+			// the port in the container
+			found, result, err := deployments.GetInstanceCapabilityAttribute(e.kv, e.deploymentID,
+				e.NodeName, instance, capName, DockerBridgePortMapping)
+			if err != nil {
+				return err
+			}
+			if !found || result != strconv.Itoa(int(port)) {
+				// This endpoint is using another port
+				continue
+			}
+			err = deployments.SetInstanceCapabilityAttribute(e.deploymentID,
+				e.NodeName, instance, capName, "ip_address", ipAddress)
+			if err != nil {
+				return err
+			}
+			err = deployments.SetInstanceCapabilityAttribute(e.deploymentID,
+				e.NodeName, instance, capName, KubernetesServicePortMapping, strconv.Itoa(int(k8sPort)))
+			if err != nil {
+				return err
+			}
+			log.Debugf("Updated %s %s %s %s port mapping %d -> %s %d\n",
+				e.deploymentID, e.NodeName, instance, capName, port, ipAddress, k8sPort)
+		}
+	}
+
+	return nil
+
+}

--- a/prov/slurm/slurm_node.go
+++ b/prov/slurm/slurm_node.go
@@ -16,12 +16,13 @@ package slurm
 
 import (
 	"context"
+	"regexp"
+	"strings"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/pkg/errors"
 	"github.com/ystia/yorc/config"
 	"github.com/ystia/yorc/deployments"
-	"regexp"
-	"strings"
 )
 
 func (g *slurmGenerator) generateNodeAllocation(ctx context.Context, kv *api.KV, cfg config.Configuration, deploymentID string, nodeName, instanceName string, infra *infrastructure) error {
@@ -73,6 +74,13 @@ func (g *slurmGenerator) generateNodeAllocation(ctx context.Context, kv *api.KV,
 		return err
 	}
 	node.gres = gres
+
+	// Set the node constraint property from Tosca slurm.Compute property
+	_, constraint, err := deployments.GetNodeProperty(kv, deploymentID, nodeName, "constraint")
+	if err != nil {
+		return err
+	}
+	node.constraint = constraint
 
 	// Set the node partition property from Tosca slurm.Compute property
 	_, partition, err := deployments.GetNodeProperty(kv, deploymentID, nodeName, "partition")

--- a/prov/slurm/slurm_node_test.go
+++ b/prov/slurm/slurm_node_test.go
@@ -16,13 +16,14 @@ package slurm
 
 import (
 	"context"
+	"path"
+	"strconv"
+	"testing"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	"github.com/ystia/yorc/config"
 	"github.com/ystia/yorc/deployments"
-	"path"
-	"strconv"
-	"testing"
 )
 
 func loadTestYaml(t *testing.T, kv *api.KV) string {
@@ -45,6 +46,7 @@ func testSimpleSlurmNodeAllocation(t *testing.T, kv *api.KV, cfg config.Configur
 	require.Len(t, infrastructure.nodes, 1)
 	require.Equal(t, "0", infrastructure.nodes[0].instanceName)
 	require.Equal(t, "gpu:1", infrastructure.nodes[0].gres)
+	require.Equal(t, "[rack1|rack2|rack3|rack4]", infrastructure.nodes[0].constraint)
 	require.Equal(t, "debug", infrastructure.nodes[0].partition)
 	require.Equal(t, "2G", infrastructure.nodes[0].memory)
 	require.Equal(t, "4", infrastructure.nodes[0].cpu)
@@ -63,6 +65,7 @@ func testSimpleSlurmNodeAllocationWithoutProps(t *testing.T, kv *api.KV, cfg con
 	require.Len(t, infrastructure.nodes, 1)
 	require.Equal(t, "0", infrastructure.nodes[0].instanceName)
 	require.Equal(t, "", infrastructure.nodes[0].gres)
+	require.Equal(t, "", infrastructure.nodes[0].constraint)
 	require.Equal(t, "", infrastructure.nodes[0].partition)
 	require.Equal(t, "", infrastructure.nodes[0].memory)
 	require.Equal(t, "", infrastructure.nodes[0].cpu)
@@ -87,6 +90,7 @@ func testMultipleSlurmNodeAllocation(t *testing.T, kv *api.KV, cfg config.Config
 		require.Len(t, infrastructure.nodes, i+1)
 		require.Equal(t, istr, infrastructure.nodes[i].instanceName)
 		require.Equal(t, "gpu:1", infrastructure.nodes[i].gres)
+		require.Equal(t, "[rack1*2&rack2*4]", infrastructure.nodes[i].constraint)
 		require.Equal(t, "debug", infrastructure.nodes[i].partition)
 		require.Equal(t, "2G", infrastructure.nodes[i].memory)
 		require.Equal(t, "4", infrastructure.nodes[i].cpu)

--- a/prov/slurm/structs.go
+++ b/prov/slurm/structs.go
@@ -22,6 +22,7 @@ type nodeAllocation struct {
 	cpu          string
 	memory       string
 	gres         string
+	constraint   string
 	partition    string
 	jobName      string
 	instanceName string

--- a/prov/slurm/testdata/multipleSlurmNodeAllocation.yaml
+++ b/prov/slurm/testdata/multipleSlurmNodeAllocation.yaml
@@ -18,6 +18,7 @@ topology_template:
         partition: debug
         user: root
         gres: gpu:1
+        constraint: "[rack1*2&rack2*4]"
         job_name: xyz
       capabilities:
         host:

--- a/prov/slurm/testdata/simpleSlurmNodeAllocation.yaml
+++ b/prov/slurm/testdata/simpleSlurmNodeAllocation.yaml
@@ -18,6 +18,7 @@ topology_template:
         partition: debug
         user: root
         gres: gpu:1
+        constraint: "[rack1|rack2|rack3|rack4]"
         job_name: xyz
       capabilities:
         host:

--- a/prov/terraform/openstack/testdata/fipOSInstance.yaml
+++ b/prov/terraform/openstack/testdata/fipOSInstance.yaml
@@ -1,8 +1,9 @@
 tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
 description: Alien4Cloud generated service template
-template_name: Test
-template_version: 0.1.0-SNAPSHOT
-template_author: admin
+metadata:
+  template_name: Test
+  template_version: 0.1.0-SNAPSHOT
+  template_author: admin
 
 imports:
   - openstack-types: <yorc-openstack-types.yml>

--- a/prov/terraform/openstack/testdata/fipOSInstanceNotAllowed.yaml
+++ b/prov/terraform/openstack/testdata/fipOSInstanceNotAllowed.yaml
@@ -1,8 +1,9 @@
 tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
 description: Alien4Cloud generated service template
-template_name: Test
-template_version: 0.1.0-SNAPSHOT
-template_author: admin
+metadata:
+  template_name: Test
+  template_version: 0.1.0-SNAPSHOT
+  template_author: admin
 
 imports:
   - openstack-types: <yorc-openstack-types.yml>

--- a/prov/terraform/openstack/testdata/simpleOSInstance.yaml
+++ b/prov/terraform/openstack/testdata/simpleOSInstance.yaml
@@ -1,8 +1,9 @@
 tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
 description: Alien4Cloud generated service template
-template_name: Test
-template_version: 0.1.0-SNAPSHOT
-template_author: admin
+metadata:
+  template_name: Test
+  template_version: 0.1.0-SNAPSHOT
+  template_author: admin
 
 imports:
   - openstack-types: <yorc-openstack-types.yml>

--- a/tosca/capabilities.go
+++ b/tosca/capabilities.go
@@ -14,6 +14,15 @@
 
 package tosca
 
+const (
+	// EndpointCapability is the default TOSCA type that should be used or
+	// extended to define a network endpoint capability.
+	EndpointCapability = "tosca.capabilities.Endpoint"
+
+	// PublicEndpointCapability represents a public endpoint.
+	PublicEndpointCapability = "tosca.capabilities.Endpoint.Public"
+)
+
 // An CapabilityDefinition is the representation of a TOSCA Capability Definition
 //
 // See http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.2/TOSCA-Simple-Profile-YAML-v1.2.html#DEFN_ELEMENT_CAPABILITY_DEFN for more details

--- a/tosca/imports.go
+++ b/tosca/imports.go
@@ -64,12 +64,11 @@ func (i *ImportDefinition) UnmarshalYAML(unmarshal func(interface{}) error) erro
 			i.NamespaceURI = str.NamespaceURI
 			i.NamespacePrefix = str.NamespacePrefix
 			return nil
-		} else {
-			// This entry is not compatible with the latest TOSCA specification.
-			// But the error is not returned yet, if ever the entry is
-			// compatible with a previous TOSCA specification
-			unmarshalError = errors.New("Missing required key 'file' in import definition")
 		}
+		// This entry is not compatible with the latest TOSCA specification.
+		// But the error is not returned yet, if ever the entry is
+		// compatible with a previous TOSCA specification
+		unmarshalError = errors.New("Missing required key 'file' in import definition")
 	}
 
 	// Additional case for backward compatibility with TOSCA 1.0 specification:

--- a/tosca/parse_test.go
+++ b/tosca/parse_test.go
@@ -23,12 +23,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
 
 func TestGroupedParsingParallel(t *testing.T) {
 	t.Run("groupParsing", func(t *testing.T) {
 		t.Run("TestParsing", parsing)
+		t.Run("TestSubsitutionMappingsParsing", parsingSubstitutionMappings)
 	})
 }
 
@@ -52,9 +54,9 @@ func parsing(t *testing.T) {
 	// Check Topology types
 	assert.Equal(t, "tosca_simple_yaml_1_0_0_wd03", topology.TOSCAVersion)
 	assert.Equal(t, "Alien4Cloud generated service template", topology.Description)
-	assert.Equal(t, "Test", topology.Name)
-	assert.Equal(t, "0.1.0-SNAPSHOT", topology.Version)
-	assert.Equal(t, "admin", topology.Author)
+	assert.Equal(t, "Test", topology.Metadata[TemplateName])
+	assert.Equal(t, "0.1.0-SNAPSHOT", topology.Metadata[TemplateVersion])
+	assert.Equal(t, "admin", topology.Metadata[TemplateAuthor])
 
 	assert.Len(t, topology.Imports, 1)
 	importDef := topology.Imports[0]
@@ -133,4 +135,127 @@ func parsing(t *testing.T) {
 	assert.Equal(t, "", computeUninstallStep.Activities[0].CallOperation)
 	assert.Equal(t, "", computeUninstallStep.Activities[0].SetState)
 	assert.Equal(t, "uninstall", computeUninstallStep.Activities[0].Delegate)
+}
+
+func parsingSubstitutionMappings(t *testing.T) {
+	t.Parallel()
+	definition, err := os.Open(filepath.Join("testdata", "test_substitution.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defBytes, err := ioutil.ReadAll(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	topology := Topology{}
+	err = yaml.Unmarshal(defBytes, &topology)
+	require.NoError(t, err, "Unexpected failure unmarshalling topology with substitution mappings")
+
+	//log.Printf("%+v\n\n%#v\n", topology, topology)
+
+	// Check Topology types
+	assert.Equal(t, "TestService", topology.Metadata[TemplateName])
+
+	mappings := topology.TopologyTemplate.SubstitionMappings
+	assert.Equal(t, "org.test.SoftwareAType", mappings.NodeType)
+	assert.Equal(t, 4, len(mappings.Properties),
+		"Wrong number of properties substitutions")
+
+	// Check property substitutions
+	assert.Equal(t, 0, len(mappings.Properties["propertyA"].Mapping),
+		"Unexpected mapping found for propertyA")
+	assert.Equal(t, ValueAssignmentLiteral, mappings.Properties["propertyA"].Value.Type,
+		"Unexpected value type for propertyA")
+	require.Equal(t, 2, len(mappings.Properties["propertyB"].Mapping),
+		"Wrong number of propertyB mapping")
+	assert.Equal(t, "ServerAInstance", mappings.Properties["propertyB"].Mapping[0],
+		"Wrong node template in propertyB mapping")
+	assert.Equal(t, "propertyB", mappings.Properties["propertyB"].Mapping[1],
+		"Wrong property in propertyB mapping")
+	assert.Equal(t, 0, len(mappings.Properties["propertyC"].Mapping),
+		"Unexpected mapping found for propertyC")
+	assert.Equal(t, ValueAssignmentLiteral, mappings.Properties["propertyC"].Value.Type,
+		"Unexpected value type for propertyC %+v", mappings.Properties["propertyC"].Value)
+	require.Equal(t, 2, len(mappings.Properties["propertyD"].Mapping),
+		"Wrong number of propertyD mapping")
+	assert.Equal(t, "ServerAInstance", mappings.Properties["propertyD"].Mapping[0],
+		"Wrong node template in propertyD mapping")
+	assert.Equal(t, "propertyD", mappings.Properties["propertyD"].Mapping[1],
+		"Wrong property in propertyD mapping")
+
+	// Check attributes substitutions
+	assert.Equal(t, 0, len(mappings.Attributes["attributesA"].Mapping),
+		"Unexpected mapping found for attributeA")
+	assert.Equal(t, ValueAssignmentLiteral, mappings.Attributes["attributeA"].Value.Type,
+		"Unexpected mapping found for attributeA")
+	require.Equal(t, 2, len(mappings.Attributes["attributeB"].Mapping),
+		"Wrong number of attributeB mapping")
+	assert.Equal(t, "ServerAInstance", mappings.Attributes["attributeB"].Mapping[0],
+		"Wrong node template in attributeB mapping")
+	assert.Equal(t, "attributeB", mappings.Attributes["attributeB"].Mapping[1],
+		"Wrong attribute in attributeB mapping")
+	assert.Equal(t, 0, len(mappings.Attributes["attributeC"].Mapping),
+		"Unexpected mapping found for attributeC")
+	assert.Equal(t, ValueAssignmentLiteral, mappings.Attributes["attributeC"].Value.Type,
+		"Unexpected value type for attributeC")
+	require.Equal(t, 2, len(mappings.Attributes["attributeD"].Mapping),
+		"Wrong number of attributeD mapping")
+	assert.Equal(t, "ServerAInstance", mappings.Attributes["attributeD"].Mapping[0],
+		"Wrong node template in attributeD mapping")
+	assert.Equal(t, "attributeD", mappings.Attributes["attributeD"].Mapping[1],
+		"Wrong attribute in attributeD mapping")
+
+	// Check capabilities substitutions
+	require.Equal(t, 3, len(mappings.Capabilities),
+		"Unexpected number of capabilities mapping")
+	require.Equal(t, 2, len(mappings.Capabilities["capabilityA"].Mapping),
+		"Unexpected size of Mapping for capabilityA")
+	assert.Equal(t, "ServerAInstance", mappings.Capabilities["capabilityA"].Mapping[0],
+		"Wrong node template in capabilityA mapping")
+	assert.Equal(t, "capabilityA", mappings.Capabilities["capabilityA"].Mapping[1],
+		"Wrong capability in capabilityA mapping")
+	assert.Equal(t, 0, len(mappings.Capabilities["capabilityA"].Properties),
+		"Unexpected size of Properties Mapping for capabilityA")
+	assert.Equal(t, 0, len(mappings.Capabilities["capabilityA"].Attributes),
+		"Unexpected size of Attributes Mapping for capabilityA")
+	require.Equal(t, 2, len(mappings.Capabilities["capabilityB"].Mapping),
+		"Unexpected size of Mapping for capabilityB")
+	assert.Equal(t, "ServerAInstance", mappings.Capabilities["capabilityB"].Mapping[0],
+		"Wrong node template in capabilityB mapping")
+	assert.Equal(t, "capabilityB", mappings.Capabilities["capabilityB"].Mapping[1],
+		"Wrong capability in capabilityB mapping")
+	require.Equal(t, 1, len(mappings.Capabilities["capabilityC"].Properties),
+		"Unexpected size of Properties Mapping for capabilityC")
+	assert.Equal(t, ValueAssignmentLiteral, mappings.Capabilities["capabilityC"].Properties["propertyA"].Type,
+		"Unexpected value type for capabilityC propertyA mapping")
+	require.Equal(t, 1, len(mappings.Capabilities["capabilityC"].Attributes),
+		"Unexpected size of Attributes Mapping for capabilityC")
+	assert.Equal(t, ValueAssignmentLiteral, mappings.Capabilities["capabilityC"].Attributes["attributeA"].Type,
+		"Unexpected value type for capabilityC attributeA mapping")
+
+	// Check requirements substitutions
+	require.Equal(t, 2, len(mappings.Requirements),
+		"Unexpected number of requirements mapping")
+	require.Equal(t, 2, len(mappings.Requirements["requirementA"].Mapping),
+		"Unexpected size of Mapping for requirementA")
+	assert.Equal(t, "ServerAInstance", mappings.Requirements["requirementA"].Mapping[0],
+		"Wrong node template in requirementA mapping")
+	assert.Equal(t, "requirementA", mappings.Requirements["requirementA"].Mapping[1],
+		"Wrong requirement in requirementA mapping")
+	assert.Equal(t, 0, len(mappings.Requirements["requirementA"].Properties),
+		"Unexpected size of Properties Mapping for requirementA")
+	assert.Equal(t, 0, len(mappings.Requirements["requirementA"].Attributes),
+		"Unexpected size of Attributes Mapping for requirementA")
+	require.Equal(t, 2, len(mappings.Requirements["requirementB"].Mapping),
+		"Unexpected size of Mapping for requirementB")
+	assert.Equal(t, "ServerAInstance", mappings.Requirements["requirementB"].Mapping[0],
+		"Wrong node template in requirementB mapping")
+	assert.Equal(t, "requirementB", mappings.Requirements["requirementB"].Mapping[1],
+		"Wrong requirement in requirementB mapping")
+
+	// Check interfaces mappings
+	require.Equal(t, 2, len(mappings.Interfaces),
+		"Unexpected number of interfaces mapping")
+	assert.Equal(t, "workflowA", mappings.Interfaces["operationA"],
+		"Wrong workflow name in operationA interface mapping")
 }

--- a/tosca/substitution_mapping.go
+++ b/tosca/substitution_mapping.go
@@ -1,0 +1,193 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tosca
+
+import (
+	"github.com/pkg/errors"
+)
+
+// SubstitutionMapping allows to create a node type out of a given topology
+// template. This allows the consumption of complex systems using a simplified
+// vision.
+//
+// See http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.2/TOSCA-Simple-Profile-YAML-v1.2.html
+// section 3.8.12 Substitution mapping
+type SubstitutionMapping struct {
+	NodeType     string                     `yaml:"node_type"`
+	Properties   map[string]PropAttrMapping `yaml:"properties,omitempty"`
+	Capabilities map[string]CapReqMapping   `yaml:"capabilities,omitempty"`
+	Requirements map[string]CapReqMapping   `yaml:"requirements,omitempty"`
+	Attributes   map[string]PropAttrMapping `yaml:"attributes,omitempty"`
+	Interfaces   map[string]string          `yaml:"interfaces,omitempty"`
+}
+
+// PropAttrMapping defines a property or attribute mapping.
+// It accepts several grammars.
+//
+// - Single-line grammar:
+//   <property_name>: <property_value>
+//   or
+//   <property_name>: [ <input_name> ]
+//   or
+//   <property_name>: [ <node_template_name>, <node_template_property_name> ]
+//   or
+//   <property_name>: [ <node_template_name>, <node_template_capability_name> | <node_template_requirement_name>, <property_name> ]
+//
+// - Multi-line grammar:
+//   <property_name>:
+//     mapping: [ < input_name > ]
+//   or
+//   <property_name>:
+//     mapping: [ <node_template_name>, <node_template_property_name> ]
+//   or
+//   <property_name>:
+//     mapping: [ <node_template_name>, <node_template_capability_name> | <node_template_requirement_name>, <property_name> ]
+//   or
+//   <property_name>:
+//     value: <property_value>
+//
+// See http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.2/TOSCA-Simple-Profile-YAML-v1.2.html
+// section 3.8.8 Property mapping
+type PropAttrMapping struct {
+	Mapping []string         `yaml:"mapping,omitempty,flow"`
+	Value   *ValueAssignment `yaml:"value,omitempty"`
+}
+
+// UnmarshalYAML unmarshals a yaml into a PropAttrMapping
+func (p *PropAttrMapping) UnmarshalYAML(unmarshal func(interface{}) error) error {
+
+	// Multi-line grammar check.
+	// Example:
+	// my_property:
+	//   mapping: [node1, property1]
+	// or
+	// my_property:
+	//   value: 1
+	var str struct {
+		Mapping []string `yaml:"mapping,flow"`
+	}
+
+	if err := unmarshal(&str); err == nil {
+		mappingSize := len(str.Mapping)
+		if mappingSize != 0 {
+			p.Mapping = str.Mapping
+			if mappingSize > 3 {
+				return errors.Errorf("Mapping should between 1 and 3 elements: %v", p.Mapping)
+			}
+			return nil
+		}
+	}
+
+	var str2 struct {
+		Value *ValueAssignment `yaml:"value"`
+	}
+
+	if err := unmarshal(&str2); err == nil && str2.Value != nil {
+		p.Value = str2.Value
+		return nil
+	}
+
+	// Single-line grammar check.
+	// Example of property mapping using this format:
+	//   my_property: [node1, property1]
+	// or
+	//   my_property: true
+	//var mapping []string
+
+	var mapping []string
+	if err := unmarshal(&mapping); err == nil && len(mapping) > 0 {
+		p.Mapping = mapping
+		return nil
+	}
+
+	var valueAssignment ValueAssignment
+	err := unmarshal(&valueAssignment)
+	if err == nil {
+		p.Value = &valueAssignment
+	}
+
+	return err
+}
+
+// CapReqMapping defines a capability mapping or a requirement mapping.
+// It accepts two grammars.
+//
+// - Single-line grammar:
+//   <capability_name>: [ <node_template_name>, <node_template_capability_name> ]
+//
+// - Multi-line grammar:
+//   <capability_name>:
+//      mapping: [ <node_template_name>, <node_template_capability_name> ]
+//   <capability_name>:
+//      properties:
+//        <property_name>: <property_value>
+//      attributes:
+//        <attribute_name>: <attribute_value>
+//
+// See http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.2/TOSCA-Simple-Profile-YAML-v1.2.html
+// section 3.8.9 Capability mapping and 3.8.10 Requirement mapping
+type CapReqMapping struct {
+	Mapping    []string                    `yaml:"mapping,omitempty,flow"`
+	Properties map[string]*ValueAssignment `yaml:"properties,omitempty"`
+	Attributes map[string]*ValueAssignment `yaml:"attributes,omitempty"`
+}
+
+// UnmarshalYAML unmarshals a yaml into a CapReqMapping
+func (c *CapReqMapping) UnmarshalYAML(unmarshal func(interface{}) error) error {
+
+	// First case, single-line grammar.
+	// Example of capability mapping using this format:
+	// exported_capability: [node1, internal_capability]
+	var mapping []string
+	if err := unmarshal(&mapping); err == nil && len(mapping) > 0 {
+		c.Mapping = mapping
+	} else {
+
+		// Second case, multi-line grammar.
+		// Example:
+		// exported_capability:
+		//   mapping: [node1, internal_capability]
+		// or
+		// exported_capability:
+		//   properties:
+		//     property1: value1
+		var str struct {
+			Mapping []string `yaml:"mapping,flow"`
+		}
+
+		if err := unmarshal(&str); err == nil && len(str.Mapping) > 0 {
+			c.Mapping = str.Mapping
+		} else {
+
+			var str2 struct {
+				Properties map[string]*ValueAssignment `yaml:"properties,omitempty"`
+				Attributes map[string]*ValueAssignment `yaml:"attributes,omitempty"`
+			}
+
+			if err := unmarshal(&str2); err == nil {
+				c.Properties = str2.Properties
+				c.Attributes = str2.Attributes
+			} else {
+				return err
+			}
+		}
+	}
+
+	if len(c.Mapping) > 0 && len(c.Mapping) != 2 {
+		return errors.Errorf("Mapping should have 2 elements: %v", c.Mapping)
+	}
+
+	return nil
+}

--- a/tosca/testdata/dep.yaml
+++ b/tosca/testdata/dep.yaml
@@ -1,8 +1,9 @@
 tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
 description: Alien4Cloud generated service template
-template_name: Test
-template_version: 0.1.0-SNAPSHOT
-template_author: admin
+metadata:
+  template_name: Test
+  template_version: 0.1.0-SNAPSHOT
+  template_author: admin
 
 imports:
   - tosca-normative-types: 1.0.0-ALIEN11

--- a/tosca/testdata/test_substitution.yaml
+++ b/tosca/testdata/test_substitution.yaml
@@ -1,0 +1,85 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: TestService
+  template_version: 0.1.0-SNAPSHOT
+  template_author: yorcTester
+
+description: "Test Service"
+topology_template:
+  substitution_mappings:
+    node_type: org.test.SoftwareAType
+    properties:
+      propertyA: 1
+      propertyB: [ ServerAInstance, propertyB ]
+      propertyC:
+        value: 3
+      propertyD:
+        mapping: [ ServerAInstance, propertyD ]
+    attributes:
+      attributeA: 1
+      attributeB: [ ServerAInstance, attributeB ]
+      attributeC:
+        value: 3
+      attributeD:
+        mapping: [ ServerAInstance, attributeD ]
+    capabilities:
+      capabilityA: [ ServerAInstance, capabilityA ]
+      capabilityB:
+        mapping: [ ServerAInstance, capabilityB ]
+      capabilityC:
+        properties:
+          propertyA: 1
+        attributes:
+          attributeA: 1
+    requirements:
+      requirementA: [ ServerAInstance, requirementA ]
+      requirementB:
+        mapping: [ ServerAInstance, requirementB ]
+    interfaces:
+      operationA: workflowA
+      operationB: wokrflowB
+  node_templates:
+    ServerAInstance:
+      type: org.test.ServerAType
+      properties:
+        propertyA: 1
+        propertyB: 2
+        propertyC: 3
+        propertyD: 4
+      attributes:
+        attributeA: 1
+        attributeB: 2
+        attributeC: 3
+        attributeD: 4
+      capabilities:
+        capabilityA:
+          properties:
+            propertyA: 1
+            propertyB: 2
+          attributes:
+            attributeA: 1
+            attributeB: 2
+        capabilityB:
+          properties:
+            propertyA: 1
+            propertyB: 2
+          attributes:
+            attributeA: 1
+            attributeB: 2
+        capabilityC:
+          properties:
+            propertyA: 1
+            propertyB: 2
+          attributes:
+            attributeA: 1
+            attributeB: 2
+      requirements:
+        - requirementA:
+            node: ServerAInstance
+            capability: SeverACapabilityA
+            relationship: tosca.relationships.HostedOn
+        - requirementB:
+            node: SoftBInstance
+            capability: SoftBBCapabilityB
+            relationship: relationshipA

--- a/tosca/topology.go
+++ b/tosca/topology.go
@@ -14,15 +14,25 @@
 
 package tosca
 
+const (
+	// TemplateName is the optional descriptive name for the template provided
+	// in the template metadata
+	TemplateName = "template_name"
+	// TemplateVersion is the optional version for the template provided in the
+	// template metadata
+	TemplateVersion = "template_version"
+	// TemplateAuthor is the optional declaration of the author of the template
+	// provided in the template metadata
+	TemplateAuthor = "template_author"
+)
+
 // An Topology is the representation of a TOSCA Service Template definition
 //
 // See http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.2/TOSCA-Simple-Profile-YAML-v1.2.html#DEFN_ELEMENT_SERVICE_TEMPLATE for more details
 type Topology struct {
-	TOSCAVersion string `yaml:"tosca_definitions_version"`
-	Description  string `yaml:"description,omitempty"`
-	Name         string `yaml:"template_name"`
-	Version      string `yaml:"template_version"`
-	Author       string `yaml:"template_author"`
+	TOSCAVersion string            `yaml:"tosca_definitions_version"`
+	Description  string            `yaml:"description,omitempty"`
+	Metadata     map[string]string `yaml:"metadata,omitempty"`
 
 	Imports []ImportDefinition `yaml:"imports,omitempty"`
 
@@ -43,15 +53,15 @@ type Topology struct {
 //
 // See http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.2/TOSCA-Simple-Profile-YAML-v1.2.html#DEFN_ENTITY_TOPOLOGY_TEMPLATE for more details
 type TopologyTemplate struct {
-	Description   string                         `yaml:"description,omitempty"`
-	Inputs        map[string]ParameterDefinition `yaml:"inputs,omitempty"`
-	NodeTemplates map[string]NodeTemplate        `yaml:"node_templates"`
+	Description        string                         `yaml:"description,omitempty"`
+	Inputs             map[string]ParameterDefinition `yaml:"inputs,omitempty"`
+	NodeTemplates      map[string]NodeTemplate        `yaml:"node_templates"`
+	Outputs            map[string]ParameterDefinition `yaml:"outputs,omitempty"`
+	SubstitionMappings *SubstitutionMapping           `yaml:"substitution_mappings,omitempty"`
+	Workflows          map[string]Workflow
 	//RelationshipTemplates []RelationshipTemplate `yaml:"relationship_templates,omitempty"`
 	//Groups                []Group `yaml:",omitempty"`
 	//Policies              []Policy                 `yaml:",omitempty"`
-	Outputs map[string]ParameterDefinition `yaml:"outputs,omitempty"`
-	//substitution_mappings
-	Workflows map[string]Workflow
 }
 
 // An NodeTemplate is the representation of a TOSCA Node Template


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fixing an issue where the orchestrator got an empty output from a ssh command, while the output is not empty.
Should be related to a concurrency issue on a buffer used for both stdout and stderr in go func session.Run().

### What I did

Replacing the call session.Run() by a call to session.CombinedOutput() taking care of managing the write exclusive access to the buffer used for both stdout an stderr.

### How to verify it

Install Alien4Cloud 2.0.0 and a Yorc Orchestrator from this branch.
From Alien4Cloud, configure a Slurm location with an on-demand resource yorc.nodes.slurm.Compute.
Create a simple application with just a Compute node.
Deploy/Undeploy this application 10 times, and check each deployment/undeployment was successful.

