### PR TITLE
Hotfix/add lazyquotes to csv reader for ansible output

### DIFF
--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -893,6 +893,11 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 				return err
 			}
 			r := csv.NewReader(fi)
+
+			// If LazyQuotes is true, a quote may appear in an unquoted field
+			// and non-doubled quote may appear in a quoted field.
+			// fix issue: https://github.com/golang/go/issues/21672
+			r.LazyQuotes = true
 			records, err := r.ReadAll()
 			if err != nil {
 				err = errors.Wrapf(err, "Output retrieving of Ansible execution for node %q failed", e.NodeName)

--- a/prov/ansible/execution_scripts.go
+++ b/prov/ansible/execution_scripts.go
@@ -41,7 +41,7 @@ do
 done
 [[[printf ". $HOME/%s/%s" $.OperationRemotePath .BasePrimary]]]
 [[[range $artName, $art := .Outputs -]]]
-[[[printf "echo %s,$%s >> $HOME/%s/out.csv" $artName (cut $artName) $.OperationRemotePath]]]
+[[[printf "echo %s,\\\"$%s\\\" >> $HOME/%s/out.csv" $artName (cut $artName) $.OperationRemotePath]]]
 [[[printf "echo $%s" $artName]]]
 [[[end]]]
 [[[if .HaveOutput]]]


### PR DESCRIPTION
# Pull Request description

- Set lazyQuotes field to true for csv reader
- Wrap csv fields with double quotes

### How to verify it
Deploy https://github.com/alien4cloud/csar-public-library/tree/develop/org/alien4cloud/java
