### PR TITLE
Fix retrieving of hosts with the Ansible executor that sometimes lead to executing operations on only one instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.x
+  - 1.10.x
 
 sudo: required
 

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -378,8 +378,8 @@ func (e *executionCommon) resolveHostsOnCompute(nodeName string, instances []str
 	}
 
 	hosts := make(map[string]hostConnection)
-
-	for i := len(hostedOnList) - 1; i >= 0; i-- {
+	var found bool
+	for i := len(hostedOnList) - 1; i >= 0 && !found; i-- {
 		host := hostedOnList[i]
 		capType, err := deployments.GetNodeCapabilityType(e.kv, e.deploymentID, host, "endpoint")
 		if err != nil {
@@ -408,6 +408,7 @@ func (e *executionCommon) resolveHostsOnCompute(nodeName string, instances []str
 						return err
 					}
 					hosts[instanceName] = hostConn
+					found = true
 				}
 			}
 		}


### PR DESCRIPTION
# Pull Request description

## Description of the change

Do not unnecessary explore back (bottom-up) the  hosted-on herarchy as soon as we found a host
