### PR TITLE
Feature/gh 77 scale a container on gke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### ENHANCEMENTS
 
 * Concurrent workflows and custom commands executions are now allowed except when a deployment/undeployment/scaling operation is in progress ([GH-182](https://github.com/ystia/yorc/issues/182))
-
+* Enable scaling of Kubernetes deployments ([GH-77](https://github.com/ystia/yorc/issues/77))
 
 ## 3.1.0-M4 (October 08, 2018)
 

--- a/data/tosca/yorc-kubernetes-types.yml
+++ b/data/tosca/yorc-kubernetes-types.yml
@@ -20,6 +20,11 @@ artifact_types:
 node_types:
   yorc.nodes.kubernetes.api.types.DeploymentResource:
     derived_from: org.alien4cloud.kubernetes.api.types.DeploymentResource
+    attributes:
+      replicas:
+        type: integer
+        description: >
+          Current number of replicas for this deployment
     interfaces:
       org.alien4cloud.management.ClusterControl:
         scale:

--- a/data/tosca/yorc-kubernetes-types.yml
+++ b/data/tosca/yorc-kubernetes-types.yml
@@ -21,6 +21,16 @@ node_types:
   yorc.nodes.kubernetes.api.types.DeploymentResource:
     derived_from: org.alien4cloud.kubernetes.api.types.DeploymentResource
     interfaces:
+      org.alien4cloud.management.ClusterControl:
+        scale:
+          inputs:
+            EXPECTED_INSTANCES:
+              type: integer
+            INSTANCES_DELTA:
+              type: integer
+          implementation:
+            file: "embedded"
+            type: yorc.artifacts.Deployment.Kubernetes
       Standard:
         create:
           implementation:

--- a/prov/kubernetes/execution.go
+++ b/prov/kubernetes/execution.go
@@ -315,7 +315,7 @@ func (e *executionCommon) manageDeploymentResource(ctx context.Context, clientse
 		if err != nil {
 			return err
 		}
-		err = deployments.SetAttributeForAllInstances(e.kv, e.deploymentID, e.NodeName, "replicas", fmt.Sprint(*deployment.Spec.Replicas))
+		err = deployments.SetAttributeForAllInstances(e.kv, e.deploymentID, e.NodeName, "replicas", expectedInstances)
 		if err != nil {
 			return err
 		}

--- a/prov/kubernetes/execution.go
+++ b/prov/kubernetes/execution.go
@@ -252,7 +252,10 @@ func (e *executionCommon) manageDeploymentResource(ctx context.Context, clientse
 		if err != nil {
 			return err
 		}
-
+		err = deployments.SetAttributeForAllInstances(e.kv, e.deploymentID, e.NodeName, "replicas", fmt.Sprint(*deployment.Spec.Replicas))
+		if err != nil {
+			return err
+		}
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelDEBUG, e.deploymentID).Registerf("k8s Deployment %s created in namespace %s", deployment.Name, namespace)
 	case k8sDeleteOperation:
 		// Delete Deployment k8s resource
@@ -312,9 +315,11 @@ func (e *executionCommon) manageDeploymentResource(ctx context.Context, clientse
 		if err != nil {
 			return err
 		}
-
+		err = deployments.SetAttributeForAllInstances(e.kv, e.deploymentID, e.NodeName, "replicas", fmt.Sprint(*deployment.Spec.Replicas))
+		if err != nil {
+			return err
+		}
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelDEBUG, e.deploymentID).Registerf("k8s Deployment %s scaled to %s instances in namespace %s", deployment.Name, expectedInstances, namespace)
-
 	default:
 		return errors.Errorf("Unsupported operation on k8s resource")
 	}

--- a/prov/kubernetes/execution.go
+++ b/prov/kubernetes/execution.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -54,6 +55,7 @@ type k8sResourceOperation int
 const (
 	k8sCreateOperation k8sResourceOperation = iota
 	k8sDeleteOperation
+	k8sScaleOperation
 )
 
 type execution interface {
@@ -151,6 +153,8 @@ func (e *executionCommon) execute(ctx context.Context, clientset *kubernetes.Cli
 		return e.uninstallNode(ctx, clientset)
 	case "standard.delete":
 		return e.manageKubernetesResource(ctx, clientset, generator, k8sDeleteOperation)
+	case "org.alien4cloud.management.clustercontrol.scale":
+		return e.manageKubernetesResource(ctx, clientset, generator, k8sScaleOperation)
 	default:
 		return errors.Errorf("Unsupported operation %q", e.Operation.Name)
 	}
@@ -286,6 +290,30 @@ func (e *executionCommon) manageDeploymentResource(ctx context.Context, clientse
 			return err
 		}
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelINFO, e.deploymentID).Registerf("k8s Namespace %s deleted", namespace)
+	case k8sScaleOperation:
+		expectedInstances, err := tasks.GetTaskInput(e.kv, e.taskID, "EXPECTED_INSTANCES")
+		if err != nil {
+			return err
+		}
+		r, err := strconv.ParseInt(expectedInstances, 10, 32)
+		if err != nil {
+			return errors.Wrapf(err, "failed to parse EXPECTED_INSTANCES: %q parameter as integer", expectedInstances)
+		}
+		replicas := int32(r)
+		deploymentRepr.Spec.Replicas = &replicas
+
+		deployment, err := clientset.ExtensionsV1beta1().Deployments(namespace).Update(&deploymentRepr)
+		if err != nil {
+			return errors.Wrap(err, "failed to update kubernetes deployment for scaling")
+		}
+		streamDeploymentLogs(ctx, e.deploymentID, clientset, deployment)
+
+		err = waitForDeploymentCompletion(ctx, e.deploymentID, clientset, deployment)
+		if err != nil {
+			return err
+		}
+
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelDEBUG, e.deploymentID).Registerf("k8s Deployment %s scaled to %s instances in namespace %s", deployment.Name, expectedInstances, namespace)
 
 	default:
 		return errors.Errorf("Unsupported operation on k8s resource")

--- a/rest/http_api.md
+++ b/rest/http_api.md
@@ -581,12 +581,15 @@ Request body:
 {
     "node": "NodeName",
     "name": "Custom_Command_Name",
+    "interface": "fully.qualified.interface.name",
     "inputs": {
       "index":"",
       "nb_replicas":"2"
     }
 }
 ```
+
+If omitted interface defaults to `custom`.
 
 **Response**:
 

--- a/rest/structs.go
+++ b/rest/structs.go
@@ -168,6 +168,7 @@ type Attribute struct {
 type CustomCommandRequest struct {
 	NodeName          string                            `json:"node"`
 	CustomCommandName string                            `json:"name"`
+	InterfaceName     string                            `json:"interface,omitempty"`
 	Inputs            map[string]*tosca.ValueAssignment `json:"inputs"`
 }
 

--- a/tasks/workflow/task_execution.go
+++ b/tasks/workflow/task_execution.go
@@ -93,6 +93,7 @@ func (t *taskExecution) setTaskStatus(ctx context.Context, status tasks.TaskStat
 		log.Debugf("[WARNING] Failed to set task status to:%q for taskID:%q as last index has been changed before. Retry it", status.String(), t.taskID)
 		return t.checkAndSetTaskStatus(ctx, status)
 	}
+	tasks.EmitTaskEventWithContextualLogs(ctx, t.kv, t.targetID, t.taskID, t.taskType, status.String())
 	if status == tasks.TaskStatusFAILED {
 		return t.addTaskErrorFlag(ctx)
 	}


### PR DESCRIPTION
# Pull Request description

## Description of the change

Implement a custom operation that allows to scale a k8s container deployment unit.

### What I did

- Implement scaling within the k8s integration
- Support custom command with interfaces names different from `custom` 

## Applicable Issues

**PR ystia/yorc-a4c-plugin#66 is required**

Fixes #77 
