### PR TITLE
Install pyopenssl lib by default in the Docker iamge

### DIFF
--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -21,7 +21,7 @@ ADD rootfs /
 RUN apk add --update make openssh-client python python-dev py-pip gcc musl-dev libffi-dev openssl-dev && \
     mkdir /tmp/docker && apk fetch -o /tmp/docker docker && \
     tar xzf /tmp/docker/*.apk -C / usr/bin/docker && \
-    pip install ansible==${ANSIBLE_VERSION} docker-py netaddr jmespath && \
+    pip install ansible==${ANSIBLE_VERSION} docker-py netaddr jmespath pyopenssl && \
     cd /tmp && \
     curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     cd /usr/local/bin && \


### PR DESCRIPTION
# Pull Request description

Install pyopenssl python lib in order to be able to use Ansible modules that use openssl to generate certificates

## Description of the change

### What I did

### How I did it

### How to verify it

### Description for the changelog

## Applicable Issues
