### PR TITLE
Managing complex types for custom command inputs

### DIFF
--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -185,8 +185,20 @@ Executes a custom command for a given node of a deployment <DeploymentId>.
 Flags:                                                                                                                                                        
   * ``-c``, ``--custom``: Provide the custom command name (use with flag n and i)                                                                       
   * ``-d``, ``--data``: Need to provide the JSON format of the custom command                                                                         
-  * ``-i``, ``--inputsMap``: Provide the input for the custom command (use with flag c and n)                                                              
-  * ``-n``, ``--node``: Provide the node name (use with flag c and i)           
+  * ``-i``, ``--input``: Provide the input for the custom command (use with flag c and n)
+  * ``-n``, ``--node``: Provide the node name (use with flag c and i)
+
+Example using ``--input`` flags:
+
+.. code-block:: bash
+
+     yorc deployments custom deployID --custom cmdName --node nodeName --input 'key1=["value1","value2"]' --input 'key2="value3"'
+
+Example using ``--data`` flag:
+
+.. code-block:: bash
+
+     yorc deployments custom deployID --data '{"name":"cmdName","node":"nodeName","inputs":{"key1":["value1","value2"],"key2":"value3"}}'
 
 
 List workflows of a given deployment

--- a/rest/dep_custom.go
+++ b/rest/dep_custom.go
@@ -72,7 +72,7 @@ func (s *Server) newCustomCommandHandler(w http.ResponseWriter, r *http.Request)
 		if err != nil {
 			log.Panic(err)
 		}
-		data[path.Join("inputs", name)] = inputMap.Inputs[name]
+		data[path.Join("inputs", name)] = inputMap.Inputs[name].String()
 	}
 
 	taskID, err := s.tasksCollector.RegisterTaskWithData(id, tasks.CustomCommand, data)

--- a/rest/structs.go
+++ b/rest/structs.go
@@ -161,9 +161,9 @@ type Attribute struct {
 
 // CustomCommandRequest is the representation of a request to process a Custom Command
 type CustomCommandRequest struct {
-	NodeName          string            `json:"node"`
-	CustomCommandName string            `json:"name"`
-	Inputs            map[string]string `json:"inputs"`
+	NodeName          string                            `json:"node"`
+	CustomCommandName string                            `json:"name"`
+	Inputs            map[string]*tosca.ValueAssignment `json:"inputs"`
 }
 
 // WorkflowsCollection is a collection of workflows links


### PR DESCRIPTION
# Pull Request description

## Description of the change

Managing complex types for custom command interface inputs

### What I did

Updated the REST api and CLI to change the type used for input key/values (map[string][string) and use instead type map[string]*ValueAssignment.
Updated the CLI custom input argument to be able to deal with non-string values.
Added an example of CLI usage in the doc.

### How to verify it


From alien4Cloud, upload the types archive:  
[liststrings-types-csar.zip](https://github.com/ystia/yorc/files/2012246/liststrings-types-csar.zip)
and the topology archive:  
[liststrings-topo-csar.zip](https://github.com/ystia/yorc/files/2012247/liststrings-topo-csar.zip)

Create an application using the topology template TopoCT and deploy it on an OpenStack location.

#### Execute a custom command from Alien4Cloud UI

Once the application is deployed, select its ```Runtime View``` in Alien4Cloud, select the component ```CT```.
A ```Details``` column appears, showing an operation ```custom.change_kw```.
Expand this operation, it shows an attribute ```KEYWORDS```. Click on the edit button and add three items:
  * blue
  * white
  * red

Once done, close the edit dialog, and click on the Operation Execute action.
Check deployment logs, you should see the following outputs when the operation is executed.
```
====> Begin change-kw
KEYWORDS=["blue", "white", "red"]
CT_0_KEYWORDS=["blue", "white", "red"]
====< End   change-kw
```
#### Execute a custom command using the orchestrator CLI

Execute the custom command with the ```--data``` flag (no change in this pull request) :
```
yorc d custom myCT-Environment --data '{"node":"CT","inputs":{"KEYWORDS":["green","blue"]},"name":"change_kw"}'
```
Check deployment logs to see the output about new KEYWORDS values.

Execute another custom command using the flag ```--input``` changed in this pull request : 
```
yorc d custom myCT-Environment --custom change_kw --node CT --input 'KEYWORDS=["orange","yellow"]'
```
Check deployment logs to see the output about new KEYWORDS values.



