### PR TITLE
Bugfix/gh 247 bootstrap url to long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Yorc bootstrap fails if downloadable URLs are too long ([GH-247](https://github.com/ystia/yorc/issues/247))
+
 ### ENHANCEMENTS
 
 * Increase default workers number per Yorc server from `3` to `30` ([GH-244](https://github.com/ystia/yorc/issues/244))

--- a/commands/bootstrap/deployment.go
+++ b/commands/bootstrap/deployment.go
@@ -32,14 +32,14 @@ func deployTopology(workdDir, deploymentDir string) (string, error) {
 	// Download Alien4Cloud whose zip is expected to be provided in the
 	// deployment
 	// First downloading it in the work dir if not yet there
-	// like other extenrla downloadable dependencies
-	url := inputValues.Alien4cloud.DownloadURL
-	if _, err := download(url, workdDir); err != nil {
+	// like other external downloadable dependencies
+	a4cFilePath, err := download(inputValues.Alien4cloud.DownloadURL, "alien4cloud-dist.tar.gz", workdDir)
+	if err != nil {
 		return "", err
 	}
 
 	// Copying this file now to the deployment dir
-	_, filename := filepath.Split(url)
+	_, filename := filepath.Split(a4cFilePath)
 	srcPath := filepath.Join(workdDir, filename)
 	dstPath := filepath.Join(deploymentDir, filename)
 	src, err := os.Open(srcPath)
@@ -78,7 +78,7 @@ func deployTopology(workdDir, deploymentDir string) (string, error) {
 	return deploymentID, err
 }
 
-// followDeployment follows deployments steps or deploymnet logs
+// followDeployment follows deployments steps or deployment logs
 // until the deployment is finished
 func followDeployment(deploymentID, followType string) error {
 

--- a/commands/bootstrap/setup.go
+++ b/commands/bootstrap/setup.go
@@ -323,18 +323,18 @@ func installDependencies(workingDirectoryPath string) error {
 	}
 
 	// Download Consul
-	if err := downloadUnzip(inputValues.Consul.DownloadURL, workingDirectoryPath); err != nil {
+	if err := downloadUnzip(inputValues.Consul.DownloadURL, "consul.zip", workingDirectoryPath); err != nil {
 		return err
 	}
 
 	// Download Terraform
-	if err := downloadUnzip(inputValues.Terraform.DownloadURL, workingDirectoryPath); err != nil {
+	if err := downloadUnzip(inputValues.Terraform.DownloadURL, "terraform.zip", workingDirectoryPath); err != nil {
 		return err
 	}
 
 	// Donwload Terraform plugins
-	for _, url := range inputValues.Terraform.PluginURLs {
-		if err := downloadUnzip(url, workingDirectoryPath); err != nil {
+	for i, url := range inputValues.Terraform.PluginURLs {
+		if err := downloadUnzip(url, fmt.Sprintf("terraform-plugin-%d.zip", i), workingDirectoryPath); err != nil {
 			return err
 		}
 	}
@@ -349,8 +349,8 @@ func getFilePath(url, destinationPath string) string {
 }
 
 // downloadUnzip donwloads and unzips a URL to a given destination
-func downloadUnzip(url, destinationPath string) error {
-	filePath, err := download(url, destinationPath)
+func downloadUnzip(url, fileName, destinationPath string) error {
+	filePath, err := download(url, fileName, destinationPath)
 	if err != nil {
 		return err
 	}
@@ -365,9 +365,9 @@ func downloadUnzip(url, destinationPath string) error {
 
 // download donwloads and optionally unzips a URL to a given destination
 // returns the path to destination file
-func download(url, destinationPath string) (string, error) {
+func download(url, fileName, destinationPath string) (string, error) {
 
-	filePath := getFilePath(url, destinationPath)
+	filePath := filepath.Join(destinationPath, fileName)
 
 	fmt.Println("Downloading", url, "to", filePath)
 


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Define fixed filenames for downloads (no more computed from the URL)

### How to verify it

### Description for the changelog

* Yorc bootstrap fails if downloadable URLs are too long ([GH-247](https://github.com/ystia/yorc/issues/247))

## Applicable Issues

fixes #247 