### PR TITLE
deployments/testdata/test_topology_client_service.yml

### DIFF
--- a/deployments/definition_store_test.go
+++ b/deployments/definition_store_test.go
@@ -944,12 +944,12 @@ func testTopologyTemplateMetadata(t *testing.T, kv *api.KV) {
 	// This topology template imports a tempologuy template with metatadata
 	// Checking the imported template metadata
 	expectedKeyValuePairs := map[string]string{
-		"topology/metadata/template_name":              "topotest-Environment",
-		"topology/metadata/template_version":           "0.1.0-SNAPSHOT",
-		"topology/metadata/template_author":            "yorcTester",
-		"topology/imports/3/metadata/template_name":    "test-component",
-		"topology/imports/3/metadata/template_version": "2.0.0-SNAPSHOT",
-		"topology/imports/3/metadata/template_author":  "yorcTester",
+		"topology/metadata/template_name":                               "topotest-Environment",
+		"topology/metadata/template_version":                            "0.1.0-SNAPSHOT",
+		"topology/metadata/template_author":                             "yorcTester",
+		"topology/imports/test_component.yml/metadata/template_name":    "test-component",
+		"topology/imports/test_component.yml/metadata/template_version": "2.0.0-SNAPSHOT",
+		"topology/imports/test_component.yml/metadata/template_author":  "yorcTester",
 	}
 
 	for key, expectedValue := range expectedKeyValuePairs {

--- a/deployments/testdata/test_topology_client_service.yml
+++ b/deployments/testdata/test_topology_client_service.yml
@@ -8,11 +8,11 @@ metadata:
 description: ""
 
 imports:
-  - <yorc-types.yml>
-  - <yorc-hostspool-types.yml>
+  - test_client_service_generated_topology.yml
   - test_service_public_types.yml
   - test_client_service_private_types.yml
-  - test_client_service_generated_topology.yml
+  - <yorc-hostspool-types.yml>
+  - <yorc-types.yml>
 
 topology_template:
   node_templates:


### PR DESCRIPTION
# Pull Request description

## Description of the change

Imports info (metadata, substitution mappings...) were stored in Consul using an import prefix imports/id,
id being the index of the import in the topology template.
This caused an issue when the import file itself contained imports, as the code was using the same prefix imports/id, and so was overloading infos stored for imports in the parent file.

### What I did

Instead of using the index of the import as a consul key, using the import path + the import name, flattened for convenience when searching for an import containing a given metadata template name

### How I did it

Reproduced the issue in unit tests by changing the order of imports in deployments/testdata/test_topology_client_service.yml
Fixed the issue by changing the import prefix used in definition_store.

### How to verify it

Besides unit tests yorc/deployments/substitution_mappings_test.go, use the Consul Service topology at https://github.com/ystia/yorc-a4c-plugin/tree/develop/tosca-samples/org/ystia/yorc/samples/consul/topologies/consulService to deploy a Consul Server on a Hosts Pool (or on OpenStack just updating the topology template to defined a public network).
At the last step of deployment wizard, select to expose a Service.

Then use the client topology at https://github.com/ystia/yorc-a4c-plugin/tree/develop/tosca-samples/org/ystia/yorc/samples/consul/topologies/consulClient to deploy a client relying on the exposed service.
Check the deployment is successful.

