### PR TITLE
Bugfix/gh 171 operation outputs several instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 * Inputs are not injected into Slurm (srun) jobs ([GH-161](https://github.com/ystia/yorc/issues/161))
 * Yorc consul service registration fails if using TLS ([GH-153](https://github.com/ystia/yorc/issues/153))
+* Retrieving operation output when provisioning several instances resolves to the same value for all instances even if they are actually different ([GH-171](https://github.com/ystia/yorc/issues/171))
 
 ## 3.1.0-M3 (September 14, 2018)
 

--- a/build/checks.sh
+++ b/build/checks.sh
@@ -41,12 +41,12 @@ install_consul() {
 }
 
 
-if [[ -z "$GOROOT" ]]; then
-    error_exit "GOROOT env var should be set..."
+if [[ -z "$(which go)" ]]; then
+    error_exit "go program should be present in your path"
 fi
 
 if [[ -z "$GOPATH" ]]; then
-    error_exit "GOPATH env var should be set..."
+    export GOPATH="$(go env GOPATH)"
 fi
 
 for tool in $@; do

--- a/build/tools.sh
+++ b/build/tools.sh
@@ -16,6 +16,14 @@
 #set -x
 scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+if [[ -z "$(which go)" ]]; then
+    error_exit "go program should be present in your path"
+fi
+
+if [[ -z "$GOPATH" ]]; then
+    export GOPATH="$(go env GOPATH)"
+fi
+
 error_exit () {
     >&2 echo "${1}"
     if [[ $# -gt 1 ]]
@@ -27,9 +35,6 @@ error_exit () {
 }
 
 copy_tools () {
-    if [[ -z "$GOPATH" ]]; then
-        error_exit "GOPATH env var should be set..."
-    fi
     for tool in $@; do
         tool="${tool%%/...*}"
         if [[ ! -x $GOPATH/bin/${tool##*/} ]]; then

--- a/plugin/operation_test.go
+++ b/plugin/operation_test.go
@@ -80,7 +80,7 @@ func TestOperationExecutorExecOperation(t *testing.T) {
 
 	plugin := raw.(prov.OperationExecutor)
 	op := prov.Operation{
-		Name: "myOps",
+		Name:                   "myOps",
 		ImplementationArtifact: "tosca.artifacts.Implementation.Bash",
 		RelOp: prov.RelationshipOperation{
 			IsRelationshipOperation: true,
@@ -124,7 +124,7 @@ func TestOperationExecutorExecOperationWithFailure(t *testing.T) {
 
 	plugin := raw.(prov.OperationExecutor)
 	op := prov.Operation{
-		Name: "myOps",
+		Name:                   "myOps",
 		ImplementationArtifact: "tosca.artifacts.Implementation.Bash",
 		RelOp: prov.RelationshipOperation{
 			IsRelationshipOperation: true,

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -990,7 +990,6 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 				if err = consulutil.StoreConsulKeyAsString(path.Join(consulutil.DeploymentKVPrefix, e.deploymentID, "topology", e.Outputs[line[0]]), line[1]); err != nil {
 					return err
 				}
-				break
 			}
 		}
 	}

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -30,7 +30,6 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/moby/moby/client"
@@ -611,8 +610,9 @@ func (e *executionCommon) resolveOperationOutputPath() error {
 
 			//For each instance of the node we create a new entry in the output map
 			for _, instanceID := range instancesIds {
-				//We decide to add an in to differentiate if we export many time the same output
-				b := uint32(time.Now().Nanosecond())
+				// TODO(loicalbertin) This part should be refactored to store properly the instance ID
+				// don't to it for now as it is for a quickfix
+				b := instanceID
 				interfaceName := strings.ToLower(url.QueryEscape(oof.Operands[1].String()))
 				operationName := strings.ToLower(url.QueryEscape(oof.Operands[2].String()))
 				outputVariableName := url.QueryEscape(oof.Operands[3].String())
@@ -960,6 +960,9 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 			return err
 		}
 		for _, outFile := range outputsFiles {
+			baseFileName := filepath.Base(outFile)
+			hostname := strings.TrimSuffix(baseFileName, "-out.csv")
+			fileInstanceID := getInstanceIDForHost(hostname, e.hosts)
 			fi, err := os.Open(outFile)
 			if err != nil {
 				err = errors.Wrapf(err, "Output retrieving of Ansible execution for node %q failed", e.NodeName)
@@ -979,10 +982,15 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 				return err
 			}
 			for _, line := range records {
+				splits := strings.Split(line[0], "_")
+				instanceID := splits[len(splits)-1]
+				if instanceID != fileInstanceID {
+					continue
+				}
 				if err = consulutil.StoreConsulKeyAsString(path.Join(consulutil.DeploymentKVPrefix, e.deploymentID, "topology", e.Outputs[line[0]]), line[1]); err != nil {
 					return err
 				}
-
+				break
 			}
 		}
 	}

--- a/prov/ansible/execution_ansible.go
+++ b/prov/ansible/execution_ansible.go
@@ -176,7 +176,7 @@ func (e *executionAnsible) runAnsible(ctx context.Context, retry bool, currentIn
 	}
 	tmpl := template.New("execTemplate").Delims("[[[", "]]]").Funcs(funcMap)
 	var playbook string
-	if e.isAlienAnsible {
+	if e.isAlienAnsible || len(e.Artifacts) == 0 {
 		playbook = ansiblePlaybook
 	} else {
 		playbook = uploadArtifactsPlaybook + ansiblePlaybook


### PR DESCRIPTION
# Pull Request description

Fix retrieval of operation outputs when several instances are provisioned
### Description for the changelog
* Retrieving operation output when provisioning several instances resolves to the same value for all instances even if they are actually different ([GH-171](https://github.com/ystia/yorc/issues/171))

## Applicable Issues

Fixes #171 
