### PR TITLE
Fixed no_address and preemptible usage

### DIFF
--- a/prov/terraform/google/compute_instance_test.go
+++ b/prov/terraform/google/compute_instance_test.go
@@ -55,7 +55,6 @@ func testSimpleComputeInstance(t *testing.T, kv *api.KV, cfg config.Configuratio
 	assert.Equal(t, "europe-west1-b", compute.Zone)
 	require.Len(t, compute.Disks, 1, "Expected one boot disk")
 	assert.Equal(t, "centos-cloud/centos-7", compute.Disks[0].Image, "Unexpected boot disk image")
-	assert.Equal(t, false, compute.NoAddress)
 	require.Len(t, compute.NetworkInterfaces, 1, "Expected one network interface for external access")
 	assert.Equal(t, []string{"tag1", "tag2"}, compute.Tags)
 	assert.Equal(t, map[string]string{"key1": "value1", "key2": "value2"}, compute.Labels)

--- a/prov/terraform/google/resources.go
+++ b/prov/terraform/google/resources.go
@@ -28,9 +28,7 @@ type ComputeInstance struct {
 	Description       string             `json:"description,omitempty"`
 	Labels            map[string]string  `json:"labels,omitempty"`
 	Metadata          map[string]string  `json:"metadata,omitempty"`
-	// NoAdress means no external IP address
-	NoAddress   bool `json:"no_address,omitempty"`
-	Preemptible bool `json:"preemptible,omitempty"`
+	Scheduling        Scheduling         `json:"scheduling,omitempty"`
 	// ServiceAccounts is an array of at most one element
 	ServiceAccounts []ServiceAccount `json:"service_account,omitempty"`
 	Tags            []string         `json:"tags,omitempty"`
@@ -63,4 +61,9 @@ type AccessConfig struct {
 type ServiceAccount struct {
 	Email  string   `json:"email,omitempty"`
 	Scopes []string `json:"scopes,omitempty"`
+}
+
+// Scheduling strategy to use
+type Scheduling struct {
+	Preemptible bool `json:"preemptible,omitempty"`
 }


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

The optional compute instance creation parameters `no_address` and `preemptible` were added in the terraform description as flat parameters, while they shouldn't.
`no_address` must just be used to create or not an `access_config` section like what we already do, and `preemptible` should be added in a section `scheduling`.

Removed the field no_address from terraform compute instance description
Removed the field preemptible from terraform compute instance description
Added a section scheduling, containing a parameter preemptible

### How to verify it

Deploy a GCP compute instance, selecting both parameters no_address and preemptible (unselected by default).

Once the compute instance is deployed, run `gcloud compute instances list` to verify the created compute instance has no external IP address assigned and is preemptible.
