### PR TITLE
Updated yorc and plugin default download URLs

### DIFF
--- a/commands/bootstrap/inputs.go
+++ b/commands/bootstrap/inputs.go
@@ -1065,12 +1065,12 @@ func getYorcDownloadURL() string {
 	var downloadURL string
 	if strings.Contains(yorcVersion, "SNAPSHOT") {
 		downloadURL = fmt.Sprintf(
-			"https://dl.bintray.com/ystia/yorc-engine/snapshots/develop/yorc-%s.tgz",
+			"https://ystia.jfrog.io/ystia/binaries/ystia/yorc/dist/develop/yorc-%s.tgz",
 			yorcVersion)
 	} else {
 		downloadURL = fmt.Sprintf(
-			"https://github.com/ystia/yorc/releases/download/v%s/yorc-%s.tgz",
-			yorcVersion, yorcVersion)
+			"https://dl.bintray.com/ystia/yorc-engine/releases/yorc-%s.tgz",
+			yorcVersion)
 	}
 	return downloadURL
 }
@@ -1081,12 +1081,12 @@ func getYorcPluginDownloadURL() string {
 	var downloadURL string
 	if strings.Contains(yorcVersion, "SNAPSHOT") {
 		downloadURL = fmt.Sprintf(
-			"https://dl.bintray.com/ystia/yorc-a4c-plugin/snapshots/develop/alien4cloud-yorc-plugin-%s.zip",
+			"https://ystia.jfrog.io/ystia/binaries/ystia/yorc-a4c-plugin/dist/develop/alien4cloud-yorc-plugin-%s.zip",
 			yorcVersion)
 	} else {
 		downloadURL = fmt.Sprintf(
-			"https://github.com/ystia/yorc-a4c-plugin/releases/download/v%s/alien4cloud-yorc-plugin-%s.zip",
-			yorcVersion, yorcVersion)
+			"https://dl.bintray.com/ystia/yorc-a4c-plugin/releases/alien4cloud-yorc-plugin-%s.zip",
+			yorcVersion)
 	}
 	return downloadURL
 }


### PR DESCRIPTION
# Pull Request description

## Description of the change

Changed default bootstrap values for yorc/plugin download URLs now that releases moved to BinTray and development artifacts to Artifactory

### How to verify it

Download yorc binary from https://ystia.jfrog.io/ystia/yorc-bin-dev-local/ystia/yorc/dist/feature/GH-272-bootstrap-artifactory/yorc-3.2.0-SNAPSHOT.tgz

Then bootstrap a full stack deployment using default values for Yorc and Yorc plugin download URLs

## Applicable Issues

https://github.com/ystia/yorc/issues/272