### PR TITLE
Ignoring empty strings

### DIFF
--- a/deployments/nodes.go
+++ b/deployments/nodes.go
@@ -414,6 +414,7 @@ func GetBooleanNodeProperty(kv *api.KV, deploymentID, nodeName, propertyName str
 }
 
 // GetStringArrayNodeProperty returns the string Array value of a node property (default: false)
+// This function returns a nil array for an empty string property value
 func GetStringArrayNodeProperty(kv *api.KV, deploymentID, nodeName, propertyName string) ([]string, error) {
 	var result []string
 	strValue, err := GetNodePropertyValue(kv, deploymentID, nodeName, propertyName)
@@ -421,7 +422,7 @@ func GetStringArrayNodeProperty(kv *api.KV, deploymentID, nodeName, propertyName
 		return nil, err
 	}
 
-	if strValue != nil {
+	if strValue != nil && strValue.RawString() != "" {
 		values := strings.Split(strValue.RawString(), ",")
 		for _, val := range values {
 			result = append(result, strings.TrimSpace(val))


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fixing a change in GetStringArrayNodeProperty introduced in previous milestone that causes an issue to a compute instance creation on GCP when keeping the property `tags` to its default value (empty string).
The function GetStringArrayNodeProperty  was returning an array of one element (the element being empty string), causing issues to terraform detecting this empty string as an invalid value.

### What I did

As in previous release, GetStringArrayNodeProperty returns a nil array in case of an empty string property value

### How to verify it

Deploy a topology containing a Compute instance on GCP, keeping the default value for the property `tags` (empty string)

### Description for the changelog

Internal milestone change, won't appear in release changelogs

## Applicable Issues

#151 
