### PR TITLE
Retrieve private key from endpoint credentials for aws and openstack

### DIFF
--- a/prov/terraform/aws/consul_test.go
+++ b/prov/terraform/aws/consul_test.go
@@ -40,6 +40,9 @@ func TestRunConsulAWSPackageTests(t *testing.T) {
 		t.Run("simpleAWSInstance", func(t *testing.T) {
 			testSimpleAWSInstance(t, kv, cfg)
 		})
+		t.Run("simpleAWSInstanceWithPrivateKey", func(t *testing.T) {
+			testSimpleAWSInstanceWithPrivateKey(t, kv, cfg)
+		})
 		t.Run("simpleAWSInstanceFailed", func(t *testing.T) {
 			testSimpleAWSInstanceFailed(t, kv, cfg)
 		})

--- a/prov/terraform/aws/testdata/simpleAWSInstanceWithPrivateKey.yaml
+++ b/prov/terraform/aws/testdata/simpleAWSInstanceWithPrivateKey.yaml
@@ -1,0 +1,39 @@
+tosca_definitions_version: alien_dsl_1_4_0
+
+metadata:
+  template_name: AWS_Compute-0_2_0
+  template_version: 0.1.0-SNAPSHOT
+  template_author: ${template_author}
+
+description: ""
+
+imports:
+  - path: <yorc-aws-types.yml>
+topology_template:
+  node_templates:
+    ComputeAWS:
+      type: yorc.nodes.aws.Compute
+      properties:
+        image_id: "ami-16dffe73"
+        instance_type: "t2.micro"
+        key_name: "yorc-keypair"
+        security_groups: "yorc-securityGroup"
+        availability_zone: "us-east-2c"
+        placement_group: "myPlacement"
+      capabilities:
+        scalable:
+          properties:
+            min_instances: 1
+            max_instances: 1
+            default_instances: 1
+        endpoint:
+          properties:
+            secure: true
+            protocol: tcp
+            network_name: PRIVATE
+            initiator: source
+            credentials:
+              user: centos
+              keys:
+                0: "/path/to/my-keypair.pem"
+

--- a/prov/terraform/commons/resources.go
+++ b/prov/terraform/commons/resources.go
@@ -14,6 +14,13 @@
 
 package commons
 
+import (
+	"github.com/hashicorp/consul/api"
+	"github.com/pkg/errors"
+	"github.com/ystia/yorc/deployments"
+	"github.com/ystia/yorc/log"
+)
+
 const (
 	// DefaultSSHPrivateKeyFilePath is the default SSH private Key file path
 	// used to connect to provisioned resources
@@ -119,4 +126,28 @@ func AddOutput(infrastructure *Infrastructure, outputName string, output *Output
 		infrastructure.Output = make(map[string]*Output)
 	}
 	infrastructure.Output[outputName] = output
+}
+
+// GetConnInfoFromEndpointCredentials allow to retrieve user and private key path for connection needs from endpoint credentials
+func GetConnInfoFromEndpointCredentials(kv *api.KV, deploymentID, nodeName string) (string, string, error) {
+	var (
+		user               string
+		privateKeyFilePath string
+		err                error
+	)
+	if _, user, err = deployments.GetCapabilityProperty(kv, deploymentID, nodeName, "endpoint", "credentials", "user"); err != nil {
+		return "", "", err
+	} else if user == "" {
+		return "", "", errors.Errorf("Missing mandatory parameter 'user' node type for %s", nodeName)
+	}
+
+	if _, privateKeyFilePath, err = deployments.GetCapabilityProperty(kv, deploymentID,
+		nodeName, "endpoint", "credentials", "keys", "0"); err != nil {
+		return "", "", err
+	} else if privateKeyFilePath == "" {
+		// Using default value
+		privateKeyFilePath = DefaultSSHPrivateKeyFilePath
+		log.Printf("No private key defined for user %s, using default %s", user, privateKeyFilePath)
+	}
+	return user, privateKeyFilePath, nil
 }

--- a/prov/terraform/google/compute_instance.go
+++ b/prov/terraform/google/compute_instance.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ystia/yorc/config"
 	"github.com/ystia/yorc/deployments"
 	"github.com/ystia/yorc/helper/consulutil"
-	"github.com/ystia/yorc/log"
 	"github.com/ystia/yorc/prov/terraform/commons"
 )
 
@@ -150,23 +149,10 @@ func (g *googleGenerator) generateComputeInstance(ctx context.Context, kv *api.K
 		return err
 	}
 
-	// user is mandatory
-	var user string
-	if _, user, err = deployments.GetCapabilityProperty(kv, deploymentID, nodeName,
-		"endpoint", "credentials", "user"); err != nil {
+	// Get connection info (user, private key)
+	user, privateKeyFilePath, err := commons.GetConnInfoFromEndpointCredentials(kv, deploymentID, nodeName)
+	if err != nil {
 		return err
-	} else if user == "" {
-		return errors.Errorf("Missing mandatory parameter 'user' node type for %s", nodeName)
-	}
-
-	var privateKeyFilePath string
-	if _, privateKeyFilePath, err = deployments.GetCapabilityProperty(kv, deploymentID,
-		nodeName, "endpoint", "credentials", "keys", "0"); err != nil {
-		return err
-	} else if privateKeyFilePath == "" {
-		// Using default value
-		privateKeyFilePath = commons.DefaultSSHPrivateKeyFilePath
-		log.Printf("No private key defined for user %s, using default %s", user, privateKeyFilePath)
 	}
 
 	// Add the compute instance


### PR DESCRIPTION
# Pull Request description
Retrieve private key from capability endpoint/property credentials/keys 0 for Openstack and AWS computes (already done for GCP)

### How to verify it
Create your own keypair with AWS and add the private key path as mentioned [here](http://yorc-a4c-plugin.readthedocs.io/en/latest/location.html#configure-a-google-cloud-platform-location)

