### PR TITLE
Increase default workers number per Yorc server from 3 to 30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### ENHANCEMENTS
+
+* Increase default workers number per Yorc server from `3` to `30` ([GH-244](https://github.com/ystia/yorc/issues/244))
+
 ## 3.1.0-RC2 (December 18, 2018)
 
 ### DEPENDENCIES

--- a/config/config.go
+++ b/config/config.go
@@ -33,7 +33,7 @@ import (
 const DefaultConsulPubMaxRoutines int = 500
 
 // DefaultWorkersNumber is the default number of workers in the Yorc server
-const DefaultWorkersNumber int = 3
+const DefaultWorkersNumber int = 30
 
 // DefaultHTTPPort is the default port number for the HTTP REST API
 const DefaultHTTPPort int = 8800

--- a/doc/bootstrap.rst
+++ b/doc/bootstrap.rst
@@ -203,7 +203,7 @@ The following ``yorc bootstrap`` option are available:
   * ``--yorc_plugin_download_url`` Yorc plugin download URL (default, current Yorc plugin release under https://github.com/ystia/yorc-a4c-plugin/releases)
   * ``--yorc_port`` Yorc HTTP REST API port (default 8800)
   * ``--yorc_private_key_file`` Path to ssh private key accessible locally
-  * ``--yorc_workers_number`` Number of Yorc workers handling bootstrap deployment tasks (default 3)
+  * ``--yorc_workers_number`` Number of Yorc workers handling bootstrap deployment tasks (default 30)
 
 In addition, similarly to the configuration of infrastructures in ``yorc server``
 command described at :ref:`_infrastructures_configuration_section`, you can use options to

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -171,7 +171,7 @@ Globals Command-line options
 
 .. _option_workers_cmd:
 
-  * ``--workers_number``: Yorc instances use a pool of workers to handle deployment tasks. This option defines the size of this pool. If not set the default value of `3` will be used.
+  * ``--workers_number``: Yorc instances use a pool of workers to handle deployment tasks. This option defines the size of this pool. If not set the default value of `30` will be used.
 
 .. _option_workdir_cmd: 
 

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -84,7 +84,7 @@ func (w *worker) Start() {
 
 			case <-w.shutdownCh:
 				// we have received a signal to stop
-				log.Printf("Worker received shutdown signal. Exiting...")
+				log.Debugln("Worker received shutdown signal. Exiting...")
 				return
 			}
 		}

--- a/testdata/infra/config/yorc.config.json.tpl
+++ b/testdata/infra/config/yorc.config.json.tpl
@@ -1,6 +1,6 @@
 {
     "working_directory": "work",
-    "workers_number": 3,
+    "workers_number": 30,
     "server_id": "${server_id}",
     "resources_prefix": "${prefix}",
     "infrastructures":{


### PR DESCRIPTION
# Pull Request description

## Description of the change

Increase default workers number per Yorc server from `3` to `30` 

### Description for the changelog

* Increase default workers number per Yorc server from `3` to `30` ([GH-244](https://github.com/ystia/yorc/issues/244))

## Applicable Issues

Resolves #244 