### PR TITLE
Fix bypass of specific add/remove/updated source/target steps on scaling

### DIFF
--- a/deployments/requirements.go
+++ b/deployments/requirements.go
@@ -94,6 +94,15 @@ func GetRequirementIndexFromRequirementKey(requirementKey string) string {
 	return path.Base(requirementKey)
 }
 
+// GetRequirementIndexByNameForNode returns the requirement index which name match with defined requirementName for a given node name
+func GetRequirementIndexByNameForNode(kv *api.KV, deploymentID, nodeName, requirementName string) (string, error) {
+	reqPath, err := GetRequirementKeyByNameForNode(kv, deploymentID, nodeName, requirementName)
+	if err != nil {
+		return "", err
+	}
+	return path.Base(reqPath), nil
+}
+
 // GetRequirementsIndexes returns the list of requirements indexes for a given node
 func GetRequirementsIndexes(kv *api.KV, deploymentID, nodeName string) ([]string, error) {
 	reqPath := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology", "nodes", nodeName, "requirements")


### PR DESCRIPTION
# Pull Request description

## Description of the change

Several issues here:

- Even if add_target is executed on source node it is related to the target node lifecycle (reciprocally for add_source)
- Target node name was not properly retrieved when checking if the target node is implied into the scaling

## How do I test it

[This sample](https://github.com/loicalbertin/tosca-samples) requires add_target to work correctly when scaling targets of a TraefikRoute
