### PR TITLE
Changed GCP compute instance parameter address to addresses

### DIFF
--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -69,11 +69,11 @@ node_types:
           keys startup-script or startup-script-url can be used to specify a script
           that will be executed by the Compute Node once it starts running.
         required: false
-      address:
+      addresses:
         type: string
         description: >
-          Assigns the given external address to the instance.
-          If not specified, and no_address is not true, an ephemeral IP address will be assigned.
+          Comma-separated list of external addresses. One external address will be assigned to each scalable Compute Node instance.
+          If not specified or if there aren't enough addresses specified for the number of scalable instances to create, and no_address is not true, an ephemeral IP address will be assigned.
         required: false
       no_address:
         type: boolean

--- a/prov/terraform/google/generator.go
+++ b/prov/terraform/google/generator.go
@@ -119,7 +119,7 @@ func (g *googleGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg
 			return false, nil, nil, err
 		}
 
-		for _, instanceName := range instances {
+		for index, instanceName := range instances {
 			var instanceState tosca.NodeState
 			instanceState, err = deployments.GetInstanceState(kv, deploymentID, nodeName, instanceName)
 			if err != nil {
@@ -129,7 +129,7 @@ func (g *googleGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg
 				// Do not generate something for this node instance (will be deleted if exists)
 				continue
 			}
-			err = g.generateComputeInstance(ctx, kv, cfg, deploymentID, nodeName, instanceName, &infrastructure, outputs)
+			err = g.generateComputeInstance(ctx, kv, cfg, deploymentID, nodeName, instanceName, index, &infrastructure, outputs)
 			if err != nil {
 				return false, nil, nil, err
 			}

--- a/prov/terraform/google/testdata/simpleComputeInstance.yaml
+++ b/prov/terraform/google/testdata/simpleComputeInstance.yaml
@@ -18,7 +18,9 @@ topology_template:
         zone: "europe-west1-b"
         image_project: "centos-cloud"
         image_family: "centos-7"
+        addresses: "1.1.1.1, 2.2.2.2"
         no_address: false
+        service_account: "yorc@yorc.net"
         tags: "tag1, tag2"
         labels: "key1=value1, key2=value2"
       capabilities:


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Changed GCP compute instance parameter `address` to `addresses`, comma-separated list of items.

### How I did it

To manage a topology with a compute node having its scalable capability default and max value > 1, changed the GCP compute parameter `address` allowing to speficy an address already reserved to use as a public address by a GCP compute instance.
The parameter is now `addresses`, and is a comma-separated list of external addresses. One external address will be assigned to each scalable Compute Node instance.
If not specified or if there aren't enough addresses specified for the number of scalable instances to create, and `no_address` is not true, an ephemeral IP address will be assigned.

### How to verify it

To be used with Yorc Alien4Cloud plugin pull request https://github.com/ystia/yorc-a4c-plugin/pull/30


Create a topology template containing a Compute node , update the Scalable capability to set default and max values to 2.
Choose to deploy this topology on a Google Cloud location, updating the Nodes Matching  Compute resource property "addresses" to specify 2 IP addresses separated by a comma
Deploy the topology
Check Yorc attempts to create 2 GCP compute instances, the first one using the first address specified and the second one using the second address specified.

