### PR TITLE
Prefix GCP resources with an hash of the deployment id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Generate unique names fro GCP resources ([GH-177](https://github.com/ystia/yorc/issues/177))
+
 ## 3.1.0-M5 (October 26, 2018)
 
 ### FEATURES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### BUG FIXES
 
-* Generate unique names fro GCP resources ([GH-177](https://github.com/ystia/yorc/issues/177))
+* Generate unique names for GCP resources ([GH-177](https://github.com/ystia/yorc/issues/177))
 
 ## 3.1.0-M5 (October 26, 2018)
 

--- a/prov/terraform/google/compute_address.go
+++ b/prov/terraform/google/compute_address.go
@@ -17,14 +17,15 @@ package google
 import (
 	"context"
 	"fmt"
+	"path"
+	"strings"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/pkg/errors"
 	"github.com/ystia/yorc/config"
 	"github.com/ystia/yorc/deployments"
 	"github.com/ystia/yorc/helper/consulutil"
 	"github.com/ystia/yorc/prov/terraform/commons"
-	"path"
-	"strings"
 )
 
 func (g *googleGenerator) generateComputeAddress(ctx context.Context, kv *api.KV,
@@ -73,7 +74,7 @@ func (g *googleGenerator) generateComputeAddress(ctx context.Context, kv *api.KV
 		return err
 	}
 
-	name := strings.ToLower(cfg.ResourcesPrefix + nodeName + "-" + instanceName)
+	name := strings.ToLower(getResourcesPrefix(cfg, deploymentID) + nodeName + "-" + instanceName)
 	computeAddress.Name = strings.Replace(name, "_", "-", -1)
 
 	if computeAddress.Region == "" {

--- a/prov/terraform/google/compute_instance.go
+++ b/prov/terraform/google/compute_instance.go
@@ -17,10 +17,11 @@ package google
 import (
 	"context"
 	"fmt"
-	"github.com/ystia/yorc/log"
 	"path"
 	"strings"
 	"time"
+
+	"github.com/ystia/yorc/log"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/pkg/errors"
@@ -51,7 +52,7 @@ func (g *googleGenerator) generateComputeInstance(ctx context.Context, kv *api.K
 	instance := ComputeInstance{}
 
 	// Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'
-	instance.Name = strings.ToLower(cfg.ResourcesPrefix + nodeName + "-" + instanceName)
+	instance.Name = strings.ToLower(getResourcesPrefix(cfg, deploymentID) + nodeName + "-" + instanceName)
 	instance.Name = strings.Replace(instance.Name, "_", "-", -1)
 
 	// Getting string parameters
@@ -403,7 +404,7 @@ func addAttachedDisks(ctx context.Context, cfg config.Configuration, kv *api.KV,
 			attachedDisk.Mode = modeValue.RawString()
 		}
 
-		attachName := strings.ToLower(cfg.ResourcesPrefix + volumeNodeName + "-" + instanceName + "-to-" + nodeName + "-" + instanceName)
+		attachName := strings.ToLower(getResourcesPrefix(cfg, deploymentID) + volumeNodeName + "-" + instanceName + "-to-" + nodeName + "-" + instanceName)
 		attachName = strings.Replace(attachName, "_", "-", -1)
 		// attachName is used as device name to retrieve device attribute as logical volume name
 		attachedDisk.DeviceName = attachName

--- a/prov/terraform/google/compute_instance_test.go
+++ b/prov/terraform/google/compute_instance_test.go
@@ -16,17 +16,18 @@ package google
 
 import (
 	"context"
-	"github.com/hashicorp/consul/testutil"
-	"github.com/ystia/yorc/helper/consulutil"
+	"fmt"
 	"path"
 	"testing"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ystia/yorc/config"
 	"github.com/ystia/yorc/deployments"
+	"github.com/ystia/yorc/helper/consulutil"
 	"github.com/ystia/yorc/prov/terraform/commons"
 )
 
@@ -41,18 +42,20 @@ func loadTestYaml(t *testing.T, kv *api.KV) string {
 func testSimpleComputeInstance(t *testing.T, kv *api.KV, cfg config.Configuration) {
 	t.Parallel()
 	deploymentID := loadTestYaml(t, kv)
+	resourcePrefix := getResourcesPrefix(cfg, deploymentID)
 	infrastructure := commons.Infrastructure{}
 	g := googleGenerator{}
 	err := g.generateComputeInstance(context.Background(), kv, cfg, deploymentID, "ComputeInstance", "0", 0, &infrastructure, make(map[string]string))
 	require.NoError(t, err, "Unexpected error attempting to generate compute instance for %s", deploymentID)
 
+	instanceName := resourcePrefix + "computeinstance-0"
 	require.Len(t, infrastructure.Resource["google_compute_instance"], 1, "Expected one compute instance")
 	instancesMap := infrastructure.Resource["google_compute_instance"].(map[string]interface{})
 	require.Len(t, instancesMap, 1)
-	require.Contains(t, instancesMap, "computeinstance-0")
+	require.Contains(t, instancesMap, instanceName)
 
-	compute, ok := instancesMap["computeinstance-0"].(*ComputeInstance)
-	require.True(t, ok, "computeinstance-0 is not a ComputeInstance")
+	compute, ok := instancesMap[instanceName].(*ComputeInstance)
+	require.True(t, ok, "%s is not a ComputeInstance", instanceName)
 	assert.Equal(t, "n1-standard-1", compute.MachineType)
 	assert.Equal(t, "europe-west1-b", compute.Zone)
 	require.NotNil(t, compute.BootDisk, 1, "Expected boot disk")
@@ -71,8 +74,9 @@ func testSimpleComputeInstance(t *testing.T, kv *api.KV, cfg config.Configuratio
 	require.Len(t, infrastructure.Resource["null_resource"], 1)
 	nullResources := infrastructure.Resource["null_resource"].(map[string]interface{})
 
-	require.Contains(t, nullResources, "computeinstance-0-ConnectionCheck")
-	nullRes, ok := nullResources["computeinstance-0-ConnectionCheck"].(*commons.Resource)
+	connectionCheckName := instanceName + "-ConnectionCheck"
+	require.Contains(t, nullResources, connectionCheckName)
+	nullRes, ok := nullResources[connectionCheckName].(*commons.Resource)
 	assert.True(t, ok)
 	require.Len(t, nullRes.Provisioners, 1)
 	mapProv := nullRes.Provisioners[0]
@@ -112,14 +116,15 @@ func testSimpleComputeInstanceWithAddress(t *testing.T, kv *api.KV, srv1 *testut
 	g := googleGenerator{}
 	err := g.generateComputeInstance(context.Background(), kv, cfg, deploymentID, "Compute", "0", 0, &infrastructure, make(map[string]string))
 	require.NoError(t, err, "Unexpected error attempting to generate compute instance for %s", deploymentID)
-
+	resourcePrefix := getResourcesPrefix(cfg, deploymentID)
+	instanceName := resourcePrefix + "compute-0"
 	require.Len(t, infrastructure.Resource["google_compute_instance"], 1, "Expected one compute instance")
 	instancesMap := infrastructure.Resource["google_compute_instance"].(map[string]interface{})
 	require.Len(t, instancesMap, 1)
-	require.Contains(t, instancesMap, "compute-0")
+	require.Contains(t, instancesMap, instanceName)
 
-	compute, ok := instancesMap["compute-0"].(*ComputeInstance)
-	require.True(t, ok, "compute-0 is not a ComputeInstance")
+	compute, ok := instancesMap[instanceName].(*ComputeInstance)
+	require.True(t, ok, "%s is not a ComputeInstance", instanceName)
 	assert.Equal(t, "n1-standard-1", compute.MachineType)
 	assert.Equal(t, "europe-west1-b", compute.Zone)
 	require.NotNil(t, compute.BootDisk, 1, "Expected boot disk")
@@ -145,13 +150,15 @@ func testSimpleComputeInstanceWithPersistentDisk(t *testing.T, kv *api.KV, srv1 
 	err := g.generateComputeInstance(context.Background(), kv, cfg, deploymentID, "Compute", "0", 0, &infrastructure, outputs)
 	require.NoError(t, err, "Unexpected error attempting to generate compute instance for %s", deploymentID)
 
+	resourcePrefix := getResourcesPrefix(cfg, deploymentID)
+	instanceName := resourcePrefix + "compute-0"
 	require.Len(t, infrastructure.Resource["google_compute_instance"], 1, "Expected one compute instance")
 	instancesMap := infrastructure.Resource["google_compute_instance"].(map[string]interface{})
 	require.Len(t, instancesMap, 1)
-	require.Contains(t, instancesMap, "compute-0")
+	require.Contains(t, instancesMap, instanceName)
 
-	compute, ok := instancesMap["compute-0"].(*ComputeInstance)
-	require.True(t, ok, "compute-0 is not a ComputeInstance")
+	compute, ok := instancesMap[instanceName].(*ComputeInstance)
+	require.True(t, ok, "%s is not a ComputeInstance", instanceName)
 	assert.Equal(t, "n1-standard-1", compute.MachineType)
 	assert.Equal(t, "europe-west1-b", compute.Zone)
 	require.NotNil(t, compute.BootDisk, 1, "Expected boot disk")
@@ -161,23 +168,27 @@ func testSimpleComputeInstanceWithPersistentDisk(t *testing.T, kv *api.KV, srv1 
 	instancesMap = infrastructure.Resource["google_compute_attached_disk"].(map[string]interface{})
 	require.Len(t, instancesMap, 1)
 
-	require.Contains(t, instancesMap, "google-bs1-0-to-compute-0")
-	attachedDisk, ok := instancesMap["google-bs1-0-to-compute-0"].(*ComputeAttachedDisk)
-	require.True(t, ok, "google-bs1-0-to-compute-0 is not a ComputeAttachedDisk")
+	attachmentName := fmt.Sprintf("%sbs1-0-to-compute-0", resourcePrefix)
+	attachmentResourceName := fmt.Sprintf("google-%s", attachmentName)
+	require.Contains(t, instancesMap, attachmentResourceName)
+	attachedDisk, ok := instancesMap[attachmentResourceName].(*ComputeAttachedDisk)
+	require.True(t, ok, "%s is not a ComputeAttachedDisk", attachmentResourceName)
 	assert.Equal(t, "my_vol_id", attachedDisk.Disk)
-	assert.Equal(t, "${google_compute_instance.compute-0.name}", attachedDisk.Instance)
+	assert.Equal(t, fmt.Sprintf("${google_compute_instance.%s.name}", instanceName), attachedDisk.Instance)
 	assert.Equal(t, "europe-west1-b", attachedDisk.Zone)
-	assert.Equal(t, "bs1-0-to-compute-0", attachedDisk.DeviceName)
+	assert.Equal(t, attachmentName, attachedDisk.DeviceName)
 	assert.Equal(t, "READ_ONLY", attachedDisk.Mode)
 
 	require.Contains(t, infrastructure.Resource, "null_resource")
 	require.Len(t, infrastructure.Resource["null_resource"], 4)
 
+	deviceAttribute := "file:" + attachmentResourceName
+
 	require.Len(t, outputs, 3, "three outputs are expected")
 	require.Contains(t, outputs, path.Join(consulutil.DeploymentKVPrefix, deploymentID+"/topology/instances/", "BS1", "0", "attributes/device"), "expected instances attribute output")
 	require.Contains(t, outputs, path.Join(consulutil.DeploymentKVPrefix, deploymentID+"/topology/relationship_instances/", "Compute", "0", "0", "attributes/device"), "expected relationship attribute output for Compute")
 	require.Contains(t, outputs, path.Join(consulutil.DeploymentKVPrefix, deploymentID+"/topology/relationship_instances/", "BS1", "0", "0", "attributes/device"), "expected relationship attribute output for Block storage")
-	require.Equal(t, "file:google-bs1-0-to-compute-0", outputs[path.Join(consulutil.DeploymentKVPrefix, deploymentID+"/topology/instances/", "BS1", "0", "attributes/device")], "output file value expected")
-	require.Equal(t, "file:google-bs1-0-to-compute-0", outputs[path.Join(consulutil.DeploymentKVPrefix, deploymentID+"/topology/relationship_instances/", "Compute", "0", "0", "attributes/device")], "output file value expected")
-	require.Equal(t, "file:google-bs1-0-to-compute-0", outputs[path.Join(consulutil.DeploymentKVPrefix, deploymentID+"/topology/relationship_instances/", "BS1", "0", "0", "attributes/device")], "output file value expected")
+	require.Equal(t, deviceAttribute, outputs[path.Join(consulutil.DeploymentKVPrefix, deploymentID+"/topology/instances/", "BS1", "0", "attributes/device")], "output file value expected")
+	require.Equal(t, deviceAttribute, outputs[path.Join(consulutil.DeploymentKVPrefix, deploymentID+"/topology/relationship_instances/", "Compute", "0", "0", "attributes/device")], "output file value expected")
+	require.Equal(t, deviceAttribute, outputs[path.Join(consulutil.DeploymentKVPrefix, deploymentID+"/topology/relationship_instances/", "BS1", "0", "0", "attributes/device")], "output file value expected")
 }

--- a/prov/terraform/google/persistent_disk.go
+++ b/prov/terraform/google/persistent_disk.go
@@ -17,6 +17,9 @@ package google
 import (
 	"context"
 	"fmt"
+	"path"
+	"strings"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/pkg/errors"
 	"github.com/ystia/yorc/config"
@@ -25,8 +28,6 @@ import (
 	"github.com/ystia/yorc/helper/sizeutil"
 	"github.com/ystia/yorc/log"
 	"github.com/ystia/yorc/prov/terraform/commons"
-	"path"
-	"strings"
 )
 
 func (g *googleGenerator) generatePersistentDisk(ctx context.Context, kv *api.KV,
@@ -112,7 +113,7 @@ func (g *googleGenerator) generatePersistentDisk(ctx context.Context, kv *api.KV
 		}
 	}
 
-	name := strings.ToLower(cfg.ResourcesPrefix + nodeName + "-" + instanceName)
+	name := strings.ToLower(getResourcesPrefix(cfg, deploymentID) + nodeName + "-" + instanceName)
 	persistentDisk.Name = strings.Replace(name, "_", "-", -1)
 
 	// Add google persistent disk resource if not any volume ID is provided

--- a/prov/terraform/google/utils.go
+++ b/prov/terraform/google/utils.go
@@ -1,0 +1,27 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"crypto/sha1"
+	"fmt"
+
+	"github.com/ystia/yorc/config"
+)
+
+func getResourcesPrefix(cfg config.Configuration, deploymentID string) string {
+	b := sha1.Sum([]byte(deploymentID))
+	return fmt.Sprintf("%s%x-", cfg.ResourcesPrefix, b[0:3])
+}


### PR DESCRIPTION
# Pull Request description

## Description of the change

First 3 bytes of the sha1 sum of the deployment ID
displayed as an hexadecimal string

### How to verify it

Import this topology:

```yaml
tosca_definitions_version: alien_dsl_2_0_0

metadata:
  template_name: SimpleApp
  template_version: 0.1.0-SNAPSHOT
  template_author: admin

description: ""

imports:
  - tosca-normative-types:1.0.0-ALIEN20
  - alien-extended-storage-types:2.1.0-SM6

topology_template:
  node_templates:
    Compute:
      metadata:
        a4c_edit_x: 262
        a4c_edit_y: "-75"
      type: tosca.nodes.Compute
      requirements:
        - networkNetworkConnection:
            type_requirement: network
            node: Network
            capability: tosca.capabilities.Connectivity
            relationship: tosca.relationships.Network
      capabilities:
        os:
          properties:
            type: linux
        scalable:
          properties:
            min_instances: 1
            max_instances: 1
            default_instances: 1
        endpoint:
          properties:
            secure: true
            protocol: tcp
            network_name: PRIVATE
            initiator: source
    BlockStorage:
      type: tosca.nodes.BlockStorage
      properties:
        size: "1 GB"
        device: "/dev/vdb"
      requirements:
        - attachToComputeAttach:
            type_requirement: attachment
            node: Compute
            capability: tosca.capabilities.Attachment
            relationship: tosca.relationships.AttachTo
    LinuxFileSystem:
      type: alien.nodes.LinuxFileSystem
      properties:
        fs_type: ext4
        location: "/home/centos/fspart"
      requirements:
        - hostedOnComputeHost:
            type_requirement: host
            node: Compute
            capability: tosca.capabilities.Container
            relationship: tosca.relationships.HostedOn
        - linuxPartitionBlockStorageFeature:
            type_requirement: partition
            node: BlockStorage
            capability: tosca.capabilities.Node
            relationship: alien.relationships.LinuxPartition
    Network:
      metadata:
        a4c_edit_x: 304
        a4c_edit_y: "-114"
      type: tosca.nodes.Network
      properties:
        ip_version: 4

```

Configure a GCP location with:

* A `yorc.nodes.google.Compute`:
  * image_project: `centos-cloud`
  * image_family: `centos-7`
  * machine_type: `n1-standard-1`
  * zone: `europe-west1-b`
  * metadata: `ssh-keys=centos:ssh-ed25519 <your_public_key>`
  * credentials: 
    * user: `centos`
    * keys:
       * 0: `<Path to ssh key>`
* A `yorc.nodes.google.PublicNetwork`
  * region: `europe-west1`
* A `yorc.nodes.google.PersistentDisk`:
  * zone: `europe-west1-b`
  * deletable: `true`

Create an application based on the above topology template.
Create a second environment on this application.
Deploy both environments. 
You should not encounter duplication issues.
If you go through the GCP console you should notice that computes, blockstorages, and addresses are prefixed with 6 hexa-characters 

### Description for the changelog

* Generate unique names for GCP resources ([GH-177](https://github.com/ystia/yorc/issues/177))

## Applicable Issues

Fixes #177