### PR TITLE
Downloading terraform plugins for local yorc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@
 
 ### BUG FIXES
 
-* Bootstrap of HA setup fails on GCP, at step configuring the NFS Client component [GH-218](https://github.com/ystia/yorc/issues/218))
-* Publish workflow events when custom workflow is finished [GH-234](https://github.com/ystia/yorc/issues/234))
+* CUDA_VISIBLE_DEVICES contains some unwanted unprintable characters ([GH-210](https://github.com/ystia/yorc/issues/210))
 * No output properties for services on GKE ([GH-214](https://github.com/ystia/yorc/issues/214))
 * K8S service IP missing in runtime view when deploying on GKE ([GH-215](https://github.com/ystia/yorc/issues/215))
+* Bootstrap of HA setup fails on GCP, at step configuring the NFS Client component ([GH-218](https://github.com/ystia/yorc/issues/218))
 * Fix issue when default yorc.pem is used by Ansible with ssh-agent ([GH-233](https://github.com/ystia/yorc/issues/233))
-
-* CUDA_VISIBLE_DEVICES contains some unwanted unprintable characters [GH-210](https://github.com/ystia/yorc/issues/210))
+* Publish workflow events when custom workflow is finished ([GH-234](https://github.com/ystia/yorc/issues/234))
+* Bootstrap without internet access fails to get terraform plugins for local yorc ([GH-239](https://github.com/ystia/yorc/issues/239))
 
 ## 3.1.0-M7 (December 07, 2018)
 

--- a/commands/bootstrap/setup.go
+++ b/commands/bootstrap/setup.go
@@ -74,6 +74,9 @@ func setupYorcServer(workingDirectoryPath string) error {
 		ResourcesPrefix:  "bootstrap-",
 		WorkersNumber:    inputValues.Yorc.WorkersNumber,
 		Infrastructures:  inputValues.Infrastructures,
+		Terraform: config.Terraform{
+			PluginsDir: workDirAbsolutePath,
+		},
 		Ansible: config.Ansible{
 			DebugExec:            true,
 			KeepGeneratedRecipes: true,
@@ -330,6 +333,11 @@ func installDependencies(workingDirectoryPath string) error {
 	}
 
 	// Donwload Terraform plugins
+	for _, url := range inputValues.Terraform.PluginURLs {
+		if err := downloadUnzip(url, workingDirectoryPath); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

To manage the case where the bootstrap is done offline, the bootstrap process should take care of downloading terraform plugins and configure the local yorc with a plugins dir where it can find these plugins, else the local yorc will attempt to download terrafrom plugins from the terrafrom public site.

### How to verify it

Boostrap a yorc, specifying internal download URLs for Terraform plugins.
Check that bootstrap logs describe these plugins are downloaded to the local working directory 

### Description for the changelog

Bootstrap without internet access fails to get terraform plugins for local yorc ([GH-239](https://github.com/ystia/yorc/issues/239))

## Applicable Issues

Fixes #239 
