### PR TITLE
Bugfix/GH 245 - K8S jobs namespace should not be removed if its provided 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * When scaling down instances are not cleaned from consul ([GH-257](https://github.com/ystia/yorc/issues/257))
 * Yorc bootstrap fails if downloadable URLs are too long ([GH-247](https://github.com/ystia/yorc/issues/247))
+* K8S jobs namespace should not be removed if its provided ([GH-245](https://github.com/ystia/yorc/issues/245))
 
 ### ENHANCEMENTS
 

--- a/prov/kubernetes/monitoring_job.go
+++ b/prov/kubernetes/monitoring_job.go
@@ -53,8 +53,8 @@ func (o *actionOperator) ExecAction(ctx context.Context, cfg config.Configuratio
 	}
 	// Check if namespace was provided
 	var namespaceProvided bool
-	namespaceProvidedStr, ok := action.Data["providedNamespace"]
-	if b, err := strconv.ParseBool(namespaceProvidedStr); ok && err != nil {
+	namespaceProvidedStr, ok := action.Data["namespaceProvided"]
+	if b, err := strconv.ParseBool(namespaceProvidedStr); ok && err == nil {
 		namespaceProvided = b
 	}
 

--- a/prov/kubernetes/monitoring_job.go
+++ b/prov/kubernetes/monitoring_job.go
@@ -54,7 +54,11 @@ func (o *actionOperator) ExecAction(ctx context.Context, cfg config.Configuratio
 	// Check if namespace was provided
 	var namespaceProvided bool
 	namespaceProvidedStr, ok := action.Data["namespaceProvided"]
-	if b, err := strconv.ParseBool(namespaceProvidedStr); ok && err == nil {
+	if ok {
+		b, err := strconv.ParseBool(namespaceProvidedStr);
+		if err != nil{
+			return true, errors.New(`unable to transform namespaceProvided value to boolean`)
+		} 
 		namespaceProvided = b
 	}
 


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did
Make yorc not remove namespace when it is provided

### How I did it
I change a wrong condition and key for a map

### How to verify it
Deploy 2 K8s job apps : 

1. one  setting the meta property "K8S_NAMESPACE" to an existing namespace on the cluster (default for example)
2. the other app not setting this meta property

Check that in case 1, it does not remove or try to remove the namespace where the job is executed ; and in case 2 that it delete the namespace once the job is finished.

### Description for the changelog

## Applicable Issues
https://github.com/ystia/yorc/issues/245