### PR TITLE
BRBDCF-1444 Namespace deleted after deployment deletion

### DIFF
--- a/prov/kubernetes/execution.go
+++ b/prov/kubernetes/execution.go
@@ -241,7 +241,7 @@ func (e *executionCommon) manageDeploymentResource(ctx context.Context, clientse
 		// Delete namespace
 		err = generator.deleteNamespace(namespace, clientset)
 		if err != nil {
-			events.WithContextOptionalFields(ctx).NewLogEntry(events.INFO, e.deploymentID).Registerf("Cannot delete %d k8s Namespace", namespace)
+			events.WithContextOptionalFields(ctx).NewLogEntry(events.INFO, e.deploymentID).Registerf("Cannot delete %s k8s Namespace", namespace)
 			return err
 		}
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.INFO, e.deploymentID).Registerf("k8s Namespace %s deleted", namespace)

--- a/prov/kubernetes/execution.go
+++ b/prov/kubernetes/execution.go
@@ -237,6 +237,15 @@ func (e *executionCommon) manageDeploymentResource(ctx context.Context, clientse
 		}
 
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.INFO, e.deploymentID).Registerf("k8s Deployment %s deleted", deploymentName)
+
+		// Delete namespace
+		err = generator.deleteNamespace(namespace, clientset)
+		if err != nil {
+			events.WithContextOptionalFields(ctx).NewLogEntry(events.INFO, e.deploymentID).Registerf("Cannot delete %d k8s Namespace", namespace)
+			return err
+		}
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.INFO, e.deploymentID).Registerf("k8s Namespace %s deleted", namespace)
+
 	default:
 		return errors.Errorf("Unsupported operation on k8s resource")
 	}

--- a/prov/kubernetes/generator.go
+++ b/prov/kubernetes/generator.go
@@ -138,6 +138,15 @@ func (k8s *k8sGenerator) createNamespaceIfMissing(deploymentID, namespaceName st
 	return nil
 }
 
+// deleteNamespace delete a Kubernetes namespaces known by its name
+func (k8s *k8sGenerator) deleteNamespace(namespaceName string, client *kubernetes.Clientset) error {
+	err := client.CoreV1().Namespaces().Delete(namespaceName, &metav1.DeleteOptions{})
+	if err != nil {
+		return errors.Wrap(err, "Failed to delete namespace "+namespaceName)
+	}
+	return nil
+}
+
 // generatePodName by replacing '_' by '-'
 func generatePodName(nodeName string) string {
 	return strings.Replace(nodeName, "_", "-", -1)


### PR DESCRIPTION
# Pull Request description

Currently a **k8s namespace** is created for every **k8s deployment** orchestrated by yorc. When yorc deletes the k8s deployment (when undeploying the application that created the k8s deployment), the k8s namespace is not deleted. If yorc re-deploys the application, the k8s resources are created in the same namespace.

## Description of the change

When a **k8s deployment** is deleted, all the other resources such as pods, services etc are deleted. Now yorc deletes the namespace created for this deployment

### What I did

Added a _deleteNamespace_ function to the kubernetes package (kubernetes provider)

### How I did it

### How to verify it

You may test using the following environment.
An alien4cloud instance is installed on the VM 10.197.138.34.
It defines an orchestrator for the yorc instance running on the same VM and a K8S location is created.
This location corresponds to an existing K8S cluster described here : https://confluence.sdmc.ao-srv.com/display/BRBDCF/Sprint+32+-+BRBDCF-1202%3A+Upgrade+Kubernetes+Tosca+Component
The yorc instance configuration has an infrastructure entry corresponding to this cluster

- Deploy the application. Check that namespace is created and k8S resources belong to it

- Undeploy the application. Check that namespace is deleted

### Description for the changelog

