### PR TITLE
Always return an empty string when attribute is not found for getAttr…

### DIFF
--- a/deployments/operations.go
+++ b/deployments/operations.go
@@ -21,11 +21,13 @@ import (
 	"strconv"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/pkg/errors"
 
+	"context"
+	"github.com/ystia/yorc/events"
 	"github.com/ystia/yorc/helper/collections"
 	"github.com/ystia/yorc/helper/consulutil"
 	"github.com/ystia/yorc/helper/stringutil"
@@ -573,11 +575,16 @@ func GetOperationInput(kv *api.KV, deploymentID, nodeName string, operation prov
 		}
 
 		for _, ins := range instances {
-			res, err = resolver(kv, deploymentID).context(withNodeName(nodeName), withInstanceName(ins), withRequirementIndex(operation.RelOp.RequirementIndex)).resolveFunction(f)
+			res, found, err = resolver(kv, deploymentID).context(withNodeName(nodeName), withInstanceName(ins), withRequirementIndex(operation.RelOp.RequirementIndex)).resolveFunction(f)
 			if err != nil {
 				return nil, err
 			}
-			results = append(results, OperationInputResult{ctxNodeName, ins, res})
+			if found {
+				results = append(results, OperationInputResult{ctxNodeName, ins, res})
+			} else {
+				ctx := events.NewContext(context.Background(), events.LogOptionalFields{events.NodeID: nodeName, events.InstanceID: ins})
+				events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).Registerf("[WARNING] The function %q hasn't be resolved for deployment: %q, node: %q, instance: %q. No operation input variable will be set", f, deploymentID, nodeName, ins)
+			}
 		}
 		return results, nil
 

--- a/deployments/resolver.go
+++ b/deployments/resolver.go
@@ -271,7 +271,12 @@ func (fr *functionResolver) resolveGetPropertyOrAttribute(rType string, operands
 	if err != nil {
 		return "", err
 	}
-	if !found {
+
+	// Always return an empty string when attribute is not found for GetAttribute function
+	if !found && rType == "attribute" {
+		log.Debugf("[WARNING] The attribute %q hasn't be found for deployment %q and node %q. So expression %q will return an empty string", args[0], fr.deploymentID, fr.nodeName, funcString)
+		return "", nil
+	} else if !found {
 		log.Debugf("Deployment %q, node %q, can't resolve expression %q", fr.deploymentID, fr.nodeName, funcString)
 		return "", errors.Errorf("Can't resolve expression %q", funcString)
 	}

--- a/deployments/resolver_test.go
+++ b/deployments/resolver_test.go
@@ -137,6 +137,10 @@ func testResolveComplex(t *testing.T, kv *api.KV) {
 		{"ResolveGetPropertyMapSubKey", context{"VANode1", "", ""}, args{`{get_property: [SELF, map, one]}`}, false, `1`},
 		{"ResolveGetPropertyMapSubKeyAlien", context{"VANode1", "", ""}, args{`{get_property: [SELF, "map.one"]}`}, false, `1`},
 		{"ResolveEmpty", context{"VANode1", "", ""}, args{`{get_property: [SELF, empty]}`}, false, ``},
+		{"ResolveGetAttributeWithAbsent", context{"VANode1", "0", ""}, args{`{get_attribute: [SELF, absentAttr]}`}, false, ``},
+		{"ResolveGetRequirementAttributeWithAbsent", context{"VANode1", "0", "0"}, args{`{get_attribute: [SELF, host, absentAttr]}`}, false, ``},
+		{"ResolveGetPropertyWithAbsent", context{"VANode1", "", ""}, args{`{get_property: [SELF, absentAttr]}`}, true, ``},
+		{"ResolveGetRequirementPropertyWithAbsent", context{"VANode1", "", "0"}, args{`{get_property: [SELF, host, absentAttr]}`}, true, ``},
 	}
 	for _, tt := range resolverTests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/deployments/resolver_test.go
+++ b/deployments/resolver_test.go
@@ -63,30 +63,35 @@ func testGetOperationOutput(t *testing.T, kv *api.KV) {
 	require.Nil(t, err)
 	r := resolver(kv, deploymentID)
 
-	result, err := r.context(withNodeName("GetOPOutputsNode"), withInstanceName("0"), withRequirementIndex("")).resolveFunction(generateToscaValueAssignmentFromString(t, `{ get_operation_output: [ SELF, Standard, configure, MY_OUTPUT ] }`).GetFunction())
+	result, found, err := r.context(withNodeName("GetOPOutputsNode"), withInstanceName("0"), withRequirementIndex("")).resolveFunction(generateToscaValueAssignmentFromString(t, `{ get_operation_output: [ SELF, Standard, configure, MY_OUTPUT ] }`).GetFunction())
 	require.Nil(t, err)
+	require.Equal(t, true, found)
 	require.Equal(t, "MY_RESULT", result)
 
 	_, err = kv.Put(&api.KVPair{Key: path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/relationship_instances/GetOPOutputsNode/0/0/outputs/configure/pre_configure_source/PARTITION_NAME"), Value: []byte("part1")}, nil)
 	require.Nil(t, err)
-	result, err = r.context(withNodeName("GetOPOutputsNode"), withInstanceName("0"), withRequirementIndex("0")).resolveFunction(generateToscaValueAssignmentFromString(t, `{ get_operation_output: [ SELF, Configure, pre_configure_source, PARTITION_NAME ] }`).GetFunction())
+	result, found, err = r.context(withNodeName("GetOPOutputsNode"), withInstanceName("0"), withRequirementIndex("0")).resolveFunction(generateToscaValueAssignmentFromString(t, `{ get_operation_output: [ SELF, Configure, pre_configure_source, PARTITION_NAME ] }`).GetFunction())
 	require.Nil(t, err, "%+v", err)
+	require.Equal(t, true, found)
 	require.Equal(t, "part1", result)
 
-	result, err = r.context(withNodeName("GetOPOutputsNode"), withInstanceName("0"), withRequirementIndex("")).resolveFunction(generateToscaValueAssignmentFromString(t, `{ get_attribute: [ SELF, partition_name ] }`).GetFunction())
+	result, found, err = r.context(withNodeName("GetOPOutputsNode"), withInstanceName("0"), withRequirementIndex("")).resolveFunction(generateToscaValueAssignmentFromString(t, `{ get_attribute: [ SELF, partition_name ] }`).GetFunction())
 	require.Nil(t, err, "%+v", err)
+	require.Equal(t, true, found)
 	require.Equal(t, "part1", result)
 
 	_, err = kv.Put(&api.KVPair{Key: path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/relationship_instances/GetOPOutputsNodeFirstReq/0/0/outputs/configure/pre_configure_source/PARTITION_NAME"), Value: []byte("part2")}, nil)
 	require.Nil(t, err)
-	result, err = r.context(withNodeName("GetOPOutputsNodeFirstReq"), withInstanceName("0"), withRequirementIndex("")).resolveFunction(generateToscaValueAssignmentFromString(t, `{ get_attribute: [ SELF, partition_name ] }`).GetFunction())
+	result, found, err = r.context(withNodeName("GetOPOutputsNodeFirstReq"), withInstanceName("0"), withRequirementIndex("")).resolveFunction(generateToscaValueAssignmentFromString(t, `{ get_attribute: [ SELF, partition_name ] }`).GetFunction())
 	require.Nil(t, err, "%+v", err)
+	require.Equal(t, true, found)
 	require.Equal(t, "part2", result)
 
 	_, err = kv.Put(&api.KVPair{Key: path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/relationship_instances/GetOPOutputsNodeSecondReq/1/0/outputs/configure/pre_configure_source/PARTITION_NAME"), Value: []byte("part3")}, nil)
 	require.Nil(t, err)
-	result, err = r.context(withNodeName("GetOPOutputsNodeSecondReq"), withInstanceName("0"), withRequirementIndex("")).resolveFunction(generateToscaValueAssignmentFromString(t, `{ get_attribute: [ SELF, partition_name ] }`).GetFunction())
+	result, found, err = r.context(withNodeName("GetOPOutputsNodeSecondReq"), withInstanceName("0"), withRequirementIndex("")).resolveFunction(generateToscaValueAssignmentFromString(t, `{ get_attribute: [ SELF, partition_name ] }`).GetFunction())
 	require.Nil(t, err, "%+v", err)
+	require.Equal(t, true, found)
 	require.Equal(t, "part3", result)
 
 }
@@ -102,8 +107,9 @@ func testGetOperationOutputReal(t *testing.T, kv *api.KV) {
 	_, err = kv.Put(&api.KVPair{Key: path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/relationship_instances/PublisherFromDockerVolume/0/0/outputs/configure/post_configure_target/HOST_PATH"), Value: []byte("/mypath")}, nil)
 	require.Nil(t, err)
 
-	result, err := r.context(withNodeName("PublisherFromDockerVolume"), withInstanceName("0"), withRequirementIndex("")).resolveFunction(generateToscaValueAssignmentFromString(t, `{ get_attribute: [ SELF, host_path ] }`).GetFunction())
+	result, found, err := r.context(withNodeName("PublisherFromDockerVolume"), withInstanceName("0"), withRequirementIndex("")).resolveFunction(generateToscaValueAssignmentFromString(t, `{ get_attribute: [ SELF, host_path ] }`).GetFunction())
 	require.Nil(t, err)
+	require.Equal(t, true, found)
 	require.Equal(t, "/mypath", result)
 
 }
@@ -124,32 +130,36 @@ func testResolveComplex(t *testing.T, kv *api.KV) {
 		functionAsString string
 	}
 	resolverTests := []struct {
-		name    string
-		context context
-		args    args
-		wantErr bool
-		want    string
+		name      string
+		context   context
+		args      args
+		wantErr   bool
+		wantFound bool
+		want      string
 	}{
-		{"ResolveGetPropertyListAll", context{"VANode1", "", ""}, args{`{get_property: [SELF, list]}`}, false, `["http://","yorc",".io"]`},
-		{"ResolveGetPropertyListIndex0", context{"VANode1", "", ""}, args{`{get_property: [SELF, list, 0]}`}, false, `http://`},
-		{"ResolveGetPropertyListIndex0Alien", context{"VANode1", "", ""}, args{`{get_property: [SELF, "list[0]"]}`}, false, `http://`},
-		{"ResolveGetPropertyMapAll", context{"VANode1", "", ""}, args{`{get_property: [SELF, map]}`}, false, `{"one":"1","two":"2"}`},
-		{"ResolveGetPropertyMapSubKey", context{"VANode1", "", ""}, args{`{get_property: [SELF, map, one]}`}, false, `1`},
-		{"ResolveGetPropertyMapSubKeyAlien", context{"VANode1", "", ""}, args{`{get_property: [SELF, "map.one"]}`}, false, `1`},
-		{"ResolveEmpty", context{"VANode1", "", ""}, args{`{get_property: [SELF, empty]}`}, false, ``},
-		{"ResolveGetAttributeWithAbsent", context{"VANode1", "0", ""}, args{`{get_attribute: [SELF, absentAttr]}`}, false, ``},
-		{"ResolveGetRequirementAttributeWithAbsent", context{"VANode1", "0", "0"}, args{`{get_attribute: [SELF, host, absentAttr]}`}, false, ``},
-		{"ResolveGetPropertyWithAbsent", context{"VANode1", "", ""}, args{`{get_property: [SELF, absentAttr]}`}, true, ``},
-		{"ResolveGetRequirementPropertyWithAbsent", context{"VANode1", "", "0"}, args{`{get_property: [SELF, host, absentAttr]}`}, true, ``},
+		{"ResolveGetPropertyListAll", context{"VANode1", "", ""}, args{`{get_property: [SELF, list]}`}, false, true, `["http://","yorc",".io"]`},
+		{"ResolveGetPropertyListIndex0", context{"VANode1", "", ""}, args{`{get_property: [SELF, list, 0]}`}, false, true, `http://`},
+		{"ResolveGetPropertyListIndex0Alien", context{"VANode1", "", ""}, args{`{get_property: [SELF, "list[0]"]}`}, false, true, `http://`},
+		{"ResolveGetPropertyMapAll", context{"VANode1", "", ""}, args{`{get_property: [SELF, map]}`}, false, true, `{"one":"1","two":"2"}`},
+		{"ResolveGetPropertyMapSubKey", context{"VANode1", "", ""}, args{`{get_property: [SELF, map, one]}`}, false, true, `1`},
+		{"ResolveGetPropertyMapSubKeyAlien", context{"VANode1", "", ""}, args{`{get_property: [SELF, "map.one"]}`}, false, true, `1`},
+		{"ResolveEmpty", context{"VANode1", "", ""}, args{`{get_property: [SELF, empty]}`}, false, true, ``},
+		{"ResolveGetAttributeWithAbsent", context{"VANode1", "0", ""}, args{`{get_attribute: [SELF, absentAttr]}`}, false, false, ``},
+		{"ResolveGetRequirementAttributeWithAbsent", context{"VANode1", "0", "0"}, args{`{get_attribute: [SELF, host, absentAttr]}`}, false, false, ``},
+		{"ResolveGetPropertyWithAbsent", context{"VANode1", "", ""}, args{`{get_property: [SELF, absentAttr]}`}, true, false, ``},
+		{"ResolveGetRequirementPropertyWithAbsent", context{"VANode1", "", "0"}, args{`{get_property: [SELF, host, absentAttr]}`}, true, false, ``},
 	}
 	for _, tt := range resolverTests {
 		t.Run(tt.name, func(t *testing.T) {
 			va := generateToscaValueAssignmentFromString(t, tt.args.functionAsString)
 			require.Equal(t, tosca.ValueAssignmentFunction, va.Type)
-			got, err := r.context(withNodeName(tt.context.nodeName), withInstanceName(tt.context.instanceName), withRequirementIndex(tt.context.requirementIndex)).resolveFunction(va.GetFunction())
+			got, found, err := r.context(withNodeName(tt.context.nodeName), withInstanceName(tt.context.instanceName), withRequirementIndex(tt.context.requirementIndex)).resolveFunction(va.GetFunction())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("resolveFunction() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if found != tt.wantFound {
+				t.Errorf("resolveFunction() found = %t, wantFound %t", found, tt.wantFound)
 			}
 
 			if err == nil && got != tt.want {

--- a/plugin/operation_test.go
+++ b/plugin/operation_test.go
@@ -76,7 +76,7 @@ func TestOperationExecutorExecOperation(t *testing.T) {
 
 	plugin := raw.(prov.OperationExecutor)
 	op := prov.Operation{
-		Name:                   "myOps",
+		Name: "myOps",
 		ImplementationArtifact: "tosca.artifacts.Implementation.Bash",
 		RelOp: prov.RelationshipOperation{
 			IsRelationshipOperation: true,
@@ -120,7 +120,7 @@ func TestOperationExecutorExecOperationWithFailure(t *testing.T) {
 
 	plugin := raw.(prov.OperationExecutor)
 	op := prov.Operation{
-		Name:                   "myOps",
+		Name: "myOps",
 		ImplementationArtifact: "tosca.artifacts.Implementation.Bash",
 		RelOp: prov.RelationshipOperation{
 			IsRelationshipOperation: true,


### PR DESCRIPTION
fixes #75
From what I understand, the selected proposal is to always return an empty string for getAttribute function when the associated attribute is not found during resolution.