### PR TITLE
Setting urllib3 version to 1.23 to avoid travis build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 
 install:
   - make tools
-  - pip install --user --upgrade sphinx==1.7.9 semantic-version requests urllib3[secure]
+  - pip install --user --upgrade sphinx==1.8.1 semantic-version requests urllib3[secure]
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64  > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 
 install:
   - make tools
-  - pip install --user --upgrade sphinx==1.8.1 semantic-version requests urllib3[secure]
+  - pip install --user --upgrade sphinx==1.8.1 semantic-version requests urllib3[secure]==1.23
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64  > ./cc-test-reporter


### PR DESCRIPTION
# Pull Request description

Latest builds on travis fail with this error:
```
Extension error:
Could not import extension sphinx.builders.linkcheck (exception: No module named ordered_dict)
make[1]: *** [html] Error 2
make[1]: Leaving directory `/home/travis/gopath/src/github.com/ystia/yorc/doc'
make: *** [dist] Error 2
```

Should be related to this issue: https://github.com/urllib3/urllib3/issues/1456
Hardcoding urllib3 version to 1.23 to bypass the issue

Upgrading to Sphinx 18.1 as well, that is fixing the issue we had with 1.8.0

