### PR TITLE
Feature/brbdcf 1302 gcp compute instance deployment

### DIFF
--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -69,6 +69,12 @@ node_types:
           keys startup-script or startup-script-url can be used to specify a script
           that will be executed by the Compute Node once it starts running.
         required: false
+      address:
+        type: string
+        description: >
+          Assigns the given external address to the instance.
+          If not specified, and no_address is not true, an ephemeral IP address will be assigned.
+        required: false
       no_address:
         type: boolean
         description: >

--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -1,0 +1,101 @@
+tosca_definitions_version: yorc_tosca_simple_yaml_1_0
+
+metadata:
+  template_name: yorc-google-types
+  template_author: yorc
+  template_version: 1.0.0
+
+imports:
+  - yorc: <yorc-types.yml>
+
+node_types:
+  yorc.nodes.google.Compute:
+    derived_from: yorc.nodes.Compute
+    description: >
+      Google Compute Engine Virtual Machine (Compute Instance)
+    properties:
+      # See defintions at:
+      # https://cloud.google.com/compute/docs/reference/rest/v1/instances
+      imageProject:
+        type: string
+        description: >
+          The project against which all image and image family references will be
+          resolved.
+          If not specified, and either image or imageFamily is provided, the current
+          default project is used.
+        required: false
+      imageFamily:
+        type: string
+        description: >
+          The family of the image that the boot disk will be initialized with.
+          When a family is specified instead of an image, the latest non-deprecated 
+          image associated with that family is used.
+        required: false
+      image:
+        type: string
+        description: >
+          Boot image for the instance.
+          If not specified, and an image family is specified, the latest 
+          non-deprecated image associated with that family is used.
+        required: false
+      machineType:
+        type: string
+        description: >
+          The machine type used for the Compute Node, defining the Compute Node 
+          CPU and Memory resources.
+        default: n1-standard-1
+      zone:
+        type: string
+        description: >
+          The zone on which the Compute Node should be hosted.
+      description:
+        type: string
+        description: >
+          Textual description of this Compute Node.
+        required: false
+      labels:
+        type: string
+        description: >
+          Comma-separated list of label KEY=VALUE pairs to assign to the Compute Node. 
+        required: false
+      metadata:
+        type: string
+        description: >
+          Comma-separated list of label KEY=VALUE pairs made available to the
+          Compute Node Operating System. On Google official images, the metadata
+          keys startup-script or startup-script-url can be used to specify a script
+          that will be executed by the Compute Node once it starts running.
+        required: false
+      noAddress:
+        type: boolean
+        description: >
+        If set to true, the instance will not be assigned an external IP address
+        required: false
+      preemptible:
+        type: boolean
+        description: >
+        If set to true, the Compute Node is preemptible and time-limited.
+        required: false
+      scopes:
+        type: string
+        description: >
+          Comma-separated list of service scopes defining access to Google Cloud APIs.
+          A scope can be either the full URI of the scope or an alias, like default 
+          or cloud-platform.
+        required: false
+        default: default
+      serviceAccount:
+        type: string
+        description: >
+          Service Account (e-mail or alias) to attach to the Compute Node.
+          If not provided, the Compute Node will get the project default service
+          account. 
+        required: false
+      tags:
+        type: string
+        description: >
+          Comma-separated list of tags to apply to the instances for identifying
+          the instances to which network firewall rules will apply.
+        required: false
+
+      

--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -14,7 +14,7 @@ node_types:
     description: >
       Google Compute Engine Virtual Machine (Compute Instance)
     properties:
-      # See defintions at:
+      # See definitions at:
       # https://cloud.google.com/compute/docs/reference/rest/v1/instances
       imageProject:
         type: string

--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -28,7 +28,7 @@ node_types:
       image_family:
         type: string
         description: >
-          The family of the image that the boot disk will be initialized with.
+          The family of the image from which to initialize the boot disk.
           When a family is specified instead of an image, the latest non-deprecated 
           image associated with that family is used.
           At least one of the tuples image_project/image_family, image_project/image, family, image, should be defined.
@@ -36,7 +36,7 @@ node_types:
       image:
         type: string
         description: >
-          Boot image for the instance.
+          Image from which to initialize the boot disk.
           If not specified, and an image family is specified, the latest 
           non-deprecated image associated with that family is used.
           At least one of the tuples image_project/image_family, image_project/image, family, image, should be defined.

--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -80,10 +80,9 @@ node_types:
         type: string
         description: >
           Comma-separated list of service scopes defining access to Google Cloud APIs.
-          A scope can be either the full URI of the scope or an alias, like default 
-          or cloud-platform.
+          A scope can be either the full URI of the scope or an alias, like
+          cloud-platform.
         required: false
-        default: default
       service_account:
         type: string
         description: >
@@ -98,4 +97,3 @@ node_types:
           the instances to which network firewall rules will apply.
         required: false
 
-      

--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -69,12 +69,12 @@ node_types:
       no_address:
         type: boolean
         description: >
-        If set to true, the instance will not be assigned an external IP address
+          If set to true, the instance will not be assigned an external IP address
         required: false
       preemptible:
         type: boolean
         description: >
-        If set to true, the Compute Node is preemptible and time-limited.
+          If set to true, the Compute Node is preemptible and time-limited.
         required: false
       scopes:
         type: string

--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -16,15 +16,15 @@ node_types:
     properties:
       # See definitions at:
       # https://cloud.google.com/compute/docs/reference/rest/v1/instances
-      imageProject:
+      image_project:
         type: string
         description: >
           The project against which all image and image family references will be
           resolved.
-          If not specified, and either image or imageFamily is provided, the current
+          If not specified, and either image or image_family is provided, the current
           default project is used.
         required: false
-      imageFamily:
+      image_family:
         type: string
         description: >
           The family of the image that the boot disk will be initialized with.
@@ -38,7 +38,7 @@ node_types:
           If not specified, and an image family is specified, the latest 
           non-deprecated image associated with that family is used.
         required: false
-      machineType:
+      machine_type:
         type: string
         description: >
           The machine type used for the Compute Node, defining the Compute Node 
@@ -66,7 +66,7 @@ node_types:
           keys startup-script or startup-script-url can be used to specify a script
           that will be executed by the Compute Node once it starts running.
         required: false
-      noAddress:
+      no_address:
         type: boolean
         description: >
         If set to true, the instance will not be assigned an external IP address
@@ -84,7 +84,7 @@ node_types:
           or cloud-platform.
         required: false
         default: default
-      serviceAccount:
+      service_account:
         type: string
         description: >
           Service Account (e-mail or alias) to attach to the Compute Node.

--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -23,6 +23,7 @@ node_types:
           resolved.
           If not specified, and either image or image_family is provided, the current
           default project is used.
+          At least one of the tuples image_project/image_family, image_project/image, family, image, should be defined.
         required: false
       image_family:
         type: string
@@ -30,6 +31,7 @@ node_types:
           The family of the image that the boot disk will be initialized with.
           When a family is specified instead of an image, the latest non-deprecated 
           image associated with that family is used.
+          At least one of the tuples image_project/image_family, image_project/image, family, image, should be defined.
         required: false
       image:
         type: string
@@ -37,6 +39,7 @@ node_types:
           Boot image for the instance.
           If not specified, and an image family is specified, the latest 
           non-deprecated image associated with that family is used.
+          At least one of the tuples image_project/image_family, image_project/image, family, image, should be defined.
         required: false
       machine_type:
         type: string

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -757,13 +757,15 @@ Google Cloud Platform infrastructure key name is ``google`` in lower case.
 +-----------------------------+----------------------------------------------+-----------+----------+----------------------------------------+
 | ``application_credentials`` | Path of file containing credentials*         | string    | no       | Google Application Default Credentials |
 +-----------------------------+----------------------------------------------+-----------+----------+----------------------------------------+
+| ``credentials``             | Content of file containing credentials       | string    | no       | Google Application Default Credentials |
++-----------------------------+----------------------------------------------+-----------+----------+----------------------------------------+
 | ``region``                  | The region to operate under                  | string    | no       |                                        |
 +-----------------------------+----------------------------------------------+-----------+----------+----------------------------------------+
 
 *``application_credentials`` is the path (accessible to Yorc server) of a file containing service account private keys in JSON format.
 This file can be downloaded from the Google Cloud Console at  `Google Cloud service account file <https://console.cloud.google.com/apis/credentials/serviceaccountkey>`_.
 
-If no file is specified, the orchestrator will fall back to using the `Google Application Default Credentials <https://cloud.google.com/docs/authentication/production>`_ if any.
+If no file path is specified in ``application_credentials`` and no file content is specified in ``credentials``, the orchestrator will fall back to using the `Google Application Default Credentials <https://cloud.google.com/docs/authentication/production>`_ if any.
 
 .. _option_infra_aws:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -749,16 +749,16 @@ Google Cloud Platform
 
 Google Cloud Platform infrastructure key name is ``google`` in lower case.
 
-+-------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
-|  Option Name                  |              Description                    | Data Type | Required | Default                                |
-|                               |                                             |           |          |                                        |
-+===============================+=============================================+===========+==========+========================================+
-| ``project``                   | ID of the project to apply any resources to | string    | yes      |                                        |
-+-------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
-| ``application_credentials`` * | Path of file containing credentials         | string    | no       | Google Application Default Credentials |
-+-------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
-| ``region``                    | The region to operate under                 | string    | no       |                                        |
-+-------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
++-----------------------------+----------------------------------------------+-----------+----------+----------------------------------------+
+|  Option Name                |              Description                     | Data Type | Required | Default                                |
+|                             |                                              |           |          |                                        |
++=============================+==============================================+===========+==========+========================================+
+| ``project``                 | ID of the project to apply any resources to  | string    | yes      |                                        |
++-----------------------------+----------------------------------------------+-----------+----------+----------------------------------------+
+| ``application_credentials`` | Path of file containing credentials*         | string    | no       | Google Application Default Credentials |
++-----------------------------+----------------------------------------------+-----------+----------+----------------------------------------+
+| ``region``                  | The region to operate under                  | string    | no       |                                        |
++-----------------------------+----------------------------------------------+-----------+----------+----------------------------------------+
 
 *``application_credentials`` is the path (accessible to Yorc server) of a file containing service account private keys in JSON format.
 This file can be downloaded from the Google Cloud Console at  `Google Cloud service account file <https://console.cloud.google.com/apis/credentials/serviceaccountkey>`_.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -742,6 +742,27 @@ Kubernetes infrastructure key name is ``kubernetes`` in lower case.
 | ``insecure``   | Server should be accessed without verifying the TLS certificate (testing only)  | boolean   | no       |         |
 +----------------+---------------------------------------------------------------------------------+-----------+----------+---------+
 
+.. _option_infra_google:
+
+Google Cloud Platform
+~~~~~~~~~~~~~~~~~~~~~
+
+Google Cloud Platform infrastructure key name is ``google`` in lower case.
+
++------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
+|  Option Name                 |              Description                    | Data Type | Required | Default                                |
+|                              |                                             |           |          |                                        |
++==============================+=============================================+===========+==========+========================================+
+| ``application_credentials``* | Path of file containing credentials         | string    | no       | Google Application Default Credentials |
++------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
+| ``project``                  | ID of the project to apply any resources to | string    | yes      |                                        |
++------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
+| ``region``                   | The region to operate under                 | string    | no       |                                        |
++------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
+
+*``application_credentials`` is the path (accessible to Yorc server) of a file containing service account private keys in JSON format.
+This file can be downloaded from the Google Cloud Console at  `Google Cloud service account file <https://console.cloud.google.com/apis/credentials/serviceaccountkey>`_.
+If no file is specified, the orchestrator will fall back to using the `Google Application Default Credentials<https://cloud.google.com/docs/authentication/production>`_ if any.
 
 .. _option_infra_aws:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -749,20 +749,21 @@ Google Cloud Platform
 
 Google Cloud Platform infrastructure key name is ``google`` in lower case.
 
-+------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
-|  Option Name                 |              Description                    | Data Type | Required | Default                                |
-|                              |                                             |           |          |                                        |
-+==============================+=============================================+===========+==========+========================================+
-| ``application_credentials``* | Path of file containing credentials         | string    | no       | Google Application Default Credentials |
-+------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
-| ``project``                  | ID of the project to apply any resources to | string    | yes      |                                        |
-+------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
-| ``region``                   | The region to operate under                 | string    | no       |                                        |
-+------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
++-------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
+|  Option Name                  |              Description                    | Data Type | Required | Default                                |
+|                               |                                             |           |          |                                        |
++===============================+=============================================+===========+==========+========================================+
+| ``project``                   | ID of the project to apply any resources to | string    | yes      |                                        |
++-------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
+| ``application_credentials`` * | Path of file containing credentials         | string    | no       | Google Application Default Credentials |
++-------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
+| ``region``                    | The region to operate under                 | string    | no       |                                        |
++-------------------------------+---------------------------------------------+-----------+----------+----------------------------------------+
 
 *``application_credentials`` is the path (accessible to Yorc server) of a file containing service account private keys in JSON format.
 This file can be downloaded from the Google Cloud Console at  `Google Cloud service account file <https://console.cloud.google.com/apis/credentials/serviceaccountkey>`_.
-If no file is specified, the orchestrator will fall back to using the `Google Application Default Credentials<https://cloud.google.com/docs/authentication/production>`_ if any.
+
+If no file is specified, the orchestrator will fall back to using the `Google Application Default Credentials <https://cloud.google.com/docs/authentication/production>`_ if any.
 
 .. _option_infra_aws:
 

--- a/doc/infrastructures.rst
+++ b/doc/infrastructures.rst
@@ -127,6 +127,30 @@ Future work
   * We also plan to support `Singularity <http://singularity.lbl.gov/>`_ , a container system similar to Docker but designed to integrate well HPC environments.
     This feature, as it will leverage some Bull HPC proprietary integration with Slurm, will be part of a premium version of Yorc.
 
+.. _yorc_infras_google_section:
+
+Google Cloud Platform
+---------------------
+
+.. only:: html
+
+   |dev|
+
+The Google Cloud Platform integration within Yorc allows to provision Compute nodes on top of `Google Compute Engine <https://cloud.google.com/compute/>`_.
+This part is ready for production.
+
+It is planned to support soon the following features and have them production-ready:
+
+  * Persistent Disks provisioning
+  * Virtual Private Cloud Networks provisioning 
+
+Future work
+~~~~~~~~~~~
+
+The following features are planned to be supported in a next release:
+
+  * `Google Kubernetes Engine <https://cloud.google.com/kubernetes-engine/`_ to deploy containers
+
 .. _yorc_infras_aws_section:
 
 AWS

--- a/doc/infrastructures.rst
+++ b/doc/infrastructures.rst
@@ -147,9 +147,9 @@ It is planned to support soon the following features and have them production-re
 Future work
 ~~~~~~~~~~~
 
-The following features are planned to be supported in a next release:
+The following feature is planned to be supported in a next release:
 
-  * `Google Kubernetes Engine <https://cloud.google.com/kubernetes-engine/`_ to deploy containers
+  * `Google Kubernetes Engine <https://cloud.google.com/kubernetes-engine/>`_ to deploy containers
 
 .. _yorc_infras_aws_section:
 

--- a/prov/terraform/commons/resources.go
+++ b/prov/terraform/commons/resources.go
@@ -14,6 +14,12 @@
 
 package commons
 
+const (
+	// DefaultSSHPrivateKeyFilePath is the default SSH private Key file path
+	// used to connect to provisioned resources
+	DefaultSSHPrivateKeyFilePath = "~/.ssh/yorc.pem"
+)
+
 // An Infrastructure is the top-level element of a Terraform infrastructure definition
 type Infrastructure struct {
 	Terraform map[string]interface{} `json:"terraform,omitempty"`

--- a/prov/terraform/google/compute_instance.go
+++ b/prov/terraform/google/compute_instance.go
@@ -221,7 +221,6 @@ func (g *googleGenerator) generateComputeInstance(ctx context.Context, kv *api.K
 
 	// Check the connection in order to be sure that ansible will be able to log on the instance
 	nullResource := commons.Resource{}
-	// TODO private key should not be hard-coded
 	re := commons.RemoteExec{Inline: []string{`echo "connected"`},
 		Connection: &commons.Connection{User: user, Host: accessIP,
 			PrivateKey: `${file("` + privateKeyFilePath + `")}`}}

--- a/prov/terraform/google/compute_instance.go
+++ b/prov/terraform/google/compute_instance.go
@@ -1,0 +1,326 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/pkg/errors"
+
+	"strconv"
+
+	"github.com/ystia/yorc/config"
+	"github.com/ystia/yorc/deployments"
+	"github.com/ystia/yorc/helper/consulutil"
+	"github.com/ystia/yorc/log"
+	"github.com/ystia/yorc/prov/terraform/commons"
+)
+
+func (g *googleGenerator) generateComputeInstance(ctx context.Context, kv *api.KV,
+	cfg config.Configuration, deploymentID, nodeName, instanceName string,
+	infrastructure *commons.Infrastructure,
+	outputs map[string]string) error {
+
+	nodeType, err := deployments.GetNodeType(kv, deploymentID, nodeName)
+	if err != nil {
+		return err
+	}
+	if nodeType != "yorc.nodes.google.Compute" {
+		return errors.Errorf("Unsupported node type for %q: %s", nodeName, nodeType)
+	}
+
+	instancesPrefix := path.Join(consulutil.DeploymentKVPrefix, deploymentID,
+		"topology", "instances")
+	instancesKey := path.Join(instancesPrefix, nodeName)
+
+	instance := ComputeInstance{}
+
+	// Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'
+	instance.Name = strings.ToLower(cfg.ResourcesPrefix + nodeName + "-" + instanceName)
+
+	// Getting string parameters
+	var imageProject, imageFamily, image, serviceAccount string
+
+	stringParams := []struct {
+		pAttr        *string
+		propertyName string
+		mandatory    bool
+	}{
+		{&instance.MachineType, "machine_type", true},
+		{&instance.Zone, "zone", true},
+		{&imageProject, "image_project", false},
+		{&imageFamily, "image_family", false},
+		{&image, "image", false},
+		{&instance.Description, "description", false},
+		{&serviceAccount, "service_acount", false},
+	}
+
+	for _, stringParam := range stringParams {
+		if *stringParam.pAttr, err = getStringProperty(kv, deploymentID, nodeName,
+			stringParam.propertyName, stringParam.mandatory); err != nil {
+			return err
+		}
+	}
+
+	// Define the boot disk from image settings
+	var bootImage string
+	if imageProject != "" {
+		bootImage = imageProject
+		if image != "" {
+			bootImage = bootImage + "/" + image
+		} else if imageFamily != "" {
+			bootImage = bootImage + "/" + imageFamily
+		} else {
+			// Unexpected image project without a family or image
+			return errors.Errorf("Exepected an image or family for image project %s on %s", imageProject, nodeName)
+		}
+	} else if image != "" {
+		bootImage = image
+	} else {
+		bootImage = imageFamily
+	}
+
+	var bootDisk Disk
+	if bootImage != "" {
+		bootDisk.Image = bootImage
+	}
+	instance.Disks = []Disk{bootDisk}
+
+	// Get boolean parameters
+
+	if instance.NoAddress, err = getBooleanProperty(kv, deploymentID, nodeName, "no_address"); err != nil {
+		return err
+	}
+
+	if instance.Preemptible, err = getBooleanProperty(kv, deploymentID, nodeName, "preemptible"); err != nil {
+		return err
+	}
+
+	// Network interface definition
+	networkInterface := NetworkInterface{Network: "default"}
+	// Define an external access if there will be an external IP address
+	if !instance.NoAddress {
+		// keeping all default values
+		accessConfig := AccessConfig{}
+		networkInterface.AccessConfigs = []AccessConfig{accessConfig}
+	}
+	instance.NetworkInterfaces = []NetworkInterface{networkInterface}
+
+	// Get list of strings parameters
+	var scopes []string
+	if scopes, err = getStringArray(kv, deploymentID, nodeName, "scopes"); err != nil {
+		return err
+	}
+
+	if serviceAccount != "" || len(scopes) > 0 {
+		// Adding a service account section, where scopes can't be empty
+		if len(scopes) == 0 {
+			scopes = []string{"cloud-platform"}
+		}
+		configuredAccount := ServiceAccount{serviceAccount, scopes}
+		instance.ServiceAccounts = []ServiceAccount{configuredAccount}
+	}
+
+	if instance.Tags, err = getStringArray(kv, deploymentID, nodeName, "tags"); err != nil {
+		return err
+	}
+
+	// Get list of key/value pairs parameters
+
+	if instance.Labels, err = getKeyValuePairs(kv, deploymentID, nodeName, "labels"); err != nil {
+		return err
+	}
+
+	if instance.Metadata, err = getKeyValuePairs(kv, deploymentID, nodeName, "metadata"); err != nil {
+		return err
+	}
+
+	// user is mandatory
+	var user string
+	if _, user, err = deployments.GetCapabilityProperty(kv, deploymentID, nodeName,
+		"endpoint", "credentials", "user"); err != nil {
+		return err
+	} else if user == "" {
+		return errors.Errorf("Missing mandatory parameter 'user' node type for %s", nodeName)
+	}
+
+	var privateKeyFilePath string
+	if _, privateKeyFilePath, err = deployments.GetCapabilityProperty(kv, deploymentID,
+		nodeName, "endpoint", "credentials", "keys", "0"); err != nil {
+		return err
+	} else if privateKeyFilePath == "" {
+		// Using default value
+		privateKeyFilePath = commons.DefaultSSHPrivateKeyFilePath
+		log.Printf("No private key defined for user %s, using default %s", user, privateKeyFilePath)
+	}
+
+	// Add the compute instance
+	commons.AddResource(infrastructure, "google_compute_instance", instance.Name, &instance)
+
+	// Provide Consul Keys
+	consulKeys := commons.ConsulKeys{Keys: []commons.ConsulKey{}}
+
+	// Define the private IP address using the value exported by Terraform
+	privateIP := fmt.Sprintf("${google_compute_instance.%s.network_interface.0.address}",
+		instance.Name)
+
+	consulKeyPrivateAddr := commons.ConsulKey{
+		Path:  path.Join(instancesKey, instanceName, "/attributes/private_address"),
+		Value: privateIP}
+
+	consulKeys.Keys = append(consulKeys.Keys, consulKeyPrivateAddr)
+
+	// Define the public IP using the value exported by Terraform
+	// except if it was specified the instance shouldn't have a public address
+	var accessIP string
+	if instance.NoAddress {
+		accessIP = privateIP
+	} else {
+		accessIP = fmt.Sprintf("${google_compute_instance.%s.network_interface.0.access_config.0.assigned_nat_ip}",
+			instance.Name)
+		consulKeyPublicAddr := commons.ConsulKey{
+			Path:  path.Join(instancesKey, instanceName, "/attributes/public_address"),
+			Value: accessIP}
+		// For backward compatibility...
+		consulKeyPublicIPAddr := commons.ConsulKey{
+			Path:  path.Join(instancesKey, instanceName, "/attributes/public_ip_address"),
+			Value: accessIP}
+
+		consulKeys.Keys = append(consulKeys.Keys, consulKeyPublicAddr,
+			consulKeyPublicIPAddr)
+	}
+
+	// IP Address capability
+	capabilityIPAddr := commons.ConsulKey{
+		Path:  path.Join(instancesKey, instanceName, "/capabilities/endpoint/attributes/ip_address"),
+		Value: accessIP}
+	// Default TOSCA Attributes
+	consulKeyIPAddr := commons.ConsulKey{
+		Path:  path.Join(instancesKey, instanceName, "/attributes/ip_address"),
+		Value: accessIP}
+
+	consulKeys.Keys = append(consulKeys.Keys, consulKeyIPAddr, capabilityIPAddr)
+
+	commons.AddResource(infrastructure, "consul_keys", instance.Name, &consulKeys)
+
+	// Check the connection in order to be sure that ansible will be able to log on the instance
+	nullResource := commons.Resource{}
+	// TODO private key should not be hard-coded
+	re := commons.RemoteExec{Inline: []string{`echo "connected"`},
+		Connection: &commons.Connection{User: user, Host: accessIP,
+			PrivateKey: `${file("` + privateKeyFilePath + `")}`}}
+	nullResource.Provisioners = make([]map[string]interface{}, 0)
+	provMap := make(map[string]interface{})
+	provMap["remote-exec"] = re
+	nullResource.Provisioners = append(nullResource.Provisioners, provMap)
+
+	commons.AddResource(infrastructure, "null_resource", instance.Name+"-ConnectionCheck", &nullResource)
+
+	return nil
+}
+
+func getStringProperty(kv *api.KV, deploymentID, nodeName, propertyName string, mandatory bool) (string, error) {
+
+	var result string
+	var err error
+	if _, result, err = deployments.GetNodeProperty(kv, deploymentID,
+		nodeName, propertyName); err != nil {
+		return result, err
+	}
+
+	if result == "" && mandatory {
+		return result, errors.Errorf("Missing value for mandatory parameter %s of %s",
+			propertyName, nodeName)
+	}
+
+	return result, nil
+}
+
+func getBooleanProperty(kv *api.KV, deploymentID, nodeName, propertyName string) (bool, error) {
+
+	var result bool
+	var strValue string
+	var err error
+	if _, strValue, err = deployments.GetNodeProperty(kv, deploymentID,
+		nodeName, propertyName); err != nil {
+		return result, err
+	}
+
+	if strValue == "" {
+		result = false
+	} else {
+		result, err = strconv.ParseBool(strValue)
+		if err != nil {
+			log.Printf("Unexpected value for %s %s: '%s', considering it is set to 'false'",
+				nodeName, propertyName, strValue)
+			result = false
+		}
+	}
+
+	return result, nil
+}
+
+func getStringArray(kv *api.KV, deploymentID, nodeName, propertyName string) ([]string, error) {
+
+	var result []string
+	var strValue string
+	var found bool
+	var err error
+	if found, strValue, err = deployments.GetNodeProperty(kv, deploymentID,
+		nodeName, propertyName); err != nil {
+		return nil, err
+	}
+
+	if found && strValue != "" {
+		values := strings.Split(strValue, ",")
+		for _, val := range values {
+			result = append(result, strings.TrimSpace(val))
+		}
+	}
+
+	return result, nil
+}
+
+func getKeyValuePairs(kv *api.KV, deploymentID, nodeName, propertyName string) (map[string]string, error) {
+
+	var result map[string]string
+	var strValue string
+	var found bool
+	var err error
+	if found, strValue, err = deployments.GetNodeProperty(kv, deploymentID,
+		nodeName, propertyName); err != nil {
+		return nil, err
+	}
+
+	if found && strValue != "" {
+		result = make(map[string]string)
+		values := strings.Split(strValue, ",")
+		for _, val := range values {
+			keyValuePair := strings.Split(val, "=")
+			if len(keyValuePair) != 2 {
+
+				return result, errors.Errorf("Expected KEY=VALUE format, got %s for property %s on %s",
+					val, propertyName, nodeName)
+			}
+			result[strings.TrimSpace(keyValuePair[0])] =
+				strings.TrimSpace(keyValuePair[1])
+		}
+	}
+	return result, nil
+}

--- a/prov/terraform/google/compute_instance_test.go
+++ b/prov/terraform/google/compute_instance_test.go
@@ -1,0 +1,90 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ystia/yorc/config"
+	"github.com/ystia/yorc/deployments"
+	"github.com/ystia/yorc/prov/terraform/commons"
+)
+
+func loadTestYaml(t *testing.T, kv *api.KV) string {
+	deploymentID := path.Base(t.Name())
+	yamlName := "testdata/" + deploymentID + ".yaml"
+	err := deployments.StoreDeploymentDefinition(context.Background(), kv, deploymentID, yamlName)
+	require.NoError(t, err, "Failed to parse "+yamlName+" definition")
+	return deploymentID
+}
+
+func testSimpleComputeInstance(t *testing.T, kv *api.KV, cfg config.Configuration) {
+	t.Parallel()
+	deploymentID := loadTestYaml(t, kv)
+	infrastructure := commons.Infrastructure{}
+	g := googleGenerator{}
+	err := g.generateComputeInstance(context.Background(), kv, cfg, deploymentID, "ComputeInstance", "0", &infrastructure, make(map[string]string))
+	require.NoError(t, err, "Unexpected error attempting to generate compute instance for %s", deploymentID)
+
+	require.Len(t, infrastructure.Resource["google_compute_instance"], 1, "Expected one compute instance")
+	instancesMap := infrastructure.Resource["google_compute_instance"].(map[string]interface{})
+	require.Len(t, instancesMap, 1)
+	require.Contains(t, instancesMap, "computeinstance-0")
+
+	compute, ok := instancesMap["computeinstance-0"].(*ComputeInstance)
+	require.True(t, ok, "computeinstance-0 is not a ComputeInstance")
+	assert.Equal(t, "n1-standard-1", compute.MachineType)
+	assert.Equal(t, "europe-west1-b", compute.Zone)
+	require.Len(t, compute.Disks, 1, "Expected one boot disk")
+	assert.Equal(t, "centos-cloud/centos-7", compute.Disks[0].Image, "Unexpected boot disk image")
+	assert.Equal(t, false, compute.NoAddress)
+	require.Len(t, compute.NetworkInterfaces, 1, "Expected one network interface for external access")
+	assert.Equal(t, []string{"tag1", "tag2"}, compute.Tags)
+	assert.Equal(t, map[string]string{"key1": "value1", "key2": "value2"}, compute.Labels)
+
+	require.Len(t, compute.ServiceAccounts, 0, "Expected no service account")
+
+	require.Contains(t, infrastructure.Resource, "null_resource")
+	require.Len(t, infrastructure.Resource["null_resource"], 1)
+	nullResources := infrastructure.Resource["null_resource"].(map[string]interface{})
+
+	require.Contains(t, nullResources, "computeinstance-0-ConnectionCheck")
+	nullRes, ok := nullResources["computeinstance-0-ConnectionCheck"].(*commons.Resource)
+	assert.True(t, ok)
+	require.Len(t, nullRes.Provisioners, 1)
+	mapProv := nullRes.Provisioners[0]
+	require.Contains(t, mapProv, "remote-exec")
+	rex, ok := mapProv["remote-exec"].(commons.RemoteExec)
+	require.True(t, ok)
+	assert.Equal(t, "centos", rex.Connection.User)
+	assert.Equal(t, `${file("~/.ssh/yorc.pem")}`, rex.Connection.PrivateKey)
+}
+
+func testSimpleComputeInstanceMissingMandatoryParameter(t *testing.T, kv *api.KV, cfg config.Configuration) {
+	t.Parallel()
+	deploymentID := loadTestYaml(t, kv)
+	g := googleGenerator{}
+	infrastructure := commons.Infrastructure{}
+
+	err := g.generateComputeInstance(context.Background(), kv, cfg, deploymentID, "ComputeInstance", "0", &infrastructure, make(map[string]string))
+	require.Error(t, err, "Expected missing mandatory parameter error, but had no error")
+	assert.Contains(t, err.Error(), "mandatory parameter zone", "Expected an error on missing parameter zone")
+}

--- a/prov/terraform/google/consul_test.go
+++ b/prov/terraform/google/consul_test.go
@@ -1,0 +1,46 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"testing"
+
+	"github.com/ystia/yorc/config"
+	"github.com/ystia/yorc/testutil"
+)
+
+// The aim of this function is to run all package tests with consul server dependency with only one consul server start
+func TestRunConsulGooglePackageTests(t *testing.T) {
+	srv, client := testutil.NewTestConsulInstance(t)
+	kv := client.KV()
+	defer srv.Stop()
+
+	// AWS infrastructure config
+	cfg := config.Configuration{
+		Infrastructures: map[string]config.DynamicMap{
+			infrastructureName: config.DynamicMap{
+				"credentials": "/tmp/creds.json",
+				"region":      "europe-west-1",
+			}}}
+
+	t.Run("googleProvider", func(t *testing.T) {
+		t.Run("simpleComputeInstance", func(t *testing.T) {
+			testSimpleComputeInstance(t, kv, cfg)
+		})
+		t.Run("simpleComputeInstanceMissingMandatoryParameter", func(t *testing.T) {
+			testSimpleComputeInstanceMissingMandatoryParameter(t, kv, cfg)
+		})
+	})
+}

--- a/prov/terraform/google/generator.go
+++ b/prov/terraform/google/generator.go
@@ -1,0 +1,159 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/ystia/yorc/config"
+	"github.com/ystia/yorc/deployments"
+	"github.com/ystia/yorc/helper/consulutil"
+	"github.com/ystia/yorc/log"
+	"github.com/ystia/yorc/prov/terraform/commons"
+	"github.com/ystia/yorc/tosca"
+)
+
+const infrastructureName = "google"
+
+type googleGenerator struct {
+}
+
+func (g *googleGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg config.Configuration, deploymentID, nodeName string) (bool, map[string]string, []string, error) {
+	log.Debugf("Generating infrastructure for deployment with id %s", deploymentID)
+	cClient, err := cfg.GetConsulClient()
+	if err != nil {
+		return false, nil, nil, err
+	}
+	kv := cClient.KV()
+	nodeKey := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology", "nodes", nodeName)
+	terraformStateKey := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "terraform-state", nodeName)
+
+	infrastructure := commons.Infrastructure{}
+
+	consulAddress := "127.0.0.1:8500"
+	if cfg.Consul.Address != "" {
+		consulAddress = cfg.Consul.Address
+	}
+	consulScheme := "http"
+	if cfg.Consul.SSL {
+		consulScheme = "https"
+	}
+	consulCA := ""
+	if cfg.Consul.CA != "" {
+		consulCA = cfg.Consul.CA
+	}
+	consulKey := ""
+	if cfg.Consul.Key != "" {
+		consulKey = cfg.Consul.Key
+	}
+	consulCert := ""
+	if cfg.Consul.Cert != "" {
+		consulCert = cfg.Consul.Cert
+	}
+
+	// Remote Configuration for Terraform State to store it in the Consul KV store
+	infrastructure.Terraform = map[string]interface{}{
+		"backend": map[string]interface{}{
+			"consul": map[string]interface{}{
+				"path": terraformStateKey,
+			},
+		},
+	}
+
+	// Define Terraform provider environment variables
+	var cmdEnv []string
+	configParams := []string{"application_credentials", "project", "region", "zone"}
+	for _, configParam := range configParams {
+		value := cfg.Infrastructures[infrastructureName].GetString(configParam)
+		if value != "" {
+			cmdEnv = append(cmdEnv,
+				fmt.Sprintf("%s=%s",
+					"GOOGLE_"+strings.ToUpper(configParam),
+					value))
+		}
+	}
+
+	// Management of variables for Terraform
+	infrastructure.Provider = map[string]interface{}{
+		"google": map[string]interface{}{},
+		"consul": map[string]interface{}{
+			"address":   consulAddress,
+			"scheme":    consulScheme,
+			"ca_file":   consulCA,
+			"cert_file": consulCert,
+			"key_file":  consulKey,
+		},
+	}
+
+	log.Debugf("inspecting node %s", nodeKey)
+	nodeType, err := deployments.GetNodeType(kv, deploymentID, nodeName)
+	if err != nil {
+		return false, nil, nil, err
+	}
+	outputs := make(map[string]string)
+	var instances []string
+	switch nodeType {
+	case "yorc.nodes.google.Compute":
+		instances, err = deployments.GetNodeInstancesIds(kv, deploymentID, nodeName)
+		if err != nil {
+			return false, nil, nil, err
+		}
+
+		for _, instanceName := range instances {
+			var instanceState tosca.NodeState
+			instanceState, err = deployments.GetInstanceState(kv, deploymentID, nodeName, instanceName)
+			if err != nil {
+				return false, nil, nil, err
+			}
+			if instanceState == tosca.NodeStateDeleting || instanceState == tosca.NodeStateDeleted {
+				// Do not generate something for this node instance (will be deleted if exists)
+				continue
+			}
+			err = g.generateComputeInstance(ctx, kv, cfg, deploymentID, nodeName, instanceName, &infrastructure, outputs)
+			if err != nil {
+				return false, nil, nil, err
+			}
+		}
+
+	case "yorc.nodes.google.PublicNetwork":
+		// Nothing to do
+	default:
+		return false, nil, nil, errors.Errorf("Unsupported node type '%s' for node '%s' in deployment '%s'", nodeType, nodeName, deploymentID)
+	}
+
+	jsonInfra, err := json.MarshalIndent(infrastructure, "", "  ")
+	if err != nil {
+		return false, nil, nil, errors.Wrap(err, "Failed to generate JSON of terraform Infrastructure description")
+	}
+	infraPath := filepath.Join(cfg.WorkingDirectory, "deployments", fmt.Sprint(deploymentID), "infra", nodeName)
+	if err = os.MkdirAll(infraPath, 0775); err != nil {
+		return false, nil, nil, errors.Wrapf(err, "Failed to create infrastructure working directory %q", infraPath)
+	}
+
+	if err = ioutil.WriteFile(filepath.Join(infraPath, "infra.tf.json"), jsonInfra, 0664); err != nil {
+		return false, nil, nil, errors.Wrapf(err, "Failed to write file %q", filepath.Join(infraPath, "infra.tf.json"))
+	}
+
+	log.Debugf("Infrastructure generated for deployment with id %s", deploymentID)
+	return true, outputs, cmdEnv, nil
+}

--- a/prov/terraform/google/generator.go
+++ b/prov/terraform/google/generator.go
@@ -82,7 +82,7 @@ func (g *googleGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg
 
 	// Define Terraform provider environment variables
 	var cmdEnv []string
-	configParams := []string{"application_credentials", "project", "region", "zone"}
+	configParams := []string{"application_credentials", "project", "region"}
 	for _, configParam := range configParams {
 		value := cfg.Infrastructures[infrastructureName].GetString(configParam)
 		if value != "" {

--- a/prov/terraform/google/generator.go
+++ b/prov/terraform/google/generator.go
@@ -82,7 +82,7 @@ func (g *googleGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg
 
 	// Define Terraform provider environment variables
 	var cmdEnv []string
-	configParams := []string{"application_credentials", "project", "region"}
+	configParams := []string{"application_credentials", "credentials", "project", "region"}
 	for _, configParam := range configParams {
 		value := cfg.Infrastructures[infrastructureName].GetString(configParam)
 		if value != "" {

--- a/prov/terraform/google/generator_test.go
+++ b/prov/terraform/google/generator_test.go
@@ -1,0 +1,47 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"testing"
+
+	"encoding/json"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ystia/yorc/prov/terraform/commons"
+)
+
+func Test_addOutput(t *testing.T) {
+	type args struct {
+		infrastructure *commons.Infrastructure
+		outputName     string
+		output         *commons.Output
+	}
+	tests := []struct {
+		name       string
+		args       args
+		jsonResult string
+	}{
+		{"OneOutput", args{&commons.Infrastructure{}, "O1", &commons.Output{Value: "V1"}}, `{"output":{"O1":{"value":"V1"}}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commons.AddOutput(tt.args.infrastructure, tt.args.outputName, tt.args.output)
+			res, err := json.Marshal(tt.args.infrastructure)
+			require.Nil(t, err)
+			require.Equal(t, tt.jsonResult, string(res))
+		})
+	}
+}

--- a/prov/terraform/google/init.go
+++ b/prov/terraform/google/init.go
@@ -1,0 +1,23 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import "github.com/ystia/yorc/registry"
+import "github.com/ystia/yorc/prov/terraform"
+
+func init() {
+	reg := registry.GetRegistry()
+	reg.RegisterDelegates([]string{`yorc\.nodes\.google\..*`}, terraform.NewExecutor(&googleGenerator{}, nil), registry.BuiltinOrigin)
+}

--- a/prov/terraform/google/resources.go
+++ b/prov/terraform/google/resources.go
@@ -1,0 +1,66 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+// ComputeInstance represents a Google Compute Engine Virtual Machine
+// See https://www.terraform.io/docs/providers/google/r/compute_instance.html
+// for the latest documentation.
+// See https://github.com/terraform-providers/terraform-provider-google/blob/v0.1.1/website/docs/r/compute_instance.html.markdown
+// for the version currently supported by the Orchestrator
+type ComputeInstance struct {
+	Name              string             `json:"name"`
+	MachineType       string             `json:"machine_type"`
+	Zone              string             `json:"zone"`
+	Disks             []Disk             `json:"disk,omitempty"`
+	NetworkInterfaces []NetworkInterface `json:"network_interface"`
+	Description       string             `json:"description,omitempty"`
+	Labels            map[string]string  `json:"labels,omitempty"`
+	Metadata          map[string]string  `json:"metadata,omitempty"`
+	// NoAdress means no external IP address
+	NoAddress   bool `json:"no_address,omitempty"`
+	Preemptible bool `json:"preemptible,omitempty"`
+	// ServiceAccounts is an array of at most one element
+	ServiceAccounts []ServiceAccount `json:"service_account,omitempty"`
+	Tags            []string         `json:"tags,omitempty"`
+}
+
+// Disk represents a disk attached to the compute instance
+type Disk struct {
+	AutoDelete bool `json:"auto_delete,omitempty"`
+	// InitializeParams is an array of at most one element
+	Image string `json:"image,omitempty"`
+}
+
+// NetworkInterface represents a network to attach to the instance
+type NetworkInterface struct {
+	Network           string         `json:"network,omitempty"`
+	Subnetwork        string         `json:"subnetwork,omitempty"`
+	SubNetworkProject string         `json:"subnetwork_project,omitempty"`
+	Address           string         `json:"address,omitempty"`
+	AccessConfigs     []AccessConfig `json:"access_config,omitempty"`
+}
+
+// AccessConfig provides IPs via which this instance can be accessed via the Internet
+type AccessConfig struct {
+	NatIP               string `json:"nat_ip,omitempty"`
+	NetworkTier         string `json:"network_tier,omitempty"`
+	PublicPtrDomainName string `json:"public_ptr_domain_name ,omitempty"`
+}
+
+// ServiceAccount to attach to the instance
+type ServiceAccount struct {
+	Email  string   `json:"email,omitempty"`
+	Scopes []string `json:"scopes,omitempty"`
+}

--- a/prov/terraform/google/testdata/simpleComputeInstance.yaml
+++ b/prov/terraform/google/testdata/simpleComputeInstance.yaml
@@ -1,0 +1,37 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: ComputeInstanceTest
+  template_version: 1.0
+  template_author: tester
+
+description: ""
+
+imports:
+  - path: <yorc-google-types.yml>
+topology_template:
+  node_templates:
+    ComputeInstance:
+      type: yorc.nodes.google.Compute
+      properties:
+        machine_type: "n1-standard-1"
+        zone: "europe-west1-b"
+        image_project: "centos-cloud"
+        image_family: "centos-7"
+        no_address: false
+        tags: "tag1, tag2"
+        labels: "key1=value1, key2=value2"
+      capabilities:
+        scalable:
+          properties:
+            min_instances: 1
+            max_instances: 1
+            default_instances: 1
+        endpoint:
+          properties:
+            secure: true
+            protocol: tcp
+            network_name: PRIVATE
+            initiator: source
+            credentials: {user: centos}
+

--- a/prov/terraform/google/testdata/simpleComputeInstanceMissingMandatoryParameter.yaml
+++ b/prov/terraform/google/testdata/simpleComputeInstanceMissingMandatoryParameter.yaml
@@ -1,0 +1,37 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: ComputeInstanceTest
+  template_version: 1.0
+  template_author: tester
+
+description: ""
+
+imports:
+  - path: <yorc-google-types.yml>
+topology_template:
+  node_templates:
+    ComputeInstance:
+      type: yorc.nodes.google.Compute
+      properties:
+        # machine_type: "n1-standard-1" (default value)
+        # zone: no default value
+        image_project: "centos-cloud"
+        image_family: "centos-7"
+        no_address: false
+        tags: "tag1, tag2"
+        labels: "key1=value1, key2=value2"
+      capabilities:
+        scalable:
+          properties:
+            min_instances: 1
+            max_instances: 1
+            default_instances: 1
+        endpoint:
+          properties:
+            secure: true
+            protocol: tcp
+            network_name: PRIVATE
+            initiator: source
+            credentials: {user: centos}
+

--- a/server/plugins.go
+++ b/server/plugins.go
@@ -18,6 +18,8 @@ package server
 import (
 	// Registering AWS delegate executor in the registry
 	_ "github.com/ystia/yorc/prov/terraform/aws"
+	// Registering Google Cloud delegate executor in the registry
+	_ "github.com/ystia/yorc/prov/terraform/google"
 	// Registering openstack delegate executor in the registry
 	_ "github.com/ystia/yorc/prov/terraform/openstack"
 	// Registering ansible operation executor in the registry

--- a/tosca/assets_test.go
+++ b/tosca/assets_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
 
@@ -26,6 +27,7 @@ func TestGroupedAssetsParallel(t *testing.T) {
 		t.Run("TestAssetNormativeParsing", assetNormativeParsing)
 		t.Run("TestAssetYorcOpenStackParsing", assetYorcOpenStackParsing)
 		t.Run("TestAssetYorcAwsParsing", assetYorcAwsParsing)
+		t.Run("TestAssetYorcGoogleParsing", assetYorcGoogleParsing)
 	})
 }
 
@@ -60,4 +62,15 @@ func assetYorcAwsParsing(t *testing.T) {
 
 	err = yaml.Unmarshal(data, &topo)
 	assert.Nil(t, err, "Can't parse yorc aws types")
+}
+
+func assetYorcGoogleParsing(t *testing.T) {
+	t.Parallel()
+	data, err := Asset("yorc-google-types.yml")
+	require.NoError(t, err, "Can't load yorc google types")
+	assert.NotNil(t, data, "Can't load yorc google types")
+	var topo Topology
+
+	err = yaml.Unmarshal(data, &topo)
+	assert.Nil(t, err, "Can't parse yorc google types")
 }


### PR DESCRIPTION
# Pull Request description

## Description of the change

Associated to Yorc Alien4Cloud plugin Pulll Request https://github.com/ystia/yorc-a4c-plugin/pull/26

### What I did

Added a yorc.nodes.google.Compute type and code to provision a Google Compute Instance through its Terraform provider.

Updated the documentation at doc/configuration.rst and doc/infrastructures.rst

### How to verify it

See doc/configuration.rst in to configure a google infrastructure.
Then see the Yorc A4C plugin associated Pull Request to configure a Google Cloud location.
A Tosca sample is also provided in the Yorc A4C plugin associated Pull Request at tosca-samples/org/ystia/yorc/samples/vision
Follow the instructions in the README provided with this sample to deploy the sample and check the application works
