### PR TITLE
Allow to run multiple workflows and custom commands in //

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### ENHANCEMENTS
+
+* Concurrent workflows and custom commands executions are now allowed except when a deployment/undeployment/scaling operation is in progress ([GH-182](https://github.com/ystia/yorc/issues/182))
+
 ## 3.0.1 (August 24, 2018)
 
 ### BUG FIXES

--- a/config/config.go
+++ b/config/config.go
@@ -85,6 +85,7 @@ type Configuration struct {
 	Vault                            DynamicMap            `mapstructure:"vault"`
 	WfStepGracefulTerminationTimeout time.Duration         `mapstructure:"wf_step_graceful_termination_timeout"`
 	ServerID                         string                `mapstructure:"server_id"`
+	Terraform                        Terraform             `mapstructure:"terraform"`
 }
 
 // DockerSandbox holds the configuration for a docker sandbox
@@ -117,6 +118,7 @@ type Ansible struct {
 	ConnectionRetries       int              `mapstructure:"connection_retries"`
 	OperationRemoteBaseDir  string           `mapstructure:"operation_remote_base_dir"`
 	KeepOperationRemotePath bool             `mapstructure:"keep_operation_remote_path"`
+	KeepGeneratedRecipes    bool             `mapstructure:"keep_generated_recipes"`
 	ArchiveArtifacts        bool             `mapstructure:"archive_artifacts"`
 	CacheFacts              bool             `mapstructure:"cache_facts"`
 	HostedOperations        HostedOperations `mapstructure:"hosted_operations"`
@@ -144,6 +146,11 @@ type Telemetry struct {
 	ServiceName             string `mapstructure:"service_name"`
 	DisableHostName         bool   `mapstructure:"disable_hostname"`
 	DisableGoRuntimeMetrics bool   `mapstructure:"disable_go_runtime_metrics"`
+}
+
+// Terraform configuration
+type Terraform struct {
+	KeepGeneratedFiles bool `mapstructure:"keep_generated_files"`
 }
 
 // DynamicMap allows to store configuration parameters that are not known in advance.

--- a/deployments/structs_enum.go
+++ b/deployments/structs_enum.go
@@ -53,11 +53,12 @@ var _DeploymentStatusMap = map[DeploymentStatus]string{
 	7: _DeploymentStatusName[107:126],
 }
 
-func (i DeploymentStatus) String() string {
-	if str, ok := _DeploymentStatusMap[i]; ok {
+// String implements the Stringer interface.
+func (x DeploymentStatus) String() string {
+	if str, ok := _DeploymentStatusMap[x]; ok {
 		return str
 	}
-	return fmt.Sprintf("DeploymentStatus(%d)", i)
+	return fmt.Sprintf("DeploymentStatus(%d)", x)
 }
 
 var _DeploymentStatusValue = map[string]DeploymentStatus{
@@ -74,7 +75,7 @@ var _DeploymentStatusValue = map[string]DeploymentStatus{
 // ParseDeploymentStatus attempts to convert a string to a DeploymentStatus
 func ParseDeploymentStatus(name string) (DeploymentStatus, error) {
 	if x, ok := _DeploymentStatusValue[name]; ok {
-		return DeploymentStatus(x), nil
+		return x, nil
 	}
 	return DeploymentStatus(0), fmt.Errorf("%s is not a valid DeploymentStatus", name)
 }

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -30,6 +30,10 @@ Globals Command-line options
 
   * ``--ansible_archive_artifacts``: If set to true, archives operation bash/python scripts locally, copies this archive and unarchives it on remote hosts (requires tar to be installed on remote hosts), to avoid multiple time consuming remote copy operations of individual scripts (false by default: no archive).
 
+.. _option_ansible_keep_generated_recipes_cmd:
+
+  * ``--ansible_keep_generated_recipes``: If set to true, generated Ansible recipes on Yorc server are not delete. (false by default: generated recipes are deleted).
+
 .. _option_operation_remote_base_dir_cmd:
 
   * ``--operation_remote_base_dir``: Specify an alternative working directory for Ansible on provisioned Compute.
@@ -73,6 +77,10 @@ Globals Command-line options
 .. _option_consul_ssl_verify_cmd:
 
   * ``--consul_ssl_verify``: If set to false, disable Consul certificate checking (true by default is ssl enabled).
+
+.. _option_terraform_keep_generated_files_cmd:
+
+  * ``--terraform_keep_generated_files``: If set to true, generated Terraform infrastructures files on Yorc server are not delete. (false by default: generated files are deleted).
 
 .. _option_pub_routines_cmd:
 
@@ -300,6 +308,10 @@ All available configuration options for Ansible are:
 
   * ``keep_operation_remote_path``: Equivalent to :ref:`--keep_operation_remote_path <option_keep_remote_path_cmd>` command-line flag.
 
+.. _option_ansible_keep_generated_recipes_cfg:
+
+  * ``keep_generated_recipes``: Equivalent to :ref:`--ansible_keep_generated_recipes <option_ansible_keep_generated_recipes_cmd>` command-line flag.
+
 .. _option_ansible_sandbox_hosted_ops_cfg:
 
   * ``hosted_operations``: This is a complex structure that allow to define the behavior of a Yorc server when it executes an hosted operation.
@@ -415,6 +427,39 @@ All available configuration options for Consul are:
 .. _option_pub_routines_cfg:
 
   * ``publisher_max_routines``: Equivalent to :ref:`--consul_publisher_max_routines <option_pub_routines_cmd>` command-line flag.
+
+.. _yorc_config_file_terraform_section:
+
+Terraform configuration
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Below is an example of configuration file with Terraform configuration options.
+
+.. code-block:: JSON
+
+    {
+      "resources_prefix": "yorc1-",
+      "infrastructures": {
+        "openstack": {
+          "auth_url": "http://your-openstack:5000/v2.0",
+          "tenant_name": "your-tenant",
+          "user_name": "os-user",
+          "password": "os-password",
+          "private_network_name": "default-private-network",
+          "default_security_groups": ["default"]
+        }
+      },
+      "terraform": {
+        "keep_generated_file": false
+      }
+    }
+
+All available configuration options for Terraform are:
+
+.. _option_terraform_keep_generated_files_cfg:
+
+  * ``keep_generated_files``: Equivalent to :ref:`--terraform_keep_generated_files <option_terraform_keep_generated_files_cmd>` command-line flag.
+
 
 .. _yorc_config_file_telemetry_section:
 
@@ -563,6 +608,10 @@ Environment variables
 
   * ``YORC_ANSIBLE_ARCHIVE_ARTIFACTS``: Equivalent to :ref:`--ansible_archive_artifacts <option_ansible_archive_artifacts_cmd>` command-line flag.
 
+.. _option_ansible_keep_generated_recipes_env:
+
+  * ``YORC_ANSIBLE_KEEP_GENERATED_RECIPES``: Equivalent to :ref:`--ansible_keep_generated_recipes <option_ansible_keep_generated_recipes_cmd>` command-line flag.
+
 .. _option_operation_remote_base_dir_env:
 
   * ``YORC_OPERATION_REMOTE_BASE_DIR``: Equivalent to :ref:`--operation_remote_base_dir <option_operation_remote_base_dir_cmd>` command-line flag.
@@ -667,14 +716,10 @@ Environment variables
 
   * ``YORC_LOG``: If set to ``1`` or ``DEBUG``, enables debug logging for Yorc.
 
-.. _option_aws_access_key:
+.. _option_terraform_keep_generated_files_env:
 
-  * ``YORC_INFRA_AWS_ACCESS_KEY``: The AWS access key credential.
+  * ``YORC_TERRAFORM_KEEP_GENERATED_FILES``: Equivalent to :ref:`--terraform_keep_generated_files <option_terraform_keep_generated_files_cmd>` command-line flag.
 
-.. _option_aws_secret_key:
-
-  * ``YORC_INFRA_AWS_SECRET_KEY``: The AWS secret key credential.
- 
 
 Infrastructures configuration
 -----------------------------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -32,7 +32,7 @@ Globals Command-line options
 
 .. _option_ansible_keep_generated_recipes_cmd:
 
-  * ``--ansible_keep_generated_recipes``: If set to true, generated Ansible recipes on Yorc server are not delete. (false by default: generated recipes are deleted).
+  * ``--ansible_keep_generated_recipes``: If set to true, generated Ansible recipes on Yorc server are not deleted. (false by default: generated recipes are deleted).
 
 .. _option_operation_remote_base_dir_cmd:
 
@@ -80,7 +80,7 @@ Globals Command-line options
 
 .. _option_terraform_keep_generated_files_cmd:
 
-  * ``--terraform_keep_generated_files``: If set to true, generated Terraform infrastructures files on Yorc server are not delete. (false by default: generated files are deleted).
+  * ``--terraform_keep_generated_files``: If set to true, generated Terraform infrastructures files on Yorc server are not deleted. (false by default: generated files are deleted).
 
 .. _option_pub_routines_cmd:
 
@@ -450,7 +450,7 @@ Below is an example of configuration file with Terraform configuration options.
         }
       },
       "terraform": {
-        "keep_generated_file": false
+        "keep_generated_files": false
       }
     }
 

--- a/events/log_entries_enum.go
+++ b/events/log_entries_enum.go
@@ -41,11 +41,12 @@ var _LogLevelMap = map[LogLevel]string{
 	3: _LogLevelName[13:18],
 }
 
-func (i LogLevel) String() string {
-	if str, ok := _LogLevelMap[i]; ok {
+// String implements the Stringer interface.
+func (x LogLevel) String() string {
+	if str, ok := _LogLevelMap[x]; ok {
 		return str
 	}
-	return fmt.Sprintf("LogLevel(%d)", i)
+	return fmt.Sprintf("LogLevel(%d)", x)
 }
 
 var _LogLevelValue = map[string]LogLevel{
@@ -58,7 +59,7 @@ var _LogLevelValue = map[string]LogLevel{
 // ParseLogLevel attempts to convert a string to a LogLevel
 func ParseLogLevel(name string) (LogLevel, error) {
 	if x, ok := _LogLevelValue[name]; ok {
-		return LogLevel(x), nil
+		return x, nil
 	}
 	return LogLevel(0), fmt.Errorf("%s is not a valid LogLevel", name)
 }

--- a/prov/hostspool/hostspool_structs_enum.go
+++ b/prov/hostspool/hostspool_structs_enum.go
@@ -39,11 +39,12 @@ var _HostStatusMap = map[HostStatus]string{
 	2: _HostStatusName[13:18],
 }
 
-func (i HostStatus) String() string {
-	if str, ok := _HostStatusMap[i]; ok {
+// String implements the Stringer interface.
+func (x HostStatus) String() string {
+	if str, ok := _HostStatusMap[x]; ok {
 		return str
 	}
-	return fmt.Sprintf("HostStatus(%d)", i)
+	return fmt.Sprintf("HostStatus(%d)", x)
 }
 
 var _HostStatusValue = map[string]HostStatus{
@@ -58,7 +59,7 @@ var _HostStatusValue = map[string]HostStatus{
 // ParseHostStatus attempts to convert a string to a HostStatus
 func ParseHostStatus(name string) (HostStatus, error) {
 	if x, ok := _HostStatusValue[name]; ok {
-		return HostStatus(x), nil
+		return x, nil
 	}
 	return HostStatus(0), fmt.Errorf("%s is not a valid HostStatus", name)
 }

--- a/prov/monitoring/monitoring_structs_enum.go
+++ b/prov/monitoring/monitoring_structs_enum.go
@@ -36,11 +36,12 @@ var _CheckStatusMap = map[CheckStatus]string{
 	1: _CheckStatusName[7:15],
 }
 
-func (i CheckStatus) String() string {
-	if str, ok := _CheckStatusMap[i]; ok {
+// String implements the Stringer interface.
+func (x CheckStatus) String() string {
+	if str, ok := _CheckStatusMap[x]; ok {
 		return str
 	}
-	return fmt.Sprintf("CheckStatus(%d)", i)
+	return fmt.Sprintf("CheckStatus(%d)", x)
 }
 
 var _CheckStatusValue = map[string]CheckStatus{
@@ -53,7 +54,7 @@ var _CheckStatusValue = map[string]CheckStatus{
 // ParseCheckStatus attempts to convert a string to a CheckStatus
 func ParseCheckStatus(name string) (CheckStatus, error) {
 	if x, ok := _CheckStatusValue[name]; ok {
-		return CheckStatus(x), nil
+		return x, nil
 	}
 	return CheckStatus(0), fmt.Errorf("%s is not a valid CheckStatus", name)
 }

--- a/prov/terraform/aws/generator.go
+++ b/prov/terraform/aws/generator.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"path/filepath"
 
@@ -37,7 +36,7 @@ const infrastructureName = "aws"
 type awsGenerator struct {
 }
 
-func (g *awsGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg config.Configuration, deploymentID, nodeName string) (bool, map[string]string, []string, error) {
+func (g *awsGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg config.Configuration, deploymentID, nodeName, infrastructurePath string) (bool, map[string]string, []string, error) {
 	log.Debugf("Generating infrastructure for deployment with id %s", deploymentID)
 	cClient, err := cfg.GetConsulClient()
 	if err != nil {
@@ -136,13 +135,9 @@ func (g *awsGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg co
 	if err != nil {
 		return false, nil, nil, errors.Wrap(err, "Failed to generate JSON of terraform Infrastructure description")
 	}
-	infraPath := filepath.Join(cfg.WorkingDirectory, "deployments", fmt.Sprint(deploymentID), "infra", nodeName)
-	if err = os.MkdirAll(infraPath, 0775); err != nil {
-		return false, nil, nil, errors.Wrapf(err, "Failed to create infrastructure working directory %q", infraPath)
-	}
 
-	if err = ioutil.WriteFile(filepath.Join(infraPath, "infra.tf.json"), jsonInfra, 0664); err != nil {
-		return false, nil, nil, errors.Wrapf(err, "Failed to write file %q", filepath.Join(infraPath, "infra.tf.json"))
+	if err = ioutil.WriteFile(filepath.Join(infrastructurePath, "infra.tf.json"), jsonInfra, 0664); err != nil {
+		return false, nil, nil, errors.Wrapf(err, "Failed to write file %q", filepath.Join(infrastructurePath, "infra.tf.json"))
 	}
 
 	log.Debugf("Infrastructure generated for deployment with id %s", deploymentID)

--- a/prov/terraform/commons/generator.go
+++ b/prov/terraform/commons/generator.go
@@ -29,8 +29,8 @@ type Generator interface {
 	// GenerateTerraformInfraForNode can also return a map of outputs names indexed by consul keys into which the outputs results should be stored.
 	// And a list of environment variables in form "key=value" to be added to the current process environment when running terraform commands.
 	// This is particularly useful for adding secrets that should not be in tf files.
-	GenerateTerraformInfraForNode(ctx context.Context, cfg config.Configuration, deploymentID, nodeName string) (bool, map[string]string, []string, error)
+	GenerateTerraformInfraForNode(ctx context.Context, cfg config.Configuration, deploymentID, nodeName, infrastructurePath string) (bool, map[string]string, []string, error)
 }
 
 // PreDestroyInfraCallback is a function that is call before destroying an infrastructure. If it returns false the node will not be destroyed.
-type PreDestroyInfraCallback func(ctx context.Context, kv *api.KV, cfg config.Configuration, deploymentID, nodeName string) (bool, error)
+type PreDestroyInfraCallback func(ctx context.Context, kv *api.KV, cfg config.Configuration, deploymentID, nodeName, infrastructurePath string) (bool, error)

--- a/prov/terraform/google/generator.go
+++ b/prov/terraform/google/generator.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -38,7 +37,7 @@ const infrastructureName = "google"
 type googleGenerator struct {
 }
 
-func (g *googleGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg config.Configuration, deploymentID, nodeName string) (bool, map[string]string, []string, error) {
+func (g *googleGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg config.Configuration, deploymentID, nodeName, infrastructurePath string) (bool, map[string]string, []string, error) {
 	log.Debugf("Generating infrastructure for deployment with id %s", deploymentID)
 	cClient, err := cfg.GetConsulClient()
 	if err != nil {
@@ -145,13 +144,9 @@ func (g *googleGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg
 	if err != nil {
 		return false, nil, nil, errors.Wrap(err, "Failed to generate JSON of terraform Infrastructure description")
 	}
-	infraPath := filepath.Join(cfg.WorkingDirectory, "deployments", fmt.Sprint(deploymentID), "infra", nodeName)
-	if err = os.MkdirAll(infraPath, 0775); err != nil {
-		return false, nil, nil, errors.Wrapf(err, "Failed to create infrastructure working directory %q", infraPath)
-	}
 
-	if err = ioutil.WriteFile(filepath.Join(infraPath, "infra.tf.json"), jsonInfra, 0664); err != nil {
-		return false, nil, nil, errors.Wrapf(err, "Failed to write file %q", filepath.Join(infraPath, "infra.tf.json"))
+	if err = ioutil.WriteFile(filepath.Join(infrastructurePath, "infra.tf.json"), jsonInfra, 0664); err != nil {
+		return false, nil, nil, errors.Wrapf(err, "Failed to write file %q", filepath.Join(infrastructurePath, "infra.tf.json"))
 	}
 
 	log.Debugf("Infrastructure generated for deployment with id %s", deploymentID)

--- a/prov/terraform/openstack/generator.go
+++ b/prov/terraform/openstack/generator.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -50,7 +49,7 @@ func (g *osGenerator) getStringFormConsul(kv *api.KV, baseURL, property string) 
 	return string(getResult.Value), nil
 }
 
-func (g *osGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg config.Configuration, deploymentID, nodeName string) (bool, map[string]string, []string, error) {
+func (g *osGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg config.Configuration, deploymentID, nodeName, infrastructurePath string) (bool, map[string]string, []string, error) {
 	log.Debugf("Generating infrastructure for deployment with id %s", deploymentID)
 	cClient, err := cfg.GetConsulClient()
 	if err != nil {
@@ -268,13 +267,9 @@ func (g *osGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg con
 	if err != nil {
 		return false, nil, nil, errors.Wrap(err, "Failed to generate JSON of terraform Infrastructure description")
 	}
-	infraPath := filepath.Join(cfg.WorkingDirectory, "deployments", deploymentID, "infra", nodeName)
-	if err = os.MkdirAll(infraPath, 0775); err != nil {
-		return false, nil, nil, errors.Wrapf(err, "Failed to create infrastructure working directory %q", infraPath)
-	}
 
-	if err = ioutil.WriteFile(filepath.Join(infraPath, "infra.tf.json"), jsonInfra, 0664); err != nil {
-		return false, nil, nil, errors.Wrapf(err, "Failed to write file %q", filepath.Join(infraPath, "infra.tf.json"))
+	if err = ioutil.WriteFile(filepath.Join(infrastructurePath, "infra.tf.json"), jsonInfra, 0664); err != nil {
+		return false, nil, nil, errors.Wrapf(err, "Failed to write file %q", filepath.Join(infrastructurePath, "infra.tf.json"))
 	}
 
 	log.Debugf("Infrastructure generated for deployment with id %s", deploymentID)

--- a/prov/terraform/openstack/init.go
+++ b/prov/terraform/openstack/init.go
@@ -33,7 +33,7 @@ func init() {
 	reg.RegisterDelegates([]string{`yorc\.nodes\.openstack\..*`}, terraform.NewExecutor(&osGenerator{}, preDestroyInfraCallback), registry.BuiltinOrigin)
 }
 
-func preDestroyInfraCallback(ctx context.Context, kv *api.KV, cfg config.Configuration, deploymentID, nodeName string) (bool, error) {
+func preDestroyInfraCallback(ctx context.Context, kv *api.KV, cfg config.Configuration, deploymentID, nodeName, infrastructurePath string) (bool, error) {
 	nodeType, err := deployments.GetNodeType(kv, deploymentID, nodeName)
 	if err != nil {
 		return false, err

--- a/rest/structs_enum.go
+++ b/rest/structs_enum.go
@@ -36,11 +36,12 @@ var _MapEntryOperationMap = map[MapEntryOperation]string{
 	1: _MapEntryOperationName[3:9],
 }
 
-func (i MapEntryOperation) String() string {
-	if str, ok := _MapEntryOperationMap[i]; ok {
+// String implements the Stringer interface.
+func (x MapEntryOperation) String() string {
+	if str, ok := _MapEntryOperationMap[x]; ok {
 		return str
 	}
-	return fmt.Sprintf("MapEntryOperation(%d)", i)
+	return fmt.Sprintf("MapEntryOperation(%d)", x)
 }
 
 var _MapEntryOperationValue = map[string]MapEntryOperation{
@@ -53,7 +54,7 @@ var _MapEntryOperationValue = map[string]MapEntryOperation{
 // ParseMapEntryOperation attempts to convert a string to a MapEntryOperation
 func ParseMapEntryOperation(name string) (MapEntryOperation, error) {
 	if x, ok := _MapEntryOperationValue[name]; ok {
-		return MapEntryOperation(x), nil
+		return x, nil
 	}
 	return MapEntryOperation(0), fmt.Errorf("%s is not a valid MapEntryOperation", name)
 }

--- a/tasks/structs_enum.go
+++ b/tasks/structs_enum.go
@@ -44,11 +44,12 @@ var _TaskStatusMap = map[TaskStatus]string{
 	4: _TaskStatusName[24:32],
 }
 
-func (i TaskStatus) String() string {
-	if str, ok := _TaskStatusMap[i]; ok {
+// String implements the Stringer interface.
+func (x TaskStatus) String() string {
+	if str, ok := _TaskStatusMap[x]; ok {
 		return str
 	}
-	return fmt.Sprintf("TaskStatus(%d)", i)
+	return fmt.Sprintf("TaskStatus(%d)", x)
 }
 
 var _TaskStatusValue = map[string]TaskStatus{
@@ -62,7 +63,7 @@ var _TaskStatusValue = map[string]TaskStatus{
 // ParseTaskStatus attempts to convert a string to a TaskStatus
 func ParseTaskStatus(name string) (TaskStatus, error) {
 	if x, ok := _TaskStatusValue[name]; ok {
-		return TaskStatus(x), nil
+		return x, nil
 	}
 	return TaskStatus(0), fmt.Errorf("%s is not a valid TaskStatus", name)
 }
@@ -99,11 +100,12 @@ var _TaskTypeMap = map[TaskType]string{
 	7: _TaskTypeName[61:66],
 }
 
-func (i TaskType) String() string {
-	if str, ok := _TaskTypeMap[i]; ok {
+// String implements the Stringer interface.
+func (x TaskType) String() string {
+	if str, ok := _TaskTypeMap[x]; ok {
 		return str
 	}
-	return fmt.Sprintf("TaskType(%d)", i)
+	return fmt.Sprintf("TaskType(%d)", x)
 }
 
 var _TaskTypeValue = map[string]TaskType{
@@ -120,7 +122,7 @@ var _TaskTypeValue = map[string]TaskType{
 // ParseTaskType attempts to convert a string to a TaskType
 func ParseTaskType(name string) (TaskType, error) {
 	if x, ok := _TaskTypeValue[name]; ok {
-		return TaskType(x), nil
+		return x, nil
 	}
 	return TaskType(0), fmt.Errorf("%s is not a valid TaskType", name)
 }

--- a/tasks/structs_step_enum.go
+++ b/tasks/structs_step_enum.go
@@ -45,11 +45,12 @@ var _TaskStepStatusMap = map[TaskStepStatus]string{
 	4: _TaskStepStatusName[23:31],
 }
 
-func (i TaskStepStatus) String() string {
-	if str, ok := _TaskStepStatusMap[i]; ok {
+// String implements the Stringer interface.
+func (x TaskStepStatus) String() string {
+	if str, ok := _TaskStepStatusMap[x]; ok {
 		return str
 	}
-	return fmt.Sprintf("TaskStepStatus(%d)", i)
+	return fmt.Sprintf("TaskStepStatus(%d)", x)
 }
 
 var _TaskStepStatusValue = map[string]TaskStepStatus{
@@ -68,7 +69,7 @@ var _TaskStepStatusValue = map[string]TaskStepStatus{
 // ParseTaskStepStatus attempts to convert a string to a TaskStepStatus
 func ParseTaskStepStatus(name string) (TaskStepStatus, error) {
 	if x, ok := _TaskStepStatusValue[name]; ok {
-		return TaskStepStatus(x), nil
+		return x, nil
 	}
 	return TaskStepStatus(0), fmt.Errorf("%s is not a valid TaskStepStatus", name)
 }

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -184,32 +184,34 @@ func DeleteTask(kv *api.KV, taskID string) error {
 }
 
 // TargetHasLivingTasks checks if a targetID has associated tasks in status INITIAL or RUNNING and returns the id and status of the first one found
+//
+// Only Deploy, UnDeploy, ScaleOut, ScaleIn and Purge task type are considered.
 func TargetHasLivingTasks(kv *api.KV, targetID string) (bool, string, string, error) {
 	tasksKeys, _, err := kv.Keys(consulutil.TasksPrefix+"/", "/", nil)
 	if err != nil {
 		return false, "", "", errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 	}
 	for _, taskKey := range tasksKeys {
-		kvp, _, err := kv.Get(path.Join(taskKey, "targetId"), nil)
+		taskID := path.Base(taskKey)
+		ttID, err := GetTaskTarget(kv, taskID)
 		if err != nil {
-			return false, "", "", errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+			return false, "", "", err
 		}
-		if kvp != nil && len(kvp.Value) > 0 && string(kvp.Value) == targetID {
-			kvp, _, err := kv.Get(path.Join(taskKey, "status"), nil)
-			taskID := path.Base(taskKey)
+		if ttID == targetID {
+			tStatus, err := GetTaskStatus(kv, taskID)
 			if err != nil {
-				return false, "", "", errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+				return false, "", "", err
 			}
-			if kvp == nil || len(kvp.Value) == 0 {
-				return false, "", "", errors.Errorf("Missing status for task with id %q", taskID)
-			}
-			statusInt, err := strconv.Atoi(string(kvp.Value))
+			tType, err := GetTaskType(kv, taskID)
 			if err != nil {
-				return false, "", "", errors.Wrap(err, "Invalid task status")
+				return false, "", "", err
 			}
-			switch TaskStatus(statusInt) {
-			case TaskStatusINITIAL, TaskStatusRUNNING:
-				return true, taskID, TaskStatus(statusInt).String(), nil
+
+			switch tType {
+			case TaskTypeDeploy, TaskTypeUnDeploy, TaskTypePurge, TaskTypeScaleIn, TaskTypeScaleOut:
+				if tStatus == TaskStatusINITIAL || tStatus == TaskStatusRUNNING {
+					return true, taskID, tStatus.String(), nil
+				}
 			}
 		}
 	}

--- a/tasks/tasks_test.go
+++ b/tasks/tasks_test.go
@@ -24,9 +24,10 @@ import (
 
 	"encoding/json"
 	"fmt"
+	"strconv"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testutil"
-	"strconv"
 )
 
 func populateKV(t *testing.T, srv *testutil.TestServer) {
@@ -81,7 +82,8 @@ func populateKV(t *testing.T, srv *testutil.TestServer) {
 		consulutil.TasksPrefix + "/t13/type":      []byte("5"),
 		consulutil.TasksPrefix + "/t13/status":    []byte("3"),
 		consulutil.TasksPrefix + "/t14/status":    []byte("3"),
-		consulutil.TasksPrefix + "/t14/type":      []byte("5"),
+		consulutil.TasksPrefix + "/t14/type":      []byte("6"),
+		consulutil.TasksPrefix + "/t14/targetId":  []byte("id"),
 
 		consulutil.TasksPrefix + "/t15/targetId": []byte("xxx"),
 		consulutil.TasksPrefix + "/t15/status":   []byte("2"),

--- a/tasks/workflow/activities_enum.go
+++ b/tasks/workflow/activities_enum.go
@@ -42,11 +42,12 @@ var _ActivityTypeMap = map[ActivityType]string{
 	3: _ActivityTypeName[31:37],
 }
 
-func (i ActivityType) String() string {
-	if str, ok := _ActivityTypeMap[i]; ok {
+// String implements the Stringer interface.
+func (x ActivityType) String() string {
+	if str, ok := _ActivityTypeMap[x]; ok {
 		return str
 	}
-	return fmt.Sprintf("ActivityType(%d)", i)
+	return fmt.Sprintf("ActivityType(%d)", x)
 }
 
 var _ActivityTypeValue = map[string]ActivityType{
@@ -63,7 +64,7 @@ var _ActivityTypeValue = map[string]ActivityType{
 // ParseActivityType attempts to convert a string to a ActivityType
 func ParseActivityType(name string) (ActivityType, error) {
 	if x, ok := _ActivityTypeValue[name]; ok {
-		return ActivityType(x), nil
+		return x, nil
 	}
 	return ActivityType(0), fmt.Errorf("%s is not a valid ActivityType", name)
 }


### PR DESCRIPTION
# Pull Request description

## Description of the change

Custom commands and custom workflows can be run along with other wf/cc but not if a deployment/undeployment/scaling workflow is currently running.

Now terraform and ansible recipes are stored under a path containing the execution task id.
By default those files are deleted after the execution by config options are available to keep them.

__Note:__ developed to be integrated on 3.0 and ported to 3.1 in another PR.

## Applicable Issues

Closes #182 