### PR TITLE
Cleanup scaled down nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### BUG FIXES
 
+* When scaling down instances are not cleaned from consul ([GH-257](https://github.com/ystia/yorc/issues/257))
 * Yorc bootstrap fails if downloadable URLs are too long ([GH-247](https://github.com/ystia/yorc/issues/247))
 
 ### ENHANCEMENTS


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Reintroduce a cleanup function removed by mistake.

### How to verify it

1. Deploy a topo with a scalable compute
2. Scale down
3. check that nodes are deleted using `yorc d info <depID>`

### Description for the changelog

* When scaling down instances are not cleaned from consul ([GH-257](https://github.com/ystia/yorc/issues/257))

## Applicable Issues

Fixes #257 
