### PR TITLE
support ansible playbook from alien format

### DIFF
--- a/data/tosca/yorc-types.yml
+++ b/data/tosca/yorc-types.yml
@@ -16,6 +16,12 @@ artifact_types:
     mime_type: application/x-yaml
     file_ext: [ yml, yaml ]
 
+  org.alien4cloud.artifacts.AnsiblePlaybook:
+    description: "null"
+    derived_from: tosca.artifacts.Implementation
+    mime_type: application/zip
+    file_ext: [ansible]
+
 data_types:
   yorc.datatypes.ProvisioningCredential:
     derived_from: tosca.datatypes.Credential

--- a/data/tosca/yorc-types.yml
+++ b/data/tosca/yorc-types.yml
@@ -17,7 +17,7 @@ artifact_types:
     file_ext: [ yml, yaml ]
 
   org.alien4cloud.artifacts.AnsiblePlaybook:
-    description: "null"
+    description: "Alien4Cloud Ansible Playbook artifact type"
     derived_from: tosca.artifacts.Implementation
     mime_type: application/zip
     file_ext: [ansible]

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -191,13 +191,17 @@ func newExecution(ctx context.Context, kv *api.KV, cfg config.Configuration, tas
 	if err != nil {
 		return nil, err
 	}
+	isAlienAnsible, err := deployments.IsTypeDerivedFrom(kv, deploymentID, operation.ImplementationArtifact, "org.alien4cloud.artifacts.AnsiblePlaybook")
+	if err != nil {
+		return nil, err
+	}
 	var exec execution
 	if isBash || isPython {
 		execScript := &executionScript{executionCommon: execCommon, isPython: isPython}
 		execCommon.ansibleRunner = execScript
 		exec = execScript
-	} else if isAnsible {
-		execAnsible := &executionAnsible{executionCommon: execCommon}
+	} else if isAnsible || isAlienAnsible {
+		execAnsible := &executionAnsible{executionCommon: execCommon, isAlienAnsible: isAlienAnsible}
 		execCommon.ansibleRunner = execAnsible
 		exec = execAnsible
 	} else {

--- a/prov/ansible/execution_ansible.go
+++ b/prov/ansible/execution_ansible.go
@@ -79,9 +79,11 @@ func (e *executionAnsible) runAnsible(ctx context.Context, retry bool, currentIn
 			}
 		}
 		if playbook == "" {
-			return errors.New("No PLAYBOOK_ENTRY input found for an alien4cloud ansible implementation")
+			err = errors.New("No PLAYBOOK_ENTRY input found for an alien4cloud ansible implementation")
 		}
-		e.PlaybookPath, err = filepath.Abs(filepath.Join(e.OverlayPath, filepath.Dir(e.Primary), playbook))
+		if err == nil {
+			e.PlaybookPath, err = filepath.Abs(filepath.Join(e.OverlayPath, filepath.Dir(e.Primary), playbook))
+		}
 	}
 	if err != nil {
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, e.deploymentID).RegisterAsString(err.Error())

--- a/prov/ansible/execution_ansible.go
+++ b/prov/ansible/execution_ansible.go
@@ -30,7 +30,7 @@ import (
 	"github.com/ystia/yorc/events"
 )
 
-const ansiblePlaybook = `
+const uploadArtifactsPlaybook = `
 - name: Upload artifacts
   hosts: all
   strategy: free
@@ -38,6 +38,9 @@ const ansiblePlaybook = `
 [[[ range $artName, $art := .Artifacts ]]]    [[[printf "- file: path=\"{{ ansible_env.HOME}}/%s/%s\" state=directory mode=0755" $.OperationRemotePath (path $art)]]]
     [[[printf "- copy: src=\"%s/%s\" dest=\"{{ ansible_env.HOME}}/%s/%s\"" $.OverlayPath $art $.OperationRemotePath (path $art)]]]
 [[[end]]]
+`
+
+const ansiblePlaybook = `
 - import_playbook: [[[.PlaybookPath]]]
 [[[if .HaveOutput]]]
 - name: Retrieving Operation outputs
@@ -59,12 +62,27 @@ const ansiblePlaybook = `
 
 type executionAnsible struct {
 	*executionCommon
-	PlaybookPath string
+	PlaybookPath   string
+	isAlienAnsible bool
 }
 
 func (e *executionAnsible) runAnsible(ctx context.Context, retry bool, currentInstance, ansibleRecipePath string) error {
 	var err error
-	e.PlaybookPath, err = filepath.Abs(filepath.Join(e.OverlayPath, e.Primary))
+	if !e.isAlienAnsible {
+		e.PlaybookPath, err = filepath.Abs(filepath.Join(e.OverlayPath, e.Primary))
+	} else {
+		var playbook string
+		for _, envInput := range e.EnvInputs {
+			if envInput.Name == "PLAYBOOK_ENTRY" {
+				playbook = envInput.Value
+				break
+			}
+		}
+		if playbook == "" {
+			return errors.New("No PLAYBOOK_ENTRY input found for an alien4cloud ansible implementation")
+		}
+		e.PlaybookPath, err = filepath.Abs(filepath.Join(e.OverlayPath, filepath.Dir(e.Primary), playbook))
+	}
 	if err != nil {
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, e.deploymentID).RegisterAsString(err.Error())
 		return err
@@ -90,13 +108,24 @@ func (e *executionAnsible) runAnsible(ctx context.Context, retry bool, currentIn
 		buffer.WriteString("\n")
 	}
 
-	for artName, art := range e.Artifacts {
-		buffer.WriteString(artName)
-		buffer.WriteString(": \"{{ansible_env.HOME}}/")
-		buffer.WriteString(e.OperationRemotePath)
-		buffer.WriteString("/")
-		buffer.WriteString(art)
-		buffer.WriteString("\"\n")
+	if !e.isAlienAnsible {
+		for artName, art := range e.Artifacts {
+			buffer.WriteString(artName)
+			buffer.WriteString(": \"{{ansible_env.HOME}}/")
+			buffer.WriteString(e.OperationRemotePath)
+			buffer.WriteString("/")
+			buffer.WriteString(art)
+			buffer.WriteString("\"\n")
+		}
+	} else {
+		for artName, art := range e.Artifacts {
+			buffer.WriteString(artName)
+			buffer.WriteString(": \"")
+			buffer.WriteString(e.OverlayPath)
+			buffer.WriteString("/")
+			buffer.WriteString(art)
+			buffer.WriteString("\"\n")
+		}
 	}
 	for contextKey, contextValue := range e.Context {
 		buffer.WriteString(fmt.Sprintf("%s: %q", contextKey, contextValue))
@@ -144,7 +173,13 @@ func (e *executionAnsible) runAnsible(ctx context.Context, retry bool, currentIn
 		"cut":  cutAfterLastUnderscore,
 	}
 	tmpl := template.New("execTemplate").Delims("[[[", "]]]").Funcs(funcMap)
-	tmpl, err = tmpl.Parse(ansiblePlaybook)
+	var playbook string
+	if e.isAlienAnsible {
+		playbook = ansiblePlaybook
+	} else {
+		playbook = uploadArtifactsPlaybook + ansiblePlaybook
+	}
+	tmpl, err = tmpl.Parse(playbook)
 	if err != nil {
 		err = errors.Wrap(err, "Failed to generate ansible playbook")
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, e.deploymentID).RegisterAsString(err.Error())

--- a/prov/ansible/execution_ansible_test.go
+++ b/prov/ansible/execution_ansible_test.go
@@ -46,7 +46,7 @@ func TestAnsibleTemplate(t *testing.T) {
 	}
 	tmpl := template.New("execTest").Funcs(funcMap)
 	tmpl = tmpl.Delims("[[[", "]]]")
-	tmpl, err := tmpl.Parse(ansiblePlaybook)
+	tmpl, err := tmpl.Parse(uploadArtifactsPlaybook + ansiblePlaybook)
 	require.Nil(t, err)
 	err = tmpl.Execute(os.Stdout, e)
 	t.Log(err)

--- a/prov/ansible/init.go
+++ b/prov/ansible/init.go
@@ -17,9 +17,10 @@ package ansible
 import "github.com/ystia/yorc/registry"
 
 const (
-	implementationArtifactBash    = "tosca.artifacts.Implementation.Bash"
-	implementationArtifactPython  = "tosca.artifacts.Implementation.Python"
-	implementationArtifactAnsible = "tosca.artifacts.Implementation.Ansible"
+	implementationArtifactBash         = "tosca.artifacts.Implementation.Bash"
+	implementationArtifactPython       = "tosca.artifacts.Implementation.Python"
+	implementationArtifactAnsible      = "tosca.artifacts.Implementation.Ansible"
+	implementationArtifactAnsibleAlien = "org.alien4cloud.artifacts.AnsiblePlaybook"
 )
 
 func init() {
@@ -29,5 +30,6 @@ func init() {
 			implementationArtifactBash,
 			implementationArtifactPython,
 			implementationArtifactAnsible,
+			implementationArtifactAnsibleAlien,
 		}, NewExecutor(), registry.BuiltinOrigin)
 }


### PR DESCRIPTION
**As:** Existing Alien4Cloud customer
**I want to:** Use my recipes developed in Ansible a4c specific format on Yorc
**So that:** I can migrate to Yorc as orchestration engine

**AC1:** Should be transparent to me

# Related issue
Closes #150 Support Alien4Cloud Ansible specific implementation  