### PR TITLE
Added attribute public_ip_address on Hosts in Pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### BUG FIXES
 
 * Generate unique names for GCP resources ([GH-177](https://github.com/ystia/yorc/issues/177))
+* Need a HOST public_ip_address attribute on Hosts Pool compute nodes ([GH-199](https://github.com/ystia/yorc/issues/199))
 
 ## 3.1.0-M5 (October 26, 2018)
 

--- a/prov/hostspool/executor.go
+++ b/prov/hostspool/executor.go
@@ -190,7 +190,16 @@ func (e *defaultExecutor) hostsPoolCreate(originalCtx context.Context, cc *api.C
 			if err != nil {
 				return err
 			}
+
+			// For compatibility with components referencing a host public_ip_address,
+			// defining an attribute public_ip_address as well
+			err = deployments.SetInstanceAttribute(deploymentID, nodeName, instance, "public_ip_address", publicAddress)
+			if err != nil {
+				return err
+			}
+
 		}
+
 		if host.Connection.Port != 0 {
 			err = deployments.SetInstanceCapabilityAttribute(deploymentID, nodeName, instance, "endpoint", "port", strconv.FormatUint(host.Connection.Port, 10))
 			if err != nil {


### PR DESCRIPTION
# Pull Request description

## Description of the change

Compute nodes in a Hosts Pool have an attribute public_address as specified by TOSCA.
But several components in the Ystia Forge and Alien4Cloud CSAR public library expect to find a Compute Node attribute public_ip_address.

### What I did

Added an attribute public_ip_address when the attribute public_address is defined.

## Applicable Issues

https://github.com/ystia/yorc/issues/199
