### PR TITLE
Bugfix/gh 214 no ouptut properties gke services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* No output properties for services on GKE ([GH-214](https://github.com/ystia/yorc/issues/214))
+
 ## 3.1.0-M7 (December 07, 2018)
 
 ### DEPENDENCIES

--- a/prov/kubernetes/execution.go
+++ b/prov/kubernetes/execution.go
@@ -368,6 +368,10 @@ func (e *execution) manageServiceResource(ctx context.Context, clientset kuberne
 				if err != nil {
 					return errors.Wrap(err, "Failed to set attribute")
 				}
+				err = deployments.SetAttributeForAllInstances(e.kv, e.deploymentID, e.nodeName, "node_port", strconv.Itoa(int(val.NodePort)))
+				if err != nil {
+					return errors.Wrap(err, "Failed to set attribute")
+				}
 			}
 		}
 	case k8sDeleteOperation:


### PR DESCRIPTION
# Pull Request description

## Description of the change
Make output properties of services visible alien4cloud for services deployed on a kubernetes hosted by GKE

### What I did
Set "node_port" attribute that was not set before

### How I did it
I just make a call of function setAttributeForAllInstances

### How to verify it
Deploy any app on GKE that have a service, for example simple appache, and check in alien "info" of "manage current deployment" tab that "node_port" output propertie is set and is no longer "N/A"

### Description for the changelog

## Applicable Issues
Bug https://github.com/ystia/yorc/issues/214