### PR TITLE
Fix REQ_TARGET error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* REQ_TARGET keyword into TOSCA functions was broken. This was introduced during the upgrade to Alien4Cloud 2.0 that changed how requirements definition on node templates ([GH-159](https://github.com/ystia/yorc/issues/159))
+
 ## 3.1.0-M2 (August 24, 2018)
 
 ### DEPENDENCIES

--- a/deployments/requirements.go
+++ b/deployments/requirements.go
@@ -201,7 +201,7 @@ func GetTargetNodeForRequirementByName(kv *api.KV, deploymentID, nodeName, requi
 	}
 
 	for _, req := range kvp {
-		reqKv, _, err := kv.Get(req+"/name", nil)
+		reqKv, _, err := kv.Get(req+"/type_requirement", nil)
 		if err != nil || kv == nil {
 			return "", errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 		}


### PR DESCRIPTION
## Description of the change

Since Alien 2.0 the name of a requirement is unique and generated.
The name of the requirement as defined into the type is contained
into the `type_requirement` attribute in the node template.

### What I did

### How I did it

### Description for the changelog

REQ_TARGET keyword into TOSCA functions was broken. This was introduced during the upgrade to Alien4Cloud 2.0 that changed how requirements definition on node templates ([GH-159](https://github.com/ystia/yorc/issues/159))

## Applicable Issues

Closes #159
