### PR TITLE
Initializing ProvisioningAdmin endpoint credentials user property

### DIFF
--- a/data/tosca/yorc-slurm-types.yml
+++ b/data/tosca/yorc-slurm-types.yml
@@ -36,3 +36,9 @@ node_types:
       partition:
         type: string
         description: Slurm partition where the nodes are deployed.
+    capabilities:
+      endpoint:
+        type: yorc.capabilities.Endpoint.ProvisioningAdmin
+        properties:
+          credentials:
+            user: "not significant, will be set by the orchestrator"


### PR DESCRIPTION
# Pull Request description

## Description of the change

When adding a yorc.nodes.slurm.Compute on-demand resource to a Slurm location,
the user had to initialize the ProvisioningAdmin endpoint credentials user property of this resource, else an application deployment will be refused by Alien4Cloud with the error that a required property capabilities[endpoint].credentials is missing for the Compute node of type yorc.nodes.slurm.Compute.
As a workaround the user can set this value to any value, but it should not be requested as this value will be ignored anyway.

### What I did

Similarly to what is done for yorc.nodes.hostspool.Compute node type,
changed yorc.nodes.slurm.Compute node type definition to assign a value to the ProvisioningAdmin endpoint credentials user property
The value is set to "not significant, will be set by the orchestrator".

### How to verify it

Use in conjunction with Yorc Alien4Cloud plugin pull request https://github.com/ystia/yorc-a4c-plugin/pull/20

Create a slurm location, add a yorc.nodes.hostspool.Compute on-demand resource, create a basic application containing a Compute node, deploy it on the slurm location
