### PR TITLE
Feature/google block storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### FEATURES
+
+* Support GCE Block storages. ([GH-82](https://github.com/ystia/yorc/issues/81))
+
 ## 3.1.0-M4 (October 08, 2018)
 
 ### DEPENDENCIES

--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -46,6 +46,12 @@ relationship_types:
         description: >
           The mode in which to attach this disk, either READ_WRITE or READ_ONLY. If not specified, the default is to attach the disk in READ_WRITE mode.
         required: false
+    attributes:
+      device:
+        type: string
+        description: >
+          The logical name of the device as exposed to the instance.
+          Note: A runtime property that gets set when the model gets instantiated by the orchestrator.
 
 node_types:
   yorc.nodes.google.Compute:

--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -25,6 +25,14 @@ data_types:
         required: false
         description: The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied encryption key that protects this resource.
 
+  yorc.datatypes.google.ScratchDisk:
+    derived_from: tosca.datatypes.Root
+    properties:
+      interface:
+        type: string
+        required: false
+        description: The disk interface to use for attaching the scratch disks; either SCSI or NVME. Defaults to SCSI.
+
 node_types:
   yorc.nodes.google.Compute:
     derived_from: yorc.nodes.Compute
@@ -116,6 +124,15 @@ node_types:
           Comma-separated list of tags to apply to the instances for identifying
           the instances to which network firewall rules will apply.
         required: false
+      scratch_disks:
+        type: list
+        description: Additional scratch disks to attach to the instance. Maximum allowed is 8.
+        required: false
+        entry_schema:
+          type: yorc.datatypes.google.ScratchDisk
+          constraints:
+            - greater_or_equal: 0
+            - max_length: 8
     requirements:
       - assignment:
           capability: yorc.capabilities.Assignable

--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -225,32 +225,33 @@ node_types:
           Customer-supplied encryption keys do not protect access to metadata of the disk.
           If you do not provide an encryption key when creating the disk, then the disk will be encrypted using an automatically generated key and you do not need to provide a key to use the disk later.
         required: false
-      source_image:
+      image_id:
         type: string
         description: >
           The image from which to initialize this disk. This can be one of: the image's self_link, projects/{project}/global/images/{image}, projects/{project}/global/images/family/{family}, global/images/{image}, global/images/family/{family}, family/{family}, {project}/{family}, {project}/{image}, {family}, or {image}.
           If referred by family, the images names must include the family name. If they don't, use the google_compute_image data source. For instance, the image centos-6-v20180104 includes its family name centos-6. These images can be referred by family name here.
         required: false
-      source_image_encryption_key:
+      image_encryption_key:
         type: yorc.datatypes.google.EncryptionKey
         description: >
           The customer-supplied encryption key of the source image. Required if the source image is protected by a customer-supplied encryption key.
         required: false
-      source_snapshot:
+      snapshot_id:
         type: string
         description: >
           The source snapshot used to create this disk. You can provide this as a partial or full URL to the resource.
           For example, https://www.googleapis.com/compute/v1/projects/project/global/snapshots/snapshot, projects/project/global/snapshots/snapshot, global/snapshots/snapshot, snapshot are valid values
         required: false
-      source_snapshot_encryption_key:
+      snapshot_encryption_key:
         type: yorc.datatypes.google.EncryptionKey
         description: >
           The customer-supplied encryption key of the source snapshot. Required if the source snapshot is protected by a customer-supplied encryption key.
         required: false
-    attributes:
-      users:
+      mode:
         type: string
         description: >
-          Links to the users of the disk (attached instances) in form: project/zones/zone/instances/instance
+          The mode in which to attach this disk, either READ_WRITE or READ_ONLY.
+          If not specified, the default is to attach the disk in READ_WRITE mode.
+        required: false
 
 

--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -12,6 +12,19 @@ artifact_types:
   yorc.artifacts.google.Deployment:
     derived_from: tosca.artifacts.Deployment
 
+data_types:
+  yorc.datatypes.google.EncryptionKey:
+    derived_from: tosca.datatypes.Root
+    properties:
+      raw_key:
+        type: string
+        required: false
+        description: Specifies a 256-bit customer-supplied encryption key, encoded in RFC 4648 base64 to either encrypt or decrypt this resource.
+      sha256:
+        type: string
+        required: false
+        description: The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied encryption key that protects this resource.
+
 node_types:
   yorc.nodes.google.Compute:
     derived_from: yorc.nodes.Compute
@@ -203,6 +216,41 @@ node_types:
         type: string
         description: >
           A reference to the zone where the disk resides. In any case the disk must be on the same zone as the associated Compute instances.
+        required: true
+      disk_encryption_key:
+        type: yorc.datatypes.google.EncryptionKey
+        description: >
+          Encrypts the disk using a customer-supplied encryption key. After you encrypt a disk with a customer-supplied key, you must provide the same key if you use the disk later
+          (e.g. to create a disk snapshot or an image, or to attach the disk to a virtual machine).
+          Customer-supplied encryption keys do not protect access to metadata of the disk.
+          If you do not provide an encryption key when creating the disk, then the disk will be encrypted using an automatically generated key and you do not need to provide a key to use the disk later.
         required: false
+      source_image:
+        type: string
+        description: >
+          The image from which to initialize this disk. This can be one of: the image's self_link, projects/{project}/global/images/{image}, projects/{project}/global/images/family/{family}, global/images/{image}, global/images/family/{family}, family/{family}, {project}/{family}, {project}/{image}, {family}, or {image}.
+          If referred by family, the images names must include the family name. If they don't, use the google_compute_image data source. For instance, the image centos-6-v20180104 includes its family name centos-6. These images can be referred by family name here.
+        required: false
+      source_image_encryption_key:
+        type: yorc.datatypes.google.EncryptionKey
+        description: >
+          The customer-supplied encryption key of the source image. Required if the source image is protected by a customer-supplied encryption key.
+        required: false
+      source_snapshot:
+        type: string
+        description: >
+          The source snapshot used to create this disk. You can provide this as a partial or full URL to the resource.
+          For example, https://www.googleapis.com/compute/v1/projects/project/global/snapshots/snapshot, projects/project/global/snapshots/snapshot, global/snapshots/snapshot, snapshot are valid values
+        required: false
+      source_snapshot_encryption_key:
+        type: yorc.datatypes.google.EncryptionKey
+        description: >
+          The customer-supplied encryption key of the source snapshot. Required if the source snapshot is protected by a customer-supplied encryption key.
+        required: false
+    attributes:
+      users:
+        type: string
+        description: >
+          Links to the users of the disk (attached instances) in form: project/zones/zone/instances/instance
 
 

--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -254,6 +254,11 @@ node_types:
         description: >
           A reference to the zone where the disk resides. In any case the disk must be on the same zone as the associated Compute instances.
         required: true
+      deletable:
+        type: boolean
+        description: should this volume be deleted at undeployment
+        required: false
+        default: false
       disk_encryption_key:
         type: yorc.datatypes.google.EncryptionKey
         description: >

--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -150,8 +150,6 @@ node_types:
         description: >
           Comma-separated list of label KEY=VALUE pairs to assign to the Compute Address.
         required: false
-        entry_schema:
-          type: string
       region:
         type: string
         description: >
@@ -179,4 +177,32 @@ node_types:
       ip_address:
         type: string
         description: The compute IP address.
+
+  yorc.nodes.google.PersistentDisk:
+    derived_from: tosca.nodes.BlockStorage
+    properties:
+    # See https://www.terraform.io/docs/providers/google/r/compute_disk.html
+      description:
+        type: string
+        description: >
+          An optional description of this resource.
+        required: false
+      type:
+        type: string
+        description: >
+          URL of the disk type resource describing which disk type to use to create the disk.
+          If this field is not specified, it is assumed to be pd-standard for Standard Persistent Disk HDD.
+          pd-ssd is for solid-state drives (SSD).
+        required: false
+      labels:
+        type: string
+        description: >
+          Comma-separated list of label KEY=VALUE pairs to assign to the Compute Disk.
+        required: false
+      zone:
+        type: string
+        description: >
+          A reference to the zone where the disk resides. In any case the disk must be on the same zone as the associated Compute instances.
+        required: false
+
 

--- a/data/tosca/yorc-google-types.yml
+++ b/data/tosca/yorc-google-types.yml
@@ -33,6 +33,20 @@ data_types:
         required: false
         description: The disk interface to use for attaching the scratch disks; either SCSI or NVME. Defaults to SCSI.
 
+relationship_types:
+  yorc.relationships.google.AttachesTo:
+    derived_from: tosca.relationships.AttachTo
+    description: >
+      This type represents an attachment relationship between two nodes.
+      For example, an AttachesTo relationship type would be used for attaching a storage node to a Compute node.
+    valid_target_types: [ tosca.capabilities.Attachment ]
+    properties:
+      mode:
+        type: string
+        description: >
+          The mode in which to attach this disk, either READ_WRITE or READ_ONLY. If not specified, the default is to attach the disk in READ_WRITE mode.
+        required: false
+
 node_types:
   yorc.nodes.google.Compute:
     derived_from: yorc.nodes.Compute
@@ -263,12 +277,6 @@ node_types:
         type: yorc.datatypes.google.EncryptionKey
         description: >
           The customer-supplied encryption key of the source snapshot. Required if the source snapshot is protected by a customer-supplied encryption key.
-        required: false
-      mode:
-        type: string
-        description: >
-          The mode in which to attach this disk, either READ_WRITE or READ_ONLY.
-          If not specified, the default is to attach the disk in READ_WRITE mode.
         required: false
 
 

--- a/deployments/consul_test.go
+++ b/deployments/consul_test.go
@@ -96,5 +96,8 @@ func TestRunConsulDeploymentsPackageTests(t *testing.T) {
 		t.Run("TestOperationHost", func(t *testing.T) {
 			testOperationHost(t, kv)
 		})
+		t.Run("testIssueGetEmptyPropOnRelationship", func(t *testing.T) {
+			testIssueGetEmptyPropOnRelationship(t, kv)
+		})
 	})
 }

--- a/deployments/definition_store.go
+++ b/deployments/definition_store.go
@@ -1091,9 +1091,11 @@ func fixAlienBlockStorages(ctx context.Context, kv *api.KV, deploymentID, nodeNa
 			if err != nil {
 				return errors.Wrapf(err, "Failed to fix Alien-specific BlockStorage %q", nodeName)
 			}
+
+			req.RelationshipProps = make(map[string]*tosca.ValueAssignment)
+
 			if device != nil {
 				va := &tosca.ValueAssignment{}
-				req.RelationshipProps = make(map[string]*tosca.ValueAssignment)
 				if device.RawString() != "" {
 					err = yaml.Unmarshal([]byte(device.RawString()), &va)
 					if err != nil {

--- a/deployments/definition_store.go
+++ b/deployments/definition_store.go
@@ -1179,7 +1179,7 @@ func createMissingBlockStorageForNode(consulStore consulutil.ConsulStore, kv *ap
 }
 
 /**
-This function check if a nodes need a floating IP, and return the name of Floating IP node.
+This function check if a nodes need a block storage, and return the name of BlockStorage node.
 */
 func checkBlockStorage(kv *api.KV, deploymentID, nodeName string) (bool, []string, error) {
 	requirementsKey, err := GetRequirementsKeysByTypeForNode(kv, deploymentID, nodeName, "local_storage")

--- a/deployments/definition_store.go
+++ b/deployments/definition_store.go
@@ -1103,6 +1103,19 @@ func fixAlienBlockStorages(ctx context.Context, kv *api.KV, deploymentID, nodeNa
 				req.RelationshipProps["device"] = va
 			}
 
+			// Get all requirement properties
+			kvps, _, err := kv.List(path.Join(attachReq, "properties"), nil)
+			if err != nil {
+				return errors.Wrapf(err, "Failed to fix Alien-specific BlockStorage %q", nodeName)
+			}
+			for _, kvp := range kvps {
+				va := &tosca.ValueAssignment{}
+				err := yaml.Unmarshal(kvp.Value, va)
+				if err != nil {
+					return errors.Wrapf(err, "Failed to fix Alien-specific BlockStorage %q", nodeName)
+				}
+				req.RelationshipProps[path.Base(kvp.Key)] = va
+			}
 			newReqID, err := GetNbRequirementsForNode(kv, deploymentID, computeNodeName)
 			if err != nil {
 				return err

--- a/deployments/definition_store_test.go
+++ b/deployments/definition_store_test.go
@@ -765,6 +765,27 @@ func testIssueGetEmptyPropRel(t *testing.T, kv *api.KV) {
 	require.Equal(t, "", results[0].Value)
 }
 
+func testIssueGetEmptyPropOnRelationship(t *testing.T, kv *api.KV) {
+	// t.Parallel()
+	deploymentID := strings.Replace(t.Name(), "/", "_", -1)
+	err := StoreDeploymentDefinition(context.Background(), kv, deploymentID, "testdata/issue_get_empty_prop_rel.yaml")
+	require.Nil(t, err)
+	// First test operation outputs detection
+
+	results, err := GetOperationInput(kv, deploymentID, "ValueAssignmentNode2", prov.Operation{
+		Name:                   "configure.pre_configure_source",
+		ImplementedInType:      "yorc.tests.relationships.ValueAssignmentConnectsTo",
+		ImplementationArtifact: "",
+		RelOp: prov.RelationshipOperation{
+			IsRelationshipOperation: true,
+			RequirementIndex:        "1",
+			TargetNodeName:          "ValueAssignmentNode1",
+		}}, "input_empty_prop")
+	require.Nil(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, "", results[0].Value)
+}
+
 func testRelationshipWorkflow(t *testing.T, kv *api.KV) {
 	// t.Parallel()
 	deploymentID := strings.Replace(t.Name(), "/", "_", -1)

--- a/deployments/testdata/issue_get_empty_prop_rel.yaml
+++ b/deployments/testdata/issue_get_empty_prop_rel.yaml
@@ -166,6 +166,11 @@ node_types:
 relationship_types:
   yorc.tests.relationships.ValueAssignmentConnectsTo:
     derived_from: tosca.relationships.ConnectsTo
+    properties:
+      empty_prop:
+        type: string
+        required: false
+        default: ""
     interfaces:
       Configure:
         pre_configure_source:
@@ -174,6 +179,9 @@ relationship_types:
             input_list: ["l1", "l2"]
             input_list_ex:
               - "le1"
+
+
+
               - "le2"
             input_map: {"key1": "value1", "key2": "value2"}
             input_map_ex:
@@ -188,6 +196,7 @@ relationship_types:
             input_propList_all: { get_property: [SOURCE, list] }
             input_propList_0_alien: { get_property: [SOURCE, "list[0]"] }
             input_propList_0_tosca: { get_property: [SOURCE, list, 0] }
+            input_empty_prop: { get_property: [SELF, empty_prop] }
           implementation: scripts/show_inputs.sh
         post_configure_source:
           inputs:

--- a/helper/sizeutil/sizeutil.go
+++ b/helper/sizeutil/sizeutil.go
@@ -1,0 +1,43 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sizeutil
+
+import (
+	"github.com/dustin/go-humanize"
+	"github.com/pkg/errors"
+	"github.com/ystia/yorc/helper/mathutil"
+	"strconv"
+)
+
+// ConvertToGB allows to convert a MB size as "42" or a human readable size as "42MB" or "42 KB" into GB
+func ConvertToGB(size string) (int, error) {
+	// Default size unit is MB
+	mSize, err := strconv.Atoi(size)
+	// Not an int value, so maybe a human readable size: we try to retrieve bytes
+	if err != nil {
+		var bsize uint64
+		bsize, err = humanize.ParseBytes(size)
+		if err != nil {
+			return 0, errors.Errorf("Can't convert size to bytes value: %v", err)
+		}
+		gSize := float64(bsize) / humanize.GByte
+		gSize = mathutil.Round(gSize, 0, 0)
+		return int(gSize), nil
+	}
+
+	gSize := float64(mSize) / 1000
+	gSize = mathutil.Round(gSize, 0, 0)
+	return int(gSize), nil
+}

--- a/helper/sizeutil/sizeutil_test.go
+++ b/helper/sizeutil/sizeutil_test.go
@@ -1,0 +1,50 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sizeutil
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestConvertToGB(t *testing.T) {
+	var testData = []struct {
+		test          string
+		inputSize     string
+		expectedSize  int
+		expectedError bool
+	}{
+		{"volume1", "1", 1, false},
+		{"volume10000000", "100", 1, false},
+		{"volume10000000", "1500 M", 2, false},
+		{"volume1GB", "1GB", 1, false},
+		{"volume1GBS", "1      GB", 1, false},
+		{"olume1GiB", "1 GiB", 2, false},
+		{"volume2GIB", "2 GIB", 3, false},
+		{"volume1TB", "1 tb", 1000, false},
+		{"volume1TiB", "1 TiB", 1100, false},
+		{"error", "1 deca", 0, true},
+	}
+	for _, tt := range testData {
+		s, err := ConvertToGB(tt.inputSize)
+		if !tt.expectedError {
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expectedSize, s)
+		} else {
+			assert.Error(t, err, "Expected an error")
+		}
+
+	}
+}

--- a/prov/terraform/commons/generator.go
+++ b/prov/terraform/commons/generator.go
@@ -21,6 +21,9 @@ import (
 	"github.com/ystia/yorc/config"
 )
 
+// FileOutputPrefix is the prefix to identify file output
+const FileOutputPrefix = "file:"
+
 // A Generator is used to generate the Terraform infrastructure for a given TOSCA node
 type Generator interface {
 	// GenerateTerraformInfraForNode generates the Terraform infrastructure file for the given node.

--- a/prov/terraform/commons/resources.go
+++ b/prov/terraform/commons/resources.go
@@ -82,6 +82,14 @@ type RemoteExec struct {
 	Scripts    []string    `json:"scripts,omitempty"`
 }
 
+// LocalExec allows to invoke a local executable after a resource is created. This invokes a process on the machine running Terraform, not on the resource
+type LocalExec struct {
+	Command     string `json:"command"`
+	WorkingDir  string `json:"working_dir,omitempty"`
+	interpreter string `json:"interpreter,omitempty"`
+	environment string `json:"environment,omitempty"`
+}
+
 // A Connection allows to overwrite the way Terraform connects to a resource
 type Connection struct {
 	ConnType   string `json:"type,omitempty"`

--- a/prov/terraform/executor.go
+++ b/prov/terraform/executor.go
@@ -28,10 +28,13 @@ import (
 	"github.com/ystia/yorc/events"
 	"github.com/ystia/yorc/helper/consulutil"
 	"github.com/ystia/yorc/helper/executil"
+	"github.com/ystia/yorc/log"
 	"github.com/ystia/yorc/prov"
 	"github.com/ystia/yorc/prov/terraform/commons"
 	"github.com/ystia/yorc/tasks"
 	"github.com/ystia/yorc/tosca"
+	"io/ioutil"
+	"path"
 )
 
 type defaultExecutor struct {
@@ -165,6 +168,17 @@ func (e *defaultExecutor) retrieveOutputs(ctx context.Context, kv *api.KV, infra
 	if len(outputs) == 0 {
 		return nil
 	}
+
+	// Filter and handle file output
+	filteredOutputs, err := e.handleFileOutputs(ctx, kv, infraPath, outputs)
+	if err != nil {
+		return err
+	}
+
+	if len(filteredOutputs) == 0 {
+		return nil
+	}
+
 	type tfJSONOutput struct {
 		Sensitive bool   `json:"sensitive,omitempty"`
 		Type      string `json:"type,omitempty"`
@@ -183,7 +197,7 @@ func (e *defaultExecutor) retrieveOutputs(ctx context.Context, kv *api.KV, infra
 	if err != nil {
 		return errors.Wrap(err, "Failed to retrieve the infrastructure outputs via terraform")
 	}
-	for outPath, outName := range outputs {
+	for outPath, outName := range filteredOutputs {
 		output, ok := outputsList[outName]
 		if !ok {
 			return errors.Errorf("failed to retrieve output %q in terraform result", outName)
@@ -195,6 +209,30 @@ func (e *defaultExecutor) retrieveOutputs(ctx context.Context, kv *api.KV, infra
 	}
 
 	return nil
+}
+
+// File outputs are outputs that terraform can't resolve and which need to be retrieved in local files
+func (e *defaultExecutor) handleFileOutputs(ctx context.Context, kv *api.KV, infraPath string, outputs map[string]string) (map[string]string, error) {
+	filteredOutputs := make(map[string]string, 0)
+	for k, v := range outputs {
+		if strings.HasPrefix(v, commons.FileOutputPrefix) {
+			file := strings.TrimPrefix(v, commons.FileOutputPrefix)
+			log.Debugf("Handle file output:%q", file)
+			content, err := ioutil.ReadFile(path.Join(infraPath, file))
+			if err != nil {
+				return nil, errors.Wrapf(err, "Failed to retrieve file output from file:%q", file)
+			}
+			contentStr := strings.Trim(string(content), "\r\n")
+			// Store keyValue in Consul
+			_, err = kv.Put(&api.KVPair{Key: k, Value: []byte(contentStr)}, nil)
+			if err != nil {
+				return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+			}
+		} else {
+			filteredOutputs[k] = v
+		}
+	}
+	return filteredOutputs, nil
 }
 
 func (e *defaultExecutor) applyInfrastructure(ctx context.Context, kv *api.KV, cfg config.Configuration, deploymentID, nodeName string, outputs map[string]string, env []string) error {

--- a/prov/terraform/google/compute_instance.go
+++ b/prov/terraform/google/compute_instance.go
@@ -325,7 +325,7 @@ func addAttachedDisks(ctx context.Context, cfg config.Configuration, kv *api.KV,
 			return err
 		}
 
-		mode, err := deployments.GetStringNodeProperty(kv, deploymentID, volumeNodeName, "mode", true)
+		modeValue, err := deployments.GetRelationshipPropertyValueFromRequirement(kv, deploymentID, nodeName, requirementIndex, "mode")
 		if err != nil {
 			return err
 		}
@@ -350,10 +350,12 @@ func addAttachedDisks(ctx context.Context, cfg config.Configuration, kv *api.KV,
 			Disk:     volumeID,
 			Instance: fmt.Sprintf("${google_compute_instance.%s.name}", computeName),
 			Zone:     zone,
-			Mode:     mode,
 		}
 		if deviceValue != nil && deviceValue.RawString() != "" {
 			attachedDisk.DeviceName = deviceValue.RawString()
+		}
+		if modeValue != nil && modeValue.RawString() != "" {
+			attachedDisk.Mode = modeValue.RawString()
 		}
 
 		attachName := strings.ToLower(cfg.ResourcesPrefix + volumeNodeName + "-" + instanceName + "-attached-to-" + nodeName + "-" + instanceName)

--- a/prov/terraform/google/compute_instance.go
+++ b/prov/terraform/google/compute_instance.go
@@ -297,6 +297,11 @@ func addAttachedDisks(ctx context.Context, cfg config.Configuration, kv *api.KV,
 			return err
 		}
 
+		mode, err := deployments.GetStringNodeProperty(kv, deploymentID, volumeNodeName, "mode", true)
+		if err != nil {
+			return err
+		}
+
 		volumeIDValue, err := deployments.GetNodePropertyValue(kv, deploymentID, volumeNodeName, "volume_id")
 		if err != nil {
 			return err
@@ -317,14 +322,15 @@ func addAttachedDisks(ctx context.Context, cfg config.Configuration, kv *api.KV,
 			Disk:     volumeID,
 			Instance: fmt.Sprintf("${google_compute_instance.%s.name}", computeName),
 			Zone:     zone,
+			Mode:     mode,
 		}
 		if deviceValue != nil && deviceValue.RawString() != "" {
 			attachedDisk.DeviceName = deviceValue.RawString()
 		}
 
-		attachName := strings.ToLower("Vol" + cfg.ResourcesPrefix + volumeNodeName + "-" + instanceName + "to" + nodeName + "-" + instanceName)
+		attachName := strings.ToLower(cfg.ResourcesPrefix + volumeNodeName + "-" + instanceName + "-attached-to-" + nodeName + "-" + instanceName)
 		attachName = strings.Replace(attachName, "_", "-", -1)
-		commons.AddResource(infrastructure, "google_compute_attached_disk", attachName, &attachedDisk)
+		commons.AddResource(infrastructure, "google_compute_attached_disk", attachName, attachedDisk)
 
 		// Provide Consul Keys
 		consulKeys := commons.ConsulKeys{Keys: []commons.ConsulKey{}}

--- a/prov/terraform/google/compute_instance_test.go
+++ b/prov/terraform/google/compute_instance_test.go
@@ -161,9 +161,9 @@ func testSimpleComputeInstanceWithPersistentDisk(t *testing.T, kv *api.KV, srv1 
 	instancesMap = infrastructure.Resource["google_compute_attached_disk"].(map[string]interface{})
 	require.Len(t, instancesMap, 1)
 
-	require.Contains(t, instancesMap, "bs1-0-to-compute-0")
-	attachedDisk, ok := instancesMap["bs1-0-to-compute-0"].(*ComputeAttachedDisk)
-	require.True(t, ok, "bs1-0-to-compute-0 is not a ComputeAttachedDisk")
+	require.Contains(t, instancesMap, "google-bs1-0-to-compute-0")
+	attachedDisk, ok := instancesMap["google-bs1-0-to-compute-0"].(*ComputeAttachedDisk)
+	require.True(t, ok, "google-bs1-0-to-compute-0 is not a ComputeAttachedDisk")
 	assert.Equal(t, "my_vol_id", attachedDisk.Disk)
 	assert.Equal(t, "${google_compute_instance.compute-0.name}", attachedDisk.Instance)
 	assert.Equal(t, "europe-west1-b", attachedDisk.Zone)

--- a/prov/terraform/google/compute_instance_test.go
+++ b/prov/terraform/google/compute_instance_test.go
@@ -160,12 +160,12 @@ func testSimpleComputeInstanceWithPersistentDisk(t *testing.T, kv *api.KV, srv1 
 	instancesMap = infrastructure.Resource["google_compute_attached_disk"].(map[string]interface{})
 	require.Len(t, instancesMap, 1)
 
-	require.Contains(t, instancesMap, "bs1-0-attached-to-compute-0")
-	attachedDisk, ok := instancesMap["bs1-0-attached-to-compute-0"].(*ComputeAttachedDisk)
-	require.True(t, ok, "bs1-0-attached-to-compute-0 is not a ComputeAttachedDisk")
+	require.Contains(t, instancesMap, "bs1-0-to-compute-0")
+	attachedDisk, ok := instancesMap["bs1-0-to-compute-0"].(*ComputeAttachedDisk)
+	require.True(t, ok, "bs1-0-to-compute-0 is not a ComputeAttachedDisk")
 	assert.Equal(t, "my_vol_id", attachedDisk.Disk)
 	assert.Equal(t, "${google_compute_instance.compute-0.name}", attachedDisk.Instance)
 	assert.Equal(t, "europe-west1-b", attachedDisk.Zone)
-	assert.Equal(t, "foo", attachedDisk.DeviceName)
+	assert.Equal(t, "bs1-0-to-compute-0", attachedDisk.DeviceName)
 	assert.Equal(t, "READ_ONLY", attachedDisk.Mode)
 }

--- a/prov/terraform/google/compute_instance_test.go
+++ b/prov/terraform/google/compute_instance_test.go
@@ -81,6 +81,10 @@ func testSimpleComputeInstance(t *testing.T, kv *api.KV, cfg config.Configuratio
 	require.True(t, ok)
 	assert.Equal(t, "centos", rex.Connection.User)
 	assert.Equal(t, `${file("~/.ssh/yorc.pem")}`, rex.Connection.PrivateKey)
+
+	require.Len(t, compute.ScratchDisks, 2, "Expected 2 scratch disks")
+	assert.Equal(t, "SCSI", compute.ScratchDisks[0].Interface, "SCSI interface expected for 1st scratch")
+	assert.Equal(t, "NVME", compute.ScratchDisks[1].Interface, "NVME interface expected for 2nd scratch")
 }
 
 func testSimpleComputeInstanceMissingMandatoryParameter(t *testing.T, kv *api.KV, cfg config.Configuration) {

--- a/prov/terraform/google/consul_test.go
+++ b/prov/terraform/google/consul_test.go
@@ -39,20 +39,5 @@ func TestRunConsulGooglePackageTests(t *testing.T) {
 		t.Run("simpleComputeInstance", func(t *testing.T) {
 			testSimpleComputeInstance(t, kv, cfg)
 		})
-		t.Run("simpleComputeInstanceMissingMandatoryParameter", func(t *testing.T) {
-			testSimpleComputeInstanceMissingMandatoryParameter(t, kv, cfg)
-		})
-		t.Run("simpleComputeAddress", func(t *testing.T) {
-			testSimpleComputeAddress(t, kv, cfg)
-		})
-		t.Run("simpleComputeInstanceWithAddress", func(t *testing.T) {
-			testSimpleComputeInstanceWithAddress(t, kv, srv, cfg)
-		})
-		t.Run("simplePersistentDisk", func(t *testing.T) {
-			testSimplePersistentDisk(t, kv, cfg)
-		})
-		t.Run("simpleComputeInstanceWithPersistentDisk", func(t *testing.T) {
-			testSimpleComputeInstanceWithPersistentDisk(t, kv, srv, cfg)
-		})
 	})
 }

--- a/prov/terraform/google/consul_test.go
+++ b/prov/terraform/google/consul_test.go
@@ -39,5 +39,20 @@ func TestRunConsulGooglePackageTests(t *testing.T) {
 		t.Run("simpleComputeInstance", func(t *testing.T) {
 			testSimpleComputeInstance(t, kv, cfg)
 		})
+		t.Run("simpleComputeInstanceMissingMandatoryParameter", func(t *testing.T) {
+			testSimpleComputeInstanceMissingMandatoryParameter(t, kv, cfg)
+		})
+		t.Run("simpleComputeAddress", func(t *testing.T) {
+			testSimpleComputeAddress(t, kv, cfg)
+		})
+		t.Run("simpleComputeInstanceWithAddress", func(t *testing.T) {
+			testSimpleComputeInstanceWithAddress(t, kv, srv, cfg)
+		})
+		t.Run("simplePersistentDisk", func(t *testing.T) {
+			testSimplePersistentDisk(t, kv, cfg)
+		})
+		t.Run("simpleComputeInstanceWithPersistentDisk", func(t *testing.T) {
+			testSimpleComputeInstanceWithPersistentDisk(t, kv, srv, cfg)
+		})
 	})
 }

--- a/prov/terraform/google/consul_test.go
+++ b/prov/terraform/google/consul_test.go
@@ -48,5 +48,11 @@ func TestRunConsulGooglePackageTests(t *testing.T) {
 		t.Run("simpleComputeInstanceWithAddress", func(t *testing.T) {
 			testSimpleComputeInstanceWithAddress(t, kv, srv, cfg)
 		})
+		t.Run("simplePersistentDisk", func(t *testing.T) {
+			testSimplePersistentDisk(t, kv, cfg)
+		})
+		t.Run("simpleComputeInstanceWithPersistentDisk", func(t *testing.T) {
+			testSimpleComputeInstanceWithPersistentDisk(t, kv, srv, cfg)
+		})
 	})
 }

--- a/prov/terraform/google/generator.go
+++ b/prov/terraform/google/generator.go
@@ -148,6 +148,11 @@ func (g *googleGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg
 			if err != nil {
 				return false, nil, nil, err
 			}
+		case "yorc.nodes.google.PersistentDisk":
+			err = g.generatePersistentDisk(ctx, kv, cfg, deploymentID, nodeName, instanceName, instNb, &infrastructure, outputs)
+			if err != nil {
+				return false, nil, nil, err
+			}
 		default:
 			return false, nil, nil, errors.Errorf("Unsupported node type '%s' for node '%s' in deployment '%s'", nodeType, nodeName, deploymentID)
 		}

--- a/prov/terraform/google/init.go
+++ b/prov/terraform/google/init.go
@@ -14,14 +14,17 @@
 
 package google
 
-import "github.com/ystia/yorc/registry"
-import "github.com/ystia/yorc/prov/terraform"
+import (
+	"github.com/ystia/yorc/prov/terraform"
+	"github.com/ystia/yorc/prov/terraform/commons"
+	"github.com/ystia/yorc/registry"
+)
 
 const googleDeploymentArtifact = "yorc.artifacts.google.Deployment"
 
 func init() {
 	reg := registry.GetRegistry()
-	reg.RegisterDelegates([]string{`yorc\.nodes\.google\..*`}, terraform.NewExecutor(&googleGenerator{}, nil), registry.BuiltinOrigin)
+	reg.RegisterDelegates([]string{`yorc\.nodes\.google\..*`}, terraform.NewExecutor(&googleGenerator{}, commons.PreDestroyStorageInfraCallback), registry.BuiltinOrigin)
 	reg.RegisterOperationExecutor(
 		[]string{googleDeploymentArtifact}, &defaultExecutor{}, registry.BuiltinOrigin)
 }

--- a/prov/terraform/google/persistent_disk.go
+++ b/prov/terraform/google/persistent_disk.go
@@ -1,0 +1,112 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/consul/api"
+	"github.com/pkg/errors"
+	"github.com/ystia/yorc/config"
+	"github.com/ystia/yorc/deployments"
+	"github.com/ystia/yorc/helper/consulutil"
+	"github.com/ystia/yorc/helper/sizeutil"
+	"github.com/ystia/yorc/log"
+	"github.com/ystia/yorc/prov/terraform/commons"
+	"path"
+	"strings"
+)
+
+func (g *googleGenerator) generatePersistentDisk(ctx context.Context, kv *api.KV,
+	cfg config.Configuration, deploymentID, nodeName, instanceName string, instanceID int,
+	infrastructure *commons.Infrastructure,
+	outputs map[string]string) error {
+
+	nodeType, err := deployments.GetNodeType(kv, deploymentID, nodeName)
+	if err != nil {
+		return err
+	}
+	if nodeType != "yorc.nodes.google.PersistentDisk" {
+		return errors.Errorf("Unsupported node type for %q: %s", nodeName, nodeType)
+	}
+
+	instancesPrefix := path.Join(consulutil.DeploymentKVPrefix, deploymentID,
+		"topology", "instances")
+	instancesKey := path.Join(instancesPrefix, nodeName)
+
+	persistentDisk := &PersistentDisk{}
+	var size, volumes string
+	stringParams := []struct {
+		pAttr        *string
+		propertyName string
+		mandatory    bool
+	}{
+		{&volumes, "volume_id", false},
+		{&persistentDisk.Description, "description", false},
+		{&persistentDisk.Snapshot, "snapshot_id", false},
+		{&persistentDisk.Type, "type", false},
+		{&persistentDisk.Zone, "zone", false},
+		{&size, "size", false},
+	}
+
+	for _, stringParam := range stringParams {
+		if *stringParam.pAttr, err = deployments.GetStringNodeProperty(kv, deploymentID, nodeName,
+			stringParam.propertyName, stringParam.mandatory); err != nil {
+			return err
+		}
+	}
+
+	var volumeID string
+	if volumes != "" {
+		tabVol := strings.Split(volumes, ",")
+		if len(tabVol) > instanceID {
+			volumeID = strings.TrimSpace(tabVol[instanceID])
+		}
+	}
+
+	persistentDisk.Labels, err = deployments.GetKeyValuePairsNodeProperty(kv, deploymentID, nodeName, "labels")
+	if err != nil {
+		return err
+	}
+
+	if size != "" {
+		// Default size unit is MB
+		log.Debugf("Initial size property value (default is MB): %q", size)
+		persistentDisk.Size, err = sizeutil.ConvertToGB(size)
+		if err != nil {
+			return err
+		}
+		log.Debugf("Computed size (in GB): %d", persistentDisk.Size)
+	}
+
+	name := strings.ToLower(cfg.ResourcesPrefix + nodeName + "-" + instanceName)
+	persistentDisk.Name = strings.Replace(name, "_", "-", -1)
+
+	// Add google persistent disk resource if not any volume ID is provided
+	if volumeID == "" {
+		commons.AddResource(infrastructure, "google_compute_disk", persistentDisk.Name, persistentDisk)
+		volumeID = fmt.Sprintf("${google_compute_disk.%s.name}", persistentDisk.Name)
+	}
+
+	// Provide Consul Key for attribute volume_id
+	consulKeys := commons.ConsulKeys{Keys: []commons.ConsulKey{}}
+	consulKeyIPAddr := commons.ConsulKey{
+		Path:  path.Join(instancesKey, instanceName, "/attributes/volume_id"),
+		Value: volumeID}
+
+	consulKeys.Keys = append(consulKeys.Keys, consulKeyIPAddr)
+	commons.AddResource(infrastructure, "consul_keys", persistentDisk.Name, &consulKeys)
+	return nil
+}

--- a/prov/terraform/google/persistent_disk_test.go
+++ b/prov/terraform/google/persistent_disk_test.go
@@ -1,0 +1,50 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"context"
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/ystia/yorc/config"
+	"github.com/ystia/yorc/prov/terraform/commons"
+	"testing"
+)
+
+func testSimplePersistentDisk(t *testing.T, kv *api.KV, cfg config.Configuration) {
+	t.Parallel()
+	deploymentID := loadTestYaml(t, kv)
+	infrastructure := commons.Infrastructure{}
+	g := googleGenerator{}
+	err := g.generatePersistentDisk(context.Background(), kv, cfg, deploymentID, "PersistentDisk", "0", 0, &infrastructure, make(map[string]string))
+	require.NoError(t, err, "Unexpected error attempting to generate persistent disk for %s", deploymentID)
+
+	require.Len(t, infrastructure.Resource["google_compute_disk"], 1, "Expected one persistent disk")
+	instancesMap := infrastructure.Resource["google_compute_disk"].(map[string]interface{})
+	require.Len(t, instancesMap, 1)
+	require.Contains(t, instancesMap, "persistentdisk-0")
+
+	persistentDisk, ok := instancesMap["persistentdisk-0"].(*PersistentDisk)
+	require.True(t, ok, "computeaddress-0 is not a PersistentDisk")
+	assert.Equal(t, "persistentdisk-0", persistentDisk.Name)
+	assert.Equal(t, "europe-west1-b", persistentDisk.Zone)
+	assert.Equal(t, 32, persistentDisk.Size)
+	assert.Equal(t, "pd-ssd", persistentDisk.Type)
+	assert.Equal(t, "1234", persistentDisk.DiskEncryptionKey.Raw)
+	assert.Equal(t, "5678", persistentDisk.DiskEncryptionKey.SHA256)
+	assert.Equal(t, "my description for persistent disk", persistentDisk.Description)
+	assert.Equal(t, map[string]string{"key1": "value1", "key2": "value2"}, persistentDisk.Labels)
+}

--- a/prov/terraform/google/resources.go
+++ b/prov/terraform/google/resources.go
@@ -30,6 +30,7 @@ type ComputeInstance struct {
 	// ServiceAccounts is an array of at most one element
 	ServiceAccounts []ServiceAccount `json:"service_account,omitempty"`
 	Tags            []string         `json:"tags,omitempty"`
+	ScratchDisks    []ScratchDisk    `json:"scratch_disk,omitempty"`
 }
 
 // BootDisk represents the required boot disk for compute instance
@@ -89,6 +90,11 @@ type ComputeAddress struct {
 type EncryptionKey struct {
 	Raw    string `json:"raw_key,omitempty"`
 	SHA256 string `json:"sha256,omitempty"`
+}
+
+// ScratchDisk represents an additional Compute instance local scratch disk
+type ScratchDisk struct {
+	Interface string `json:"interface,omitempty"`
 }
 
 // PersistentDisk represents a Google persistent disk

--- a/prov/terraform/google/resources.go
+++ b/prov/terraform/google/resources.go
@@ -85,14 +85,33 @@ type ComputeAddress struct {
 	Project     string            `json:"project,omitempty"`
 }
 
+// EncryptionKey represents a Google encryption key
+type EncryptionKey struct {
+	Raw    string `json:"raw_key,omitempty"`
+	SHA256 string `json:"sha256,omitempty"`
+}
+
 // PersistentDisk represents a Google persistent disk
 // See https://www.terraform.io/docs/providers/google/r/compute_disk.html
 type PersistentDisk struct {
-	Name        string            `json:"name"`
-	Size        int               `json:"size,omitempty"`
-	Description string            `json:"description,omitempty"`
-	Type        string            `json:"type,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Zone        string            `json:"zone,omitempty"`
-	Snapshot    string            `json:"snapshot,omitempty"`
+	Name                        string            `json:"name"`
+	Size                        int               `json:"size,omitempty"`
+	Description                 string            `json:"description,omitempty"`
+	Type                        string            `json:"type,omitempty"`
+	Labels                      map[string]string `json:"labels,omitempty"`
+	Zone                        string            `json:"zone,omitempty"`
+	DiskEncryptionKey           *EncryptionKey    `json:"disk_encryption_key,omitempty"`
+	SourceSnapshot              string            `json:"snapshot,omitempty"`
+	SourceSnapshotEncryptionKey *EncryptionKey    `json:"source_snapshot_encryption_key,omitempty"`
+	SourceImage                 string            `json:"image,omitempty"`
+	SourceImageEncryptionKey    *EncryptionKey    `json:"source_image_encryption_key,omitempty"`
+}
+
+// ComputeAttachedDisk represents compute instance's attached disk
+type ComputeAttachedDisk struct {
+	Instance   string `json:"instance"`
+	Disk       string `json:"disk"`
+	DeviceName string `json:"device_name,omitempty"`
+	Mode       string `json:"mode,omitempty"`
+	Zone       string `json:"zone,omitempty"`
 }

--- a/prov/terraform/google/resources.go
+++ b/prov/terraform/google/resources.go
@@ -84,3 +84,15 @@ type ComputeAddress struct {
 	Labels      map[string]string `json:"labels,omitempty"`
 	Project     string            `json:"project,omitempty"`
 }
+
+// PersistentDisk represents a Google persistent disk
+// See https://www.terraform.io/docs/providers/google/r/compute_disk.html
+type PersistentDisk struct {
+	Name        string            `json:"name"`
+	Size        int               `json:"size,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Type        string            `json:"type,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Zone        string            `json:"zone,omitempty"`
+	Snapshot    string            `json:"snapshot,omitempty"`
+}

--- a/prov/terraform/google/resources.go
+++ b/prov/terraform/google/resources.go
@@ -108,6 +108,7 @@ type PersistentDisk struct {
 }
 
 // ComputeAttachedDisk represents compute instance's attached disk
+// See https://www.terraform.io/docs/providers/google/r/compute_attached_disk.html
 type ComputeAttachedDisk struct {
 	Instance   string `json:"instance"`
 	Disk       string `json:"disk"`

--- a/prov/terraform/google/testdata/simpleComputeInstance.yaml
+++ b/prov/terraform/google/testdata/simpleComputeInstance.yaml
@@ -22,6 +22,9 @@ topology_template:
         service_account: "yorc@yorc.net"
         tags: "tag1, tag2"
         labels: "key1=value1, key2=value2"
+        scratch_disks:
+          - interface: SCSI
+          - interface: NVME
       capabilities:
         scalable:
           properties:

--- a/prov/terraform/google/testdata/simpleComputeInstanceWithPersistentDisk.yaml
+++ b/prov/terraform/google/testdata/simpleComputeInstanceWithPersistentDisk.yaml
@@ -30,6 +30,7 @@ topology_template:
               type: tosca.relationships.AttachesTo
               properties:
                 device: foo
+                mode: "READ_ONLY"
       capabilities:
         endpoint:
           properties:
@@ -50,10 +51,3 @@ topology_template:
         zone: "europe-west1-b"
         size: "12 GB"
         device: foo
-        mode: "READ_ONLY"
-      requirements:
-        - attachToComputeAttach:
-            type_requirement: attachment
-            node: Comp
-            capability: tosca.capabilities.Attachment
-            relationship: tosca.relationships.AttachTo

--- a/prov/terraform/google/testdata/simpleComputeInstanceWithPersistentDisk.yaml
+++ b/prov/terraform/google/testdata/simpleComputeInstanceWithPersistentDisk.yaml
@@ -29,7 +29,6 @@ topology_template:
             relationship:
               type: tosca.relationships.AttachesTo
               properties:
-                device: foo
                 mode: "READ_ONLY"
       capabilities:
         endpoint:
@@ -50,4 +49,3 @@ topology_template:
       properties:
         zone: "europe-west1-b"
         size: "12 GB"
-        device: foo

--- a/prov/terraform/google/testdata/simpleComputeInstanceWithPersistentDisk.yaml
+++ b/prov/terraform/google/testdata/simpleComputeInstanceWithPersistentDisk.yaml
@@ -1,0 +1,59 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: PersistentDiskTest
+  template_version: 1.0
+  template_author: tester
+
+description: ""
+
+imports:
+  - <normative-types.yml>
+  - <yorc-google-types.yml>
+  - <yorc-types.yml>
+
+topology_template:
+  node_templates:
+    Compute:
+      metadata:
+      type: yorc.nodes.google.Compute
+      properties:
+        image_project: "centos-cloud"
+        image_family: "centos-7"
+        machine_type: "n1-standard-1"
+        zone: "europe-west1-b"
+      requirements:
+        - local_storage:
+            node: BS1
+            capability: tosca.capabilities.Attachment
+            relationship:
+              type: tosca.relationships.AttachesTo
+              properties:
+                device: foo
+      capabilities:
+        endpoint:
+          properties:
+            secure: true
+            protocol: tcp
+            network_name: PRIVATE
+            initiator: source
+            credentials: {user: centos}
+        scalable:
+          properties:
+            min_instances: 1
+            max_instances: 1
+            default_instances: 1
+    BS1:
+      metadata:
+      type: yorc.nodes.google.PersistentDisk
+      properties:
+        zone: "europe-west1-b"
+        size: "12 GB"
+        device: foo
+        mode: "READ_ONLY"
+      requirements:
+        - attachToComputeAttach:
+            type_requirement: attachment
+            node: Comp
+            capability: tosca.capabilities.Attachment
+            relationship: tosca.relationships.AttachTo

--- a/prov/terraform/google/testdata/simplePersistentDisk.yaml
+++ b/prov/terraform/google/testdata/simplePersistentDisk.yaml
@@ -1,0 +1,35 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: PersistentDiskTest
+  template_version: 1.0
+  template_author: tester
+
+description: ""
+
+imports:
+  - <normative-types.yml>
+  - <yorc-google-types.yml>
+  - <yorc-types.yml>
+
+topology_template:
+  node_templates:
+    PersistentDisk:
+      type: yorc.nodes.google.PersistentDisk
+      properties:
+        zone: "europe-west1-b"
+        size: "12 GB"
+        type: "pd-ssd"
+        description: "my description for persistent disk"
+        snapshot_id: "projects/project/global/snapshots/snapshot"
+        size: "32 GB"
+        labels: "key1=value1, key2=value2"
+        disk_encryption_key:
+          raw_key: 1234
+          sha256: 5678
+      requirements:
+        - attachToComputeAttach:
+            type_requirement: attachment
+            node: Comp
+            capability: tosca.capabilities.Attachment
+            relationship: tosca.relationships.AttachTo


### PR DESCRIPTION
# Pull Request description

**Support GCE Block Storages**

As: an app manager
I want to: attach block storage on an GCE Compute
So that: I can persist informations on those persistent storages

AC1: Could provision a new volume and attach it to a compute
AC2: Could reuse an existing volume and attach it to a compute
AC3: Compute could have multiple volumes attached
AC4: All above should work with scalable computes

## Description of the change

### What I did
- Create yorc.nodes.google.PersistentDisk node type
- Create relationship **yorc.relationships.google.AttachesTo** with specific prop **mode** to allow
the possibility for a compute to attach a disk with **read only** mode.
- Create **scratch_disks** prop for google compute instance to attach local SSD disks.

### How I did it
- Use the existing code around topology modification for BlockStorage and compute **local_storage** 
requirement.

### How to verify it
- Simple topology with a scalable compute and one or many block storages.
You can use **yorc.relationships.google.AttachesTo** and set mode property to **READ_ONLY**
You can use generic **tosca.relationships.AttachTo**.
You can attach existing disk by setting **volume_id** property.
Check the deployment and the resources creation on gcloud console


## Applicable Issues
fixes #81 
