### PR TITLE
Publish workflow events when custom workflow is finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### BUG FIXES
 
 * Bootstrap of HA setup fails on GCP, at step configuring the NFS Client component [GH-218](https://github.com/ystia/yorc/issues/218))
+* Publish workflow events when custom workflow is finished [GH-234](https://github.com/ystia/yorc/issues/234))
 
 ## 3.1.0-M7 (December 07, 2018)
 


### PR DESCRIPTION
# Pull Request description

Publish worflow events when a custom workflow is done/failed

## Description of the change

### How to verify it
Execute a custom workflow and check Alien receives the workflowMonitor succeeded/failed event from Yorc. This must allows displaying notification toaster in Alien UI


## Applicable Issues
fixes #234 