### PR TITLE
Backport 3.0: Parse properties on requirements in A4C format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Inputs are not injected into Slurm (srun) jobs ([GH-161](https://github.com/ystia/yorc/issues/161))
 * Retrieving operation output when provisioning several instances resolves to the same value for all instances even if they are actually different ([GH-171](https://github.com/ystia/yorc/issues/171))
+* Parse Alien specific way of defining properties on relationships ([GH-155](https://github.com/ystia/yorc/issues/155))
 
 ### ENHANCEMENTS
 

--- a/deployments/testdata/value_assignments.yaml
+++ b/deployments/testdata/value_assignments.yaml
@@ -480,29 +480,28 @@ topology_template:
         - host:
             node: VANode1
             capability: yorc.tests.capabilities.ValueAssignmentContainer
-            relationship: 
-              type: yorc.tests.relationships.ValueAssignmentHostedOn
-              properties:
-                literal: "user rel literal"
-                mapProp: {"U1": "V1", "U2": "V2"}
-                listProp: ["UV1", "UV2", "UV3"]
-                complex:
-                  literal: 5
-                  literalDefault: VANode2ToVANode1
-                baseComplex:
-                  nestedType:
-                    listofstring: ["VANode2ToVANode1L1", "VANode2ToVANode1L2"]
-                    subcomplex:
-                      literal: 2
-                    listofcomplex:
-                      - literal: 2
-                        mymap: {"VANode2ToVANode1": 1}
-                      - literal: 3
-                        mymap: {"VANode2ToVANode1": 2}
-                    mapofcomplex:
-                      m1: 
-                        literal: 4
-                        mymap: {"VANode2ToVANode1": 3}
+            relationship: yorc.tests.relationships.ValueAssignmentHostedOn
+            properties:
+              literal: "user rel literal"
+              mapProp: {"U1": "V1", "U2": "V2"}
+              listProp: ["UV1", "UV2", "UV3"]
+              complex:
+                literal: 5
+                literalDefault: VANode2ToVANode1
+              baseComplex:
+                nestedType:
+                  listofstring: ["VANode2ToVANode1L1", "VANode2ToVANode1L2"]
+                  subcomplex:
+                    literal: 2
+                  listofcomplex:
+                    - literal: 2
+                      mymap: {"VANode2ToVANode1": 1}
+                    - literal: 3
+                      mymap: {"VANode2ToVANode1": 2}
+                  mapofcomplex:
+                    m1: 
+                      literal: 4
+                      mymap: {"VANode2ToVANode1": 3}
 
 
 

--- a/testutil/helper.go
+++ b/testutil/helper.go
@@ -45,14 +45,18 @@ func NewTestConsulInstance(t *testing.T) (*testutil.TestServer, *api.Client) {
 		t.Fatalf("Failed to create consul server: %v", err)
 	}
 
-	consulConfig := api.DefaultConfig()
-	consulConfig.Address = srv1.HTTPAddr
+	cfg := config.Configuration{
+		Consul: config.Consul{
+			Address:        srv1.HTTPAddr,
+			PubMaxRoutines: config.DefaultConsulPubMaxRoutines,
+		},
+	}
 
-	client, err := api.NewClient(consulConfig)
+	client, err := cfg.GetNewConsulClient()
 	assert.Nil(t, err)
 
 	kv := client.KV()
-	consulutil.InitConsulPublisher(config.DefaultConsulPubMaxRoutines, kv)
+	consulutil.InitConsulPublisher(cfg.Consul.PubMaxRoutines, kv)
 	return srv1, client
 }
 

--- a/tosca/requirements.go
+++ b/tosca/requirements.go
@@ -158,10 +158,11 @@ func (r *RequirementAssignment) UnmarshalYAML(unmarshal func(interface{}) error)
 	}
 
 	var ra struct {
-		Capability      string `yaml:"capability"`
-		Node            string `yaml:"node,omitempty"`
-		Relationship    string `yaml:"relationship,omitempty"`
-		TypeRequirement string `yaml:"type_requirement,omitempty"`
+		Capability      string                      `yaml:"capability"`
+		Node            string                      `yaml:"node,omitempty"`
+		Relationship    string                      `yaml:"relationship,omitempty"`
+		TypeRequirement string                      `yaml:"type_requirement,omitempty"`
+		Properties      map[string]*ValueAssignment `yaml:"properties,omitempty"`
 	}
 
 	if err := unmarshal(&ra); err == nil {
@@ -169,6 +170,7 @@ func (r *RequirementAssignment) UnmarshalYAML(unmarshal func(interface{}) error)
 		r.Node = ra.Node
 		r.Relationship = ra.Relationship
 		r.TypeRequirement = ra.TypeRequirement
+		r.RelationshipProps = ra.Properties
 		return nil
 	}
 

--- a/tosca/requirements_test.go
+++ b/tosca/requirements_test.go
@@ -23,16 +23,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func TestGroupedRequirementParallel(t *testing.T) {
-	t.Run("groupRequirement", func(t *testing.T) {
-		t.Run("TestrequirementAssignmentComplex", requirementAssignmentComplex)
-		t.Run("TestrequirementAssignmentSimple", requirementAssignmentSimple)
-		t.Run("TestrequirementAssignmentSimpleRelationship", requirementAssignmentSimpleRelationship)
-		t.Run("TestrequirementDefinitionStandard", requirementDefinitionStandard)
-		t.Run("TestrequirementDefinitionAlien", requirementDefinitionAlien)
-	})
-}
-
 type ReqTestNode struct {
 	Requirements []RequirementAssignmentMap `yaml:"requirements,omitempty"`
 }
@@ -41,7 +31,7 @@ type ReqDefTestNode struct {
 	Requirements []RequirementDefinitionMap `yaml:"requirements,omitempty"`
 }
 
-func requirementAssignmentComplex(t *testing.T) {
+func TestRequirementAssignmentComplex(t *testing.T) {
 	t.Parallel()
 	data := `Compute:
   requirements:
@@ -68,7 +58,7 @@ func requirementAssignmentComplex(t *testing.T) {
 	assert.Contains(t, lc.TypeRequirement, "host")
 }
 
-func requirementAssignmentSimple(t *testing.T) {
+func TestRequirementAssignmentSimple(t *testing.T) {
 	t.Parallel()
 	data := `Compute:
   requirements:
@@ -85,14 +75,18 @@ func requirementAssignmentSimple(t *testing.T) {
 	assert.Equal(t, "nodeName", req.Node)
 }
 
-func requirementAssignmentSimpleRelationship(t *testing.T) {
+func TestRequirementAssignmentSimpleRelationship(t *testing.T) {
 	t.Parallel()
-	data := `Compute:
+	data := `
+Compute:
   requirements:
     - req:
         node: nodeName
         capability: tosca.capabilities.cap
-        relationship: tosca.relationships.rs`
+        relationship: tosca.relationships.rs
+        properties:
+          literal: "value"
+`
 	nodes := make(map[string]ReqTestNode)
 	err := yaml.Unmarshal([]byte(data), &nodes)
 	assert.Nil(t, err)
@@ -105,9 +99,11 @@ func requirementAssignmentSimpleRelationship(t *testing.T) {
 	assert.Equal(t, "nodeName", req.Node)
 	assert.Equal(t, "tosca.capabilities.cap", req.Capability)
 	assert.Equal(t, "tosca.relationships.rs", req.Relationship)
+	assert.NotNil(t, req.RelationshipProps["literal"])
+	assert.Equal(t, "value", req.RelationshipProps["literal"].GetLiteral())
 }
 
-func requirementDefinitionStandard(t *testing.T) {
+func TestRequirementDefinitionStandard(t *testing.T) {
 	t.Parallel()
 	log.SetDebug(true)
 	data := `NodeType:
@@ -160,7 +156,7 @@ func requirementDefinitionStandard(t *testing.T) {
 
 }
 
-func requirementDefinitionAlien(t *testing.T) {
+func TestRequirementDefinitionAlien(t *testing.T) {
 	t.Parallel()
 	log.SetDebug(true)
 	data := `NodeType:


### PR DESCRIPTION
# Pull Request description

Backport of #157 into 3.0

Also contains a fix on the way we run consul test to limit the max open files issue

## Applicable Issues

Fixes #155 