### PR TITLE
Supporting both fully qualified and short standard operation names

### DIFF
--- a/prov/kubernetes/execution.go
+++ b/prov/kubernetes/execution.go
@@ -110,9 +110,9 @@ func (e *executionCommon) execute(ctx context.Context) (err error) {
 	nbInstances := int32(len(instances))
 
 	// Supporting both fully qualified and short standard operation names, ie.
-	// - tosca.interfaces.node.lifecycle.standard.XXX
+	// - tosca.interfaces.node.lifecycle.standard.operation
 	// or
-	// - standard.XXX
+	// - standard.operation
 	operationName := strings.TrimPrefix(strings.ToLower(e.Operation.Name),
 		"tosca.interfaces.node.lifecycle.")
 	switch operationName {

--- a/prov/kubernetes/execution.go
+++ b/prov/kubernetes/execution.go
@@ -108,12 +108,18 @@ func (e *executionCommon) execute(ctx context.Context) (err error) {
 	ctx = context.WithValue(ctx, "generator", newGenerator(e.kv, e.cfg))
 	instances, err := tasks.GetInstances(e.kv, e.taskID, e.deploymentID, e.NodeName)
 	nbInstances := int32(len(instances))
-	switch strings.ToLower(e.Operation.Name) {
-	case "tosca.interfaces.node.lifecycle.standard.delete",
-		"tosca.interfaces.node.lifecycle.standard.configure":
+
+	// Supporting both fully qualified and short standard operation names, ie.
+	// - tosca.interfaces.node.lifecycle.standard.XXX
+	// or
+	// - standard.XXX
+	operationName := strings.TrimPrefix(strings.ToLower(e.Operation.Name),
+		"tosca.interfaces.node.lifecycle.")
+	switch operationName {
+	case "standard.delete", "standard.configure":
 		log.Printf("Voluntary bypassing operation %s", e.Operation.Name)
 		return nil
-	case "tosca.interfaces.node.lifecycle.standard.start":
+	case "standard.start":
 		if e.taskType == tasks.ScaleOut {
 			log.Println("##### Scale up node !")
 			err = e.scaleNode(ctx, tasks.ScaleOut, nbInstances)
@@ -125,7 +131,7 @@ func (e *executionCommon) execute(ctx context.Context) (err error) {
 			return err
 		}
 		return e.checkNode(ctx)
-	case "tosca.interfaces.node.lifecycle.standard.stop":
+	case "standard.stop":
 		if e.taskType == tasks.ScaleIn {
 			log.Println("##### Scale down node !")
 			return e.scaleNode(ctx, tasks.ScaleIn, nbInstances)


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fixing a deployment error attempting to deploy a container on k8s :
```
Unsupported operation "standard.start" 
```

### What I did

The back-end code was expecting the fully qualified name ```tosca.interfaces.node.lifecycle.standard.start``` for the operation, and considered the short name ```standard.start``` as an unsupported operation.

Updated the code to accept both the fully qualified name and the short name for standard operations.


### How to verify it

Upload in Alien4Cloud the archive ```mysql-yorc-csar.zip``` in attachment below.
Create a topology template using the type yorc.nodes.Docker.MySQL defined in this archive, and attempt to deploy this template on a Kubernetes location.
The deployment should be successful.
[mysql-yorc-csar.zip](https://github.com/ystia/yorc/files/2001761/mysql-yorc-csar.zip)


