### PR TITLE
Rename yorc.tgz into yorc-{VERSION}.tgz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ deploy:
     api_key:
       secure: N4G6gM4QaEUNn0DqgLazDeUh99VZzoKhbUF/v3sqvQLBLAQqL7k6pCfocuv8lLjhP4W1Xp+KpvUPC3jm8cWVApyuw0Ye9N4RBmpMNueujBO16beXXQf9oRWSCK7l9gcT++RjgIZNErcImQ99qObNB22XWzgVxvgRrqrsom+48qW/Vznh03Euv20xDBp96fvBkoTWKWW4nWZWg6sNx26c23vNZRPv49/sxa5brVdod7HD5x0QB3ZjeiChUQV7nOVfGJRtHiQuBZYGNOzStYUiLXClTB4xO5dywJ31pwLMJaOk2qLosHw+Kng5z1BghwzCfPhzMmJwVXdhUDqaVoXDRYMIHRyQFP48l3mYq0pw66JyoWyS82TnVjF4xvhbvUh7VW76kJWA15tyyM6kQ12o/14YG6GNgKp/qwRaTl5OiyH7G+8mt6ifHH/SIMkfpWQp4kTx4fHgrC6OYTuQe0YIvHt7SxRBAEXfj2wlosK7aLLzQ8OrVga/FDri85LfONE4U7anxpoDjAn8IzZrp2hFDyvZd6S7v7f6IusE0QJhSqDT1hsP9OTeKyrZSHYy9pVaZbmPKvmoz/xhx2hSEaa5gVACuPNMEfcy401SLunvrQqWQQq+qFdpTFRwCNtldWOJZeJlECZmJfz8CKbvYtJFixp+YvyjXzviO9RV83ZcY1U=
     file:
-      - dist/yorc.tgz
+      - dist/yorc-*.tgz
       - dist/yorc-server-*-distrib.zip
       - pkg/docker-ystia-yorc-*.tgz
     skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ header:
 dist: build
 	@rm -rf ./dist && mkdir -p ./dist
 	@echo "--> Creating an archive"
-	@tar czvf yorc.tgz yorc && echo "TODO: clean this part after CI update" &&  cp yorc yorc.tgz dist/
+	@tar czvf yorc-$(VERSION).tgz yorc && echo "TODO: clean this part after CI update" &&  cp yorc yorc-$(VERSION).tgz dist/
 	@cd doc && make html latexpdf && cd _build && cp -r html latex/Yorc.pdf ../../dist
 	@cd ./dist && zip -r yorc-server-$(VERSION)-documentation.zip html Yorc.pdf && zip yorc-server-$(VERSION)-distrib.zip yorc yorc-server-$(VERSION)-documentation.zip
 

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,9 @@ header:
 dist: build
 	@rm -rf ./dist && mkdir -p ./dist
 	@echo "--> Creating an archive"
-	@tar czvf yorc-$(VERSION).tgz yorc && echo "TODO: clean this part after CI update" &&  cp yorc yorc-$(VERSION).tgz dist/
+	@tar czvf "yorc-$(VERSION).tgz" yorc &&  cp yorc "yorc-$(VERSION)".tgz dist/
 	@cd doc && make html latexpdf && cd _build && cp -r html latex/Yorc.pdf ../../dist
-	@cd ./dist && zip -r yorc-server-$(VERSION)-documentation.zip html Yorc.pdf && zip yorc-server-$(VERSION)-distrib.zip yorc yorc-server-$(VERSION)-documentation.zip
+	@cd ./dist && zip -r "yorc-server-$(VERSION)-documentation.zip" html Yorc.pdf && zip "yorc-server-$(VERSION)-distrib.zip" yorc "yorc-server-$(VERSION)-documentation.zip"
 
 test: generate header format
 ifndef SKIP_TESTS

--- a/deploy.sh
+++ b/deploy.sh
@@ -43,7 +43,7 @@ bintray_snapshots_pr_path="snapshots/@BRANCH@/pr/@PR_ID@"
 bintray_snapshots_path="snapshots/@BRANCH@"
 
 #### Artifacts Variables
-artifacts_list="dist/yorc.tgz dist/yorc-server-*-distrib.zip"
+artifacts_list="dist/yorc-*.tgz dist/yorc-server-*-distrib.zip"
 distrib_artifact_dir="./dist"
 distrib_artifact_basename="yorc-server-"
 


### PR DESCRIPTION
# Pull Request description
Renaming the deployment artifact yorc.tgz into yorc-{VERSION}.tgz fixes the Travis build issue on Bintray deployment.
run command: "curl -T dist/yorc.tgz -H "X-Bintray-Publish: 1" -H "X-Bintray-Override: 1" -u stebenoist:[secure] https://api.bintray.com/content/ystia/yorc-engine/distributions/3.1.0/snapshots/develop/yorc.tgz"

{"message":"Unable to upload files: An artifact with the path 'snapshots/develop/yorc.tgz' already exists under another version"}

