### PR TITLE
Feature/brbdcf 1356 deployments latency

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -223,7 +223,7 @@ func setConfig() {
 	serverCmd.PersistentFlags().Int("ansible_connection_retries", 5, "Number of retries in case of Ansible SSH connection failure")
 	serverCmd.PersistentFlags().String("operation_remote_base_dir", ".yorc", "Name of the temporary directory used by Ansible on the nodes")
 	serverCmd.PersistentFlags().Bool("keep_operation_remote_path", config.DefaultKeepOperationRemotePath, "Define wether the path created to store artifacts on the nodes will be removed at the end of workflow executions.")
-	serverCmd.PersistentFlags().Bool("ansible_archive_artifacts", config.DefaultArchiveArtifacts, "Define wether artifacts should be archived before being copied on remote nodes.")
+	serverCmd.PersistentFlags().Bool("ansible_archive_artifacts", config.DefaultArchiveArtifacts, "Define wether artifacts should be archived before being copied on remote nodes (requires tar to be installed on remote nodes).")
 	serverCmd.PersistentFlags().Bool("ansible_cache_facts", config.DefaultCacheFacts, "Define wether Ansible facts (useful variables about remote hosts) should be cached.")
 
 	//Bind Consul persistent flags

--- a/commands/server.go
+++ b/commands/server.go
@@ -47,6 +47,8 @@ var ansibleConfiguration = map[string]interface{}{
 	"ansible.connection_retries":         5,
 	"ansible.operation_remote_base_dir":  ".yorc",
 	"ansible.keep_operation_remote_path": config.DefaultKeepOperationRemotePath,
+	"ansible.archive_artifacts":          config.DefaultArchiveArtifacts,
+	"ansible.fact_caching":               config.DefaultFactCaching,
 }
 
 var consulConfiguration = map[string]interface{}{
@@ -221,6 +223,8 @@ func setConfig() {
 	serverCmd.PersistentFlags().Int("ansible_connection_retries", 5, "Number of retries in case of Ansible SSH connection failure")
 	serverCmd.PersistentFlags().String("operation_remote_base_dir", ".yorc", "Name of the temporary directory used by Ansible on the nodes")
 	serverCmd.PersistentFlags().Bool("keep_operation_remote_path", config.DefaultKeepOperationRemotePath, "Define wether the path created to store artifacts on the nodes will be removed at the end of workflow executions.")
+	serverCmd.PersistentFlags().Bool("ansible_archive_artifacts", config.DefaultArchiveArtifacts, "Define wether artifacts should be archived before being copied on remote nodes.")
+	serverCmd.PersistentFlags().Bool("ansible_fact_caching", config.DefaultFactCaching, "Define wether Ansible facts (useful variables about remote hosts) should be cached.")
 
 	//Bind Consul persistent flags
 	for key := range consulConfiguration {

--- a/commands/server.go
+++ b/commands/server.go
@@ -48,7 +48,7 @@ var ansibleConfiguration = map[string]interface{}{
 	"ansible.operation_remote_base_dir":  ".yorc",
 	"ansible.keep_operation_remote_path": config.DefaultKeepOperationRemotePath,
 	"ansible.archive_artifacts":          config.DefaultArchiveArtifacts,
-	"ansible.fact_caching":               config.DefaultFactCaching,
+	"ansible.cache_facts":                config.DefaultCacheFacts,
 }
 
 var consulConfiguration = map[string]interface{}{
@@ -224,7 +224,7 @@ func setConfig() {
 	serverCmd.PersistentFlags().String("operation_remote_base_dir", ".yorc", "Name of the temporary directory used by Ansible on the nodes")
 	serverCmd.PersistentFlags().Bool("keep_operation_remote_path", config.DefaultKeepOperationRemotePath, "Define wether the path created to store artifacts on the nodes will be removed at the end of workflow executions.")
 	serverCmd.PersistentFlags().Bool("ansible_archive_artifacts", config.DefaultArchiveArtifacts, "Define wether artifacts should be archived before being copied on remote nodes.")
-	serverCmd.PersistentFlags().Bool("ansible_fact_caching", config.DefaultFactCaching, "Define wether Ansible facts (useful variables about remote hosts) should be cached.")
+	serverCmd.PersistentFlags().Bool("ansible_cache_facts", config.DefaultCacheFacts, "Define wether Ansible facts (useful variables about remote hosts) should be cached.")
 
 	//Bind Consul persistent flags
 	for key := range consulConfiguration {

--- a/commands/server_test.go
+++ b/commands/server_test.go
@@ -165,7 +165,10 @@ func TestConfigFile(t *testing.T) {
 				DebugExec:               true,
 				ConnectionRetries:       10,
 				OperationRemoteBaseDir:  "test_base_dir",
-				KeepOperationRemotePath: true},
+				KeepOperationRemotePath: true,
+				ArchiveArtifacts:        true,
+				FactCaching:             true,
+			},
 			ConsulConfig: config.Consul{
 				Token:          "testToken",
 				Datacenter:     "testDC",
@@ -186,6 +189,8 @@ func TestConfigFile(t *testing.T) {
 				ConnectionRetries:       11,
 				OperationRemoteBaseDir:  "test_base_dir2",
 				KeepOperationRemotePath: true,
+				ArchiveArtifacts:        true,
+				FactCaching:             true,
 			},
 			ConsulConfig: config.Consul{
 				Token:          "testToken2",

--- a/commands/server_test.go
+++ b/commands/server_test.go
@@ -167,7 +167,7 @@ func TestConfigFile(t *testing.T) {
 				OperationRemoteBaseDir:  "test_base_dir",
 				KeepOperationRemotePath: true,
 				ArchiveArtifacts:        true,
-				FactCaching:             true,
+				CacheFacts:              true,
 			},
 			ConsulConfig: config.Consul{
 				Token:          "testToken",
@@ -190,7 +190,7 @@ func TestConfigFile(t *testing.T) {
 				OperationRemoteBaseDir:  "test_base_dir2",
 				KeepOperationRemotePath: true,
 				ArchiveArtifacts:        true,
-				FactCaching:             true,
+				CacheFacts:              true,
 			},
 			ConsulConfig: config.Consul{
 				Token:          "testToken2",

--- a/commands/testdata/config_flat.yorc.json
+++ b/commands/testdata/config_flat.yorc.json
@@ -12,6 +12,8 @@
   "ansible_connection_retries": 10,
   "operation_remote_base_dir": "test_base_dir",
 	"keep_operation_remote_path": true, 
+  "ansible_archive_artifacts": true,
+  "ansible_fact_caching": true,
   "consul_address": "http://127.0.0.1:8500",
   "consul_datacenter": "testDC",
   "consul_token": "testToken",

--- a/commands/testdata/config_flat.yorc.json
+++ b/commands/testdata/config_flat.yorc.json
@@ -13,7 +13,7 @@
   "operation_remote_base_dir": "test_base_dir",
 	"keep_operation_remote_path": true, 
   "ansible_archive_artifacts": true,
-  "ansible_fact_caching": true,
+  "ansible_cache_facts": true,
   "consul_address": "http://127.0.0.1:8500",
   "consul_datacenter": "testDC",
   "consul_token": "testToken",

--- a/commands/testdata/config_structured.yorc.json
+++ b/commands/testdata/config_structured.yorc.json
@@ -14,7 +14,7 @@
     "operation_remote_base_dir": "test_base_dir2",
     "keep_operation_remote_path": true,
     "archive_artifacts": true,
-    "fact_caching": true
+    "cache_facts": true
   },
   "consul":{
     "address": "http://127.0.0.1:8502",

--- a/commands/testdata/config_structured.yorc.json
+++ b/commands/testdata/config_structured.yorc.json
@@ -12,7 +12,9 @@
     "debug": true,
     "connection_retries": 11,
     "operation_remote_base_dir": "test_base_dir2",
-    "keep_operation_remote_path": true
+    "keep_operation_remote_path": true,
+    "archive_artifacts": true,
+    "fact_caching": true
   },
   "consul":{
     "address": "http://127.0.0.1:8502",

--- a/config/config.go
+++ b/config/config.go
@@ -47,8 +47,16 @@ const DefaultPluginDir = "plugins"
 // DefaultServerGracefulShutdownTimeout is the default timeout for a graceful shutdown of a Yorc server before exiting
 const DefaultServerGracefulShutdownTimeout = 5 * time.Minute
 
-//DefaultKeepOperationRemotePath is set to true by default in order to remove path created to store operation artifacts on nodes.
+//DefaultKeepOperationRemotePath is set to false by default in order to remove path created to store operation artifacts on nodes.
 const DefaultKeepOperationRemotePath = false
+
+//DefaultArchiveArtifacts is set to false by default.
+// When ArchiveArtifacts is true, destination hosts need tar to be installed,
+// to be able to unarchive artifacts.
+const DefaultArchiveArtifacts = false
+
+// DefaultFactCaching is set to false by default, meaning ansible facts are not cached by default
+const DefaultFactCaching = false
 
 // DefaultWfStepGracefulTerminationTimeout is the default timeout for a graceful termination of a workflow step during concurrent workflow step failure
 const DefaultWfStepGracefulTerminationTimeout = 2 * time.Minute
@@ -109,6 +117,8 @@ type Ansible struct {
 	ConnectionRetries       int              `mapstructure:"connection_retries"`
 	OperationRemoteBaseDir  string           `mapstructure:"operation_remote_base_dir"`
 	KeepOperationRemotePath bool             `mapstructure:"keep_operation_remote_path"`
+	ArchiveArtifacts        bool             `mapstructure:"archive_artifacts"`
+	FactCaching             bool             `mapstructure:"fact_caching"`
 	HostedOperations        HostedOperations `mapstructure:"hosted_operations"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -55,8 +55,8 @@ const DefaultKeepOperationRemotePath = false
 // to be able to unarchive artifacts.
 const DefaultArchiveArtifacts = false
 
-// DefaultFactCaching is set to false by default, meaning ansible facts are not cached by default
-const DefaultFactCaching = false
+// DefaultCacheFacts is set to false by default, meaning ansible facts are not cached by default
+const DefaultCacheFacts = false
 
 // DefaultWfStepGracefulTerminationTimeout is the default timeout for a graceful termination of a workflow step during concurrent workflow step failure
 const DefaultWfStepGracefulTerminationTimeout = 2 * time.Minute
@@ -118,7 +118,7 @@ type Ansible struct {
 	OperationRemoteBaseDir  string           `mapstructure:"operation_remote_base_dir"`
 	KeepOperationRemotePath bool             `mapstructure:"keep_operation_remote_path"`
 	ArchiveArtifacts        bool             `mapstructure:"archive_artifacts"`
-	FactCaching             bool             `mapstructure:"fact_caching"`
+	CacheFacts              bool             `mapstructure:"cache_facts"`
 	HostedOperations        HostedOperations `mapstructure:"hosted_operations"`
 }
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -22,6 +22,14 @@ Globals Command-line options
 
   * ``--ansible_connection_retries``: Number of retries in case of Ansible SSH connection failure.
 
+.. _option_ansible_cache_facts_cmd:
+
+  * ``--ansible_cache_facts``: If set to true, caches Ansible facts (values fetched on remote hosts about network/hardware/OS/virtualization configuration) so that these facts are not recomputed each time a new operation is a run for a given deployment (false by default: no caching).
+
+.. _option_ansible_archive_artifacts_cmd:
+
+  * ``--ansible_archive_artifacts``: If set to true, archives operation bash/python scripts locally, copies this archive and unarchives it on remote hosts (requires tar to be installed on remote hosts), to avoid multiple time consuming remote copy operations of individual scripts, (false by default: no archive).
+
 .. _option_operation_remote_base_dir_cmd:
 
   * ``--operation_remote_base_dir``: Specify an alternative working directory for Ansible on provisioned Compute.
@@ -276,6 +284,14 @@ All available configuration options for Ansible are:
 
   * ``connection_retries``: Equivalent to :ref:`--ansible_connection_retries <option_ansible_connection_retries_cmd>` command-line flag.
 
+.. _option_ansible_cache_facts_cfg:
+
+  * ``cache_facts``: Equivalent to :ref:`--ansible_cache_facts <option_ansible_cache_facts_cmd>` command-line flag.
+
+.. _option_ansible_archive_artifacts_cfg:
+
+  * ``archive_artifacts``: Equivalent to :ref:`--ansible_archive_artifacts <option_ansible_archive_artifacts_cmd>` command-line flag.
+
 .. _option_operation_remote_base_dir_cfg:
 
   * ``operation_remote_base_dir``: Equivalent to :ref:`--operation_remote_base_dir <option_operation_remote_base_dir_cmd>` command-line flag.
@@ -315,6 +331,23 @@ All available configuration options for Ansible are:
       .. _option_ansible_sandbox_hosted_ops_default_sandbox_env_cfg:
 
       * ``env``: An optional list environment variables to set when creating the container. The format of each variable is ``var_name=value``.
+
+
+Ansible performance considerations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As described in TOSCA :ref:`tosca_operations_implementations_section`, Yorc supports these builtin implementations for operations to execute on remote hosts :
+  * Bash scripts
+  * Python scripts
+  * Ansible Playbooks
+
+It is recommended to implement operations as Ansible Playbooks to get the best execution performance.
+
+When operations are not implemented using Ansible playbooks, the following Ansible configuration settings allow to improve the performance of scripts execution on remote hosts :
+  * ``use_openssh``: Prefer OpenSSH over Paramiko, a Python implementation of SSH (used by default) to provision remote hosts. OpenSSH have several optimization like reusing connections that should improve preformance but may lead to issues on older systems
+    See Ansible documentation on `Remote connection information <https://docs.ansible.com/ansible/latest/user_guide/intro_getting_started.html#remote-connection-information>`_.
+  * ``cache_facts``: Caches `Ansible facts <https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#fact-caching>`_ (values fetched on remote hosts about network/hardware/OS/virtualization configuration) so that these facts are not recomputed each time a new operation is a run for a given deployment.
+  * ``archive_artifacts``: Archives operation bash/python scripts locally, copies this archive and unarchives it on remote hosts (requires tar to be installed on remote hosts), to avoid multiple time consuming remote copy operations of individual scripts.
 
 .. _yorc_config_file_consul_section:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -28,7 +28,7 @@ Globals Command-line options
 
 .. _option_ansible_archive_artifacts_cmd:
 
-  * ``--ansible_archive_artifacts``: If set to true, archives operation bash/python scripts locally, copies this archive and unarchives it on remote hosts (requires tar to be installed on remote hosts), to avoid multiple time consuming remote copy operations of individual scripts, (false by default: no archive).
+  * ``--ansible_archive_artifacts``: If set to true, archives operation bash/python scripts locally, copies this archive and unarchives it on remote hosts (requires tar to be installed on remote hosts), to avoid multiple time consuming remote copy operations of individual scripts (false by default: no archive).
 
 .. _option_operation_remote_base_dir_cmd:
 
@@ -337,6 +337,7 @@ Ansible performance considerations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 As described in TOSCA :ref:`tosca_operations_implementations_section`, Yorc supports these builtin implementations for operations to execute on remote hosts :
+
   * Bash scripts
   * Python scripts
   * Ansible Playbooks
@@ -344,6 +345,7 @@ As described in TOSCA :ref:`tosca_operations_implementations_section`, Yorc supp
 It is recommended to implement operations as Ansible Playbooks to get the best execution performance.
 
 When operations are not implemented using Ansible playbooks, the following Ansible configuration settings allow to improve the performance of scripts execution on remote hosts :
+
   * ``use_openssh``: Prefer OpenSSH over Paramiko, a Python implementation of SSH (used by default) to provision remote hosts. OpenSSH have several optimization like reusing connections that should improve preformance but may lead to issues on older systems
     See Ansible documentation on `Remote connection information <https://docs.ansible.com/ansible/latest/user_guide/intro_getting_started.html#remote-connection-information>`_.
   * ``cache_facts``: Caches `Ansible facts <https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#fact-caching>`_ (values fetched on remote hosts about network/hardware/OS/virtualization configuration) so that these facts are not recomputed each time a new operation is a run for a given deployment.
@@ -557,6 +559,14 @@ Environment variables
 .. _option_ansible_connection_retries_env:
 
   * ``YORC_ANSIBLE_CONNECTION_RETRIES``: Equivalent to :ref:`--ansible_connection_retries <option_ansible_connection_retries_cmd>` command-line flag.
+
+.. _option_ansible_cache_facts_env:
+
+  * ``YORC_ANSIBLE_CACHE_FACTS``: Equivalent to :ref:`--ansible_cache_facts <option_ansible_cache_facts_cmd>` command-line flag.
+
+.. _option_ansible_archive_artifacts_env:
+
+  * ``YORC_ANSIBLE_ARCHIVE_ARTIFACTS``: Equivalent to :ref:`--ansible_archive_artifacts <option_ansible_archive_artifacts_cmd>` command-line flag.
 
 .. _option_operation_remote_base_dir_env:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -344,12 +344,7 @@ As described in TOSCA :ref:`tosca_operations_implementations_section`, Yorc supp
 
 It is recommended to implement operations as Ansible Playbooks to get the best execution performance.
 
-When operations are not implemented using Ansible playbooks, the following Ansible configuration settings allow to improve the performance of scripts execution on remote hosts :
-
-  * ``use_openssh``: Prefer OpenSSH over Paramiko, a Python implementation of SSH (used by default) to provision remote hosts. OpenSSH have several optimization like reusing connections that should improve preformance but may lead to issues on older systems
-    See Ansible documentation on `Remote connection information <https://docs.ansible.com/ansible/latest/user_guide/intro_getting_started.html#remote-connection-information>`_.
-  * ``cache_facts``: Caches `Ansible facts <https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#fact-caching>`_ (values fetched on remote hosts about network/hardware/OS/virtualization configuration) so that these facts are not recomputed each time a new operation is a run for a given deployment.
-  * ``archive_artifacts``: Archives operation bash/python scripts locally, copies this archive and unarchives it on remote hosts (requires tar to be installed on remote hosts), to avoid multiple time consuming remote copy operations of individual scripts.
+When operations are not implemented using Ansible playbooks, see the Performance section on :ref:`tosca_operations_performance_section` to improve the performance of scripts execution on remote hosts.
 
 .. _yorc_config_file_consul_section:
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,4 +21,5 @@ Yorc |release| Documentation
    ha
    docker
    telemetry
+   performance
 

--- a/doc/performance.rst
+++ b/doc/performance.rst
@@ -1,0 +1,23 @@
+.. _yorc_performance_section:
+
+Performance
+===========
+
+.. _tosca_operations_performance_section:
+TOSCA Operations
+----------------
+
+As described in TOSCA :ref:`tosca_operations_implementations_section`, Yorc supports these builtin implementations for operations to execute on remote hosts :
+
+  * Bash scripts
+  * Python scripts
+  * Ansible Playbooks
+
+It is recommended to implement operations as Ansible Playbooks to get the best execution performance.
+
+When operations are not implemented using Ansible playbooks, the following Yorc Server :ref:`yorc_config_file_ansible_section` settings allow to improve the performance of scripts execution on remote hosts :
+
+  * ``use_openssh``: Prefer OpenSSH over Paramiko, a Python implementation of SSH (used by default) to provision remote hosts. OpenSSH have several optimization like reusing connections that should improve preformance but may lead to issues on older systems
+    See Ansible documentation on `Remote connection information <https://docs.ansible.com/ansible/latest/user_guide/intro_getting_started.html#remote-connection-information>`_.
+  * ``cache_facts``: Caches `Ansible facts <https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#fact-caching>`_ (values fetched on remote hosts about network/hardware/OS/virtualization configuration) so that these facts are not recomputed each time a new operation is a run for a given deployment.
+  * ``archive_artifacts``: Archives operation bash/python scripts locally, copies this archive and unarchives it on remote hosts (requires tar to be installed on remote hosts), to avoid multiple time consuming remote copy operations of individual scripts.

--- a/doc/tosca.rst
+++ b/doc/tosca.rst
@@ -21,6 +21,8 @@ Bellow are the specificities of Yorc
 TOSCA Operations
 ----------------
 
+.. _tosca_operations_implementations_section:
+
 Supported Operations implementations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -57,7 +57,6 @@ host_key_checking=False
 timeout=30
 stdout_callback = json
 retry_files_save_path = #PLAY_PATH#
-callback_whitelist = profile_tasks, timer
 `
 const ansibleFactCaching = `
 gathering = smart
@@ -124,7 +123,7 @@ type executionCommon struct {
 	OperationRemotePath      string
 	KeepOperationRemotePath  bool
 	ArchiveArtifacts         string
-	FactCaching              bool
+	CacheFacts               bool
 	EnvInputs                []*operations.EnvInput
 	VarInputsNames           []string
 	Primary                  string
@@ -159,7 +158,7 @@ func newExecution(ctx context.Context, kv *api.KV, cfg config.Configuration, tas
 		//KeepOperationRemotePath property is required to be public when resolving templates.
 		KeepOperationRemotePath: cfg.Ansible.KeepOperationRemotePath,
 		ArchiveArtifacts:        strconv.FormatBool(cfg.Ansible.ArchiveArtifacts),
-		FactCaching:             cfg.Ansible.FactCaching,
+		CacheFacts:              cfg.Ansible.CacheFacts,
 		operation:               operation,
 		VarInputsNames:          make([]string, 0),
 		EnvInputs:               make([]*operations.EnvInput, 0),
@@ -884,7 +883,7 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 	}
 
 	ansibleCfgContent := strings.Replace(ansibleConfig, "#PLAY_PATH#", ansibleRecipePath, -1)
-	if e.FactCaching {
+	if e.CacheFacts {
 		ansibleCfgCacheContent := strings.Replace(ansibleFactCaching, "#FACTS_CACHE_PATH#", ansiblePath, -1)
 		ansibleCfgContent += ansibleCfgCacheContent
 	}

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -15,10 +15,12 @@
 package ansible
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"encoding/csv"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -55,6 +57,12 @@ host_key_checking=False
 timeout=30
 stdout_callback = json
 retry_files_save_path = #PLAY_PATH#
+callback_whitelist = profile_tasks, timer
+`
+const ansibleFactCaching = `
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = #FACTS_CACHE_PATH#/facts_cache
 `
 
 type ansibleRetriableError struct {
@@ -115,6 +123,8 @@ type executionCommon struct {
 	OperationRemoteBaseDir   string
 	OperationRemotePath      string
 	KeepOperationRemotePath  bool
+	ArchiveArtifacts         string
+	FactCaching              bool
 	EnvInputs                []*operations.EnvInput
 	VarInputsNames           []string
 	Primary                  string
@@ -148,6 +158,8 @@ func newExecution(ctx context.Context, kv *api.KV, cfg config.Configuration, tas
 		NodeName:     nodeName,
 		//KeepOperationRemotePath property is required to be public when resolving templates.
 		KeepOperationRemotePath: cfg.Ansible.KeepOperationRemotePath,
+		ArchiveArtifacts:        strconv.FormatBool(cfg.Ansible.ArchiveArtifacts),
+		FactCaching:             cfg.Ansible.FactCaching,
 		operation:               operation,
 		VarInputsNames:          make([]string, 0),
 		EnvInputs:               make([]*operations.EnvInput, 0),
@@ -758,16 +770,20 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 	logOptFields[events.InstanceID] = currentInstance
 	ctx = events.NewContext(ctx, logOptFields)
 	events.WithContextOptionalFields(ctx).NewLogEntry(events.INFO, e.deploymentID).RegisterAsString("Start the ansible execution of : " + e.NodeName + " with operation : " + e.operation.Name)
-	var ansibleRecipePath string
-	if e.operation.RelOp.IsRelationshipOperation {
-		ansibleRecipePath = filepath.Join(e.cfg.WorkingDirectory, "deployments", e.deploymentID, "ansible", e.NodeName, e.relationshipType, e.operation.RelOp.TargetRelationship, e.operation.Name, currentInstance)
-	} else {
-		ansibleRecipePath = filepath.Join(e.cfg.WorkingDirectory, "deployments", e.deploymentID, "ansible", e.NodeName, e.operation.Name, currentInstance)
-	}
-	ansibleRecipePath, err := filepath.Abs(ansibleRecipePath)
+
+	ansiblePath := filepath.Join(e.cfg.WorkingDirectory, "deployments", e.deploymentID, "ansible")
+	ansiblePath, err := filepath.Abs(ansiblePath)
 	if err != nil {
 		return err
 	}
+
+	var ansibleRecipePath string
+	if e.operation.RelOp.IsRelationshipOperation {
+		ansibleRecipePath = filepath.Join(ansiblePath, e.NodeName, e.relationshipType, e.operation.RelOp.TargetRelationship, e.operation.Name, currentInstance)
+	} else {
+		ansibleRecipePath = filepath.Join(ansiblePath, e.NodeName, e.operation.Name, currentInstance)
+	}
+
 	if err = os.RemoveAll(ansibleRecipePath); err != nil {
 		err = errors.Wrapf(err, "Failed to remove ansible recipe directory %q for node %q operation %q", ansibleRecipePath, e.NodeName, e.operation.Name)
 		log.Debugf("%+v", err)
@@ -866,7 +882,13 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
 		return err
 	}
-	if err = ioutil.WriteFile(filepath.Join(ansibleRecipePath, "ansible.cfg"), []byte(strings.Replace(ansibleConfig, "#PLAY_PATH#", ansibleRecipePath, -1)), 0664); err != nil {
+
+	ansibleCfgContent := strings.Replace(ansibleConfig, "#PLAY_PATH#", ansibleRecipePath, -1)
+	if e.FactCaching {
+		ansibleCfgCacheContent := strings.Replace(ansibleFactCaching, "#FACTS_CACHE_PATH#", ansiblePath, -1)
+		ansibleCfgContent += ansibleCfgCacheContent
+	}
+	if err = ioutil.WriteFile(filepath.Join(ansibleRecipePath, "ansible.cfg"), []byte(ansibleCfgContent), 0664); err != nil {
 		err = errors.Wrap(err, "Failed to write ansible.cfg file")
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.ERROR, e.deploymentID).RegisterAsString(err.Error())
 		return err
@@ -879,6 +901,12 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 		e.OperationRemotePath = path.Join(e.OperationRemoteBaseDir, e.NodeName, e.operation.Name)
 	}
 	log.Debugf("OperationRemotePath:%s", e.OperationRemotePath)
+	// Build archives for artifacts
+	for artifactName, artifactPath := range e.Artifacts {
+		tarPath := filepath.Join(ansibleRecipePath, artifactName+".tar")
+		buildArchive(e.OverlayPath, artifactPath, tarPath)
+	}
+
 	err = e.ansibleRunner.runAnsible(ctx, retry, currentInstance, ansibleRecipePath)
 	if err != nil {
 		return err
@@ -986,4 +1014,56 @@ func (e *executionCommon) executePlaybook(ctx context.Context, retry bool, ansib
 	}
 
 	return nil
+}
+
+func buildArchive(rootDir, artifactDir, tarPath string) error {
+
+	srcDir := filepath.Join(rootDir, artifactDir)
+	tarFile, err := os.Create(tarPath)
+	if err != nil {
+		return err
+	}
+	defer tarFile.Close()
+
+	var fileWriter io.WriteCloser = tarFile
+
+	tarfileWriter := tar.NewWriter(fileWriter)
+	defer tarfileWriter.Close()
+
+	_, err = os.Stat(srcDir)
+	if err != nil {
+		return nil
+	}
+
+	return filepath.Walk(srcDir,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			header, err := tar.FileInfoHeader(info, info.Name())
+			if err != nil {
+				return err
+			}
+
+			if rootDir != "" {
+				header.Name = strings.TrimPrefix(strings.Replace(path, rootDir, "", -1), string(filepath.Separator))
+			}
+
+			if err := tarfileWriter.WriteHeader(header); err != nil {
+				return err
+			}
+
+			if info.IsDir() {
+				return nil
+			}
+
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+			_, err = io.Copy(tarfileWriter, file)
+			return err
+		})
 }

--- a/prov/ansible/execution_scripts.go
+++ b/prov/ansible/execution_scripts.go
@@ -128,7 +128,13 @@ const shellAnsiblePlaybook = `
     - copy: src="[[[.ScriptToRun]]]" dest="{{ ansible_env.HOME}}/[[[.OperationRemotePath]]]" mode=0744
     [[[ range $artName, $art := .Artifacts -]]]
     [[[printf "- file: path=\"{{ ansible_env.HOME}}/%s/%s\" state=directory mode=0755" $.OperationRemotePath (path $art)]]]
+    [[[printf "- unarchive: src=\"%s/%s.tar\" dest=\"{{ ansible_env.HOME}}/%s\"" $.DestFolder $artName $.OperationRemotePath]]]
+    [[[printf "  register: result"]]]
+    [[[printf "  ignore_errors: yes"]]]
+    [[[printf "  when: %s" $.ArchiveArtifacts]]]
+    [[[printf "# Fall back on copy if archive artifacts is disabled or unarchive failed (can happen if tar is missing on remote host)"]]]
     [[[printf "- copy: src=\"%s/%s\" dest=\"{{ ansible_env.HOME}}/%s/%s\"" $.OverlayPath $art $.OperationRemotePath (path $art)]]]
+    [[[printf "  when: (not %s) or result.failed" $.ArchiveArtifacts]]]
     [[[end]]]
     [[[printf "- shell: \"/bin/bash -l -c {{ ansible_env.HOME}}/%s/wrapper\"" $.OperationRemotePath]]]
       environment:


### PR DESCRIPTION
# Pull Request description

## Description of the change

Added Yorc server configuration parameters to improve the performance of bash/python scripts implementation artifacts when needed.

### What I did

Added 2 new configuration parameters in the Ansible section of Yorc server configuration :

- **cache_facts**: If set to true, caches Ansible facts (values fetched on remote hosts about network/hardware/OS/virtualization configuration) so that these facts are not recomputed each time a new operation is a run for a given deployment (false by default: no caching).
- **archive_artifacts**: If set to true, archives operation bash/python scripts locally, copies this archive and unarchives it on remote hosts (requires tar to be installed on remote hosts), to avoid multiple time consuming remote copy operations of individual scripts (false by default: no archive).


Updated the Yorc Server configuration documentation to describe these new parameters.
In the Ansible Configuration section, added a paragraph on performance considerations, to describe ansible playbooks performs better than scripts artifacts, and to describe parameters that can be used to improve performances when scripts are used.

### How to verify it

First, keeping default values in Yorc Server configuration, upload the Consul Component in Ystia Forge at https://github.com/ystia/forge/tree/develop/org/ystia/consul
Create a topoloy with one such Consul component on a compute node, and deploy it on an OpenStack location with a CentOS 7 on-demand compute node.
Check in yorc deployment logs, that the consul deployment (once the Compute node has been created) takes more than 5 minutes.

Undeploy.

Then change the Yorc server configuration to have these Ansible settings :

>   "ansible": {
>     "use_openssh": true,
>     "debug": true,
>     "keep_operation_remote_path": true,
>     "archive_artifacts": true,
>     "cache_facts": true
>   }

These 3 parameters are the parameters allowing to improve performances: use_openssh, archive_artifacts, cache_facts.

Restart the Yorc Server with this new config, and deploy again the Consul topology.
Check the consul deployment (once the Compute node has been created) takes less than 1 minute now.
