### PR TITLE
Bugfix/gh 287 custom command interface missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### BUG FIXES
 
 * Deployment with a topology parsing error remains in initial status ([GH-283](https://github.com/ystia/yorc/issues/283)
+* Interface name is not retrieved from custom command Rest request ([GH-287](https://github.com/ystia/yorc/issues/287)
 
 ## 3.2.0-M1 (January 28, 2019)
 

--- a/commands/deployments/dep_custom.go
+++ b/commands/deployments/dep_custom.go
@@ -34,6 +34,7 @@ func init() {
 	var jsonParam string
 	var nodeName string
 	var customCName string
+	var interfaceName string
 	var inputs []string
 	var customCmd = &cobra.Command{
 		Use:   "custom <id>",
@@ -46,14 +47,15 @@ func init() {
 			if err != nil {
 				httputil.ErrExit(err)
 			}
-			if len(jsonParam) == 0 && len(nodeName) == 0 {
-				return errors.Errorf("You need to provide a JSON or complete the arguments")
+			if len(jsonParam) == 0 && (len(nodeName) == 0 || len(interfaceName) == 0 || len(customCName) == 0) {
+				return errors.Errorf("You need to provide a JSON or complete the mandatory flags (\"custom\", \"node\", \"interface\")")
 			}
 
 			if len(jsonParam) == 0 && len(nodeName) != 0 && len(customCName) != 0 {
 				var InputsStruct rest.CustomCommandRequest
 				InputsStruct.CustomCommandName = customCName
 				InputsStruct.NodeName = nodeName
+				InputsStruct.InterfaceName = interfaceName
 				InputsStruct.Inputs = make(map[string]*tosca.ValueAssignment)
 				for _, arg := range inputs {
 					keyValue := strings.Split(arg, "=")
@@ -90,9 +92,10 @@ func init() {
 			return nil
 		},
 	}
-	customCmd.PersistentFlags().StringVarP(&jsonParam, "data", "d", "", "Need to provide the JSON format of the custom command")
-	customCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Provide the node name (use with flag custom and input)")
-	customCmd.PersistentFlags().StringVarP(&customCName, "custom", "", "", "Provide the custom command name (use with flag node and input)")
-	customCmd.PersistentFlags().StringArrayVarP(&inputs, "input", "i", make([]string, 0), "Provide the input for the custom command (use with flag custom and node)")
+	customCmd.PersistentFlags().StringVarP(&jsonParam, "data", "d", "", "Provide the JSON format of the custom command with node, interface, custom and inputs data")
+	customCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Provide the node name (mandatory)")
+	customCmd.PersistentFlags().StringVarP(&interfaceName, "interface", "", "", "Provide the interface name (mandatory)")
+	customCmd.PersistentFlags().StringVarP(&customCName, "custom", "", "", "Provide the custom command name (mandatory)")
+	customCmd.PersistentFlags().StringArrayVarP(&inputs, "input", "i", make([]string, 0), "Provide the input for the custom command")
 	DeploymentsCmd.AddCommand(customCmd)
 }

--- a/commands/deployments/dep_custom.go
+++ b/commands/deployments/dep_custom.go
@@ -91,8 +91,8 @@ func init() {
 		},
 	}
 	customCmd.PersistentFlags().StringVarP(&jsonParam, "data", "d", "", "Need to provide the JSON format of the custom command")
-	customCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Provide the node name (use with flag c and i)")
-	customCmd.PersistentFlags().StringVarP(&customCName, "custom", "", "", "Provide the custom command name (use with flag n and i)")
-	customCmd.PersistentFlags().StringArrayVarP(&inputs, "input", "i", make([]string, 0), "Provide the input for the custom command (use with flag c and n)")
+	customCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Provide the node name (use with flag custom and input)")
+	customCmd.PersistentFlags().StringVarP(&customCName, "custom", "", "", "Provide the custom command name (use with flag node and input)")
+	customCmd.PersistentFlags().StringArrayVarP(&inputs, "input", "i", make([]string, 0), "Provide the input for the custom command (use with flag custom and node)")
 	DeploymentsCmd.AddCommand(customCmd)
 }

--- a/commands/deployments/dep_custom.go
+++ b/commands/deployments/dep_custom.go
@@ -92,7 +92,7 @@ func init() {
 	}
 	customCmd.PersistentFlags().StringVarP(&jsonParam, "data", "d", "", "Need to provide the JSON format of the custom command")
 	customCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Provide the node name (use with flag c and i)")
-	customCmd.PersistentFlags().StringVarP(&customCName, "custom", "c", "", "Provide the custom command name (use with flag n and i)")
+	customCmd.PersistentFlags().StringVarP(&customCName, "custom", "", "", "Provide the custom command name (use with flag n and i)")
 	customCmd.PersistentFlags().StringArrayVarP(&inputs, "input", "i", make([]string, 0), "Provide the input for the custom command (use with flag c and n)")
 	DeploymentsCmd.AddCommand(customCmd)
 }

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -200,22 +200,23 @@ Executes a custom command for a given node of a deployment <DeploymentId>.
      yorc deployments custom <DeploymentId> [flags]
 
 Flags:                                                                                                                                                        
-  * ``-c``, ``--custom``: Provide the custom command name (use with flag n and i)                                                                       
-  * ``-d``, ``--data``: Need to provide the JSON format of the custom command                                                                         
-  * ``-i``, ``--input``: Provide the input for the custom command (use with flag c and n)
-  * ``-n``, ``--node``: Provide the node name (use with flag c and i)
+  * ``--custom``: Provide the custom command name (mandatory)
+  * ``--interface``: Provide the interface name (mandatory)
+  * ``-d``, ``--data``: Provide the JSON format of the custom command with node, interface, custom and inputs data
+  * ``-i``, ``--input``: Provide the input for the custom command
+  * ``-n``, ``--node``: Provide the node name (mandatory)
 
 Example using ``--input`` flags:
 
 .. code-block:: bash
 
-     yorc deployments custom deployID --custom cmdName --node nodeName --input 'key1=["value1","value2"]' --input 'key2="value3"'
+     yorc deployments custom deployID --custom cmdName --interface interfaceName --node nodeName --input 'key1=["value1","value2"]' --input 'key2="value3"'
 
 Example using ``--data`` flag:
 
 .. code-block:: bash
 
-     yorc deployments custom deployID --data '{"name":"cmdName","node":"nodeName","inputs":{"key1":["value1","value2"],"key2":"value3"}}'
+     yorc deployments custom deployID --data '{"name":"cmdName","interface":"interfaceName",""node":"nodeName","inputs":{"key1":["value1","value2"],"key2":"value3"}}'
 
 
 List workflows of a given deployment

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -285,12 +285,8 @@ func (w *worker) runCustomCommand(ctx context.Context, t *taskExecution) error {
 
 	var interfaceName string
 	interfaceName, err = tasks.GetTaskData(kv, t.taskID, "interfaceName")
-	if err != nil && !tasks.IsTaskDataNotFoundError(err) {
+	if err != nil {
 		return errors.Wrap(err, "failed to retrieve custom interface name")
-	}
-	// default interface name is custom
-	if interfaceName == "" {
-		interfaceName = "custom"
 	}
 	nodes, err := tasks.GetTaskRelatedNodes(kv, t.taskID)
 	if err != nil {

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -282,7 +282,15 @@ func (w *worker) runCustomCommand(ctx context.Context, t *taskExecution) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve custom command name")
 	}
-	interfaceNameKv, _, err := kv.Get(path.Join(consulutil.TasksPrefix, t.taskID, "interfaceName"), nil)
+
+	// Interface is optional
+	interfaceName := "custom"
+	interfaceName, err = tasks.GetTaskData(kv, t.taskID, "interfaceName")
+	if err != nil && !tasks.IsTaskDataNotFoundError(err) {
+		return errors.Wrap(err, "failed to retrieve custom interface name")
+	}
+
+	log.Debugf("laaaaaaaaaaaaaaaaaa interfaceName interfaceName%+v", interfaceName)
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve custom command interface name")
 	}
@@ -294,10 +302,6 @@ func (w *worker) runCustomCommand(ctx context.Context, t *taskExecution) error {
 		return errors.Wrapf(err, "expecting custom command to be related to \"1\" node while it is actually related to \"%d\" nodes", len(nodes))
 	}
 	nodeName := nodes[0]
-	interfaceName := "custom"
-	if interfaceNameKv != nil && len(interfaceNameKv.Value) != 0 {
-		interfaceName = string(interfaceNameKv.Value)
-	}
 	nodeType, err := deployments.GetNodeType(w.consulClient.KV(), t.targetID, nodeName)
 	if err != nil {
 		return err

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -289,8 +289,6 @@ func (w *worker) runCustomCommand(ctx context.Context, t *taskExecution) error {
 	if err != nil && !tasks.IsTaskDataNotFoundError(err) {
 		return errors.Wrap(err, "failed to retrieve custom interface name")
 	}
-
-	log.Debugf("laaaaaaaaaaaaaaaaaa interfaceName interfaceName%+v", interfaceName)
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve custom command interface name")
 	}

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -283,14 +283,14 @@ func (w *worker) runCustomCommand(ctx context.Context, t *taskExecution) error {
 		return errors.Wrap(err, "failed to retrieve custom command name")
 	}
 
-	// Interface is optional
-	interfaceName := "custom"
+	var interfaceName string
 	interfaceName, err = tasks.GetTaskData(kv, t.taskID, "interfaceName")
 	if err != nil && !tasks.IsTaskDataNotFoundError(err) {
 		return errors.Wrap(err, "failed to retrieve custom interface name")
 	}
-	if err != nil {
-		return errors.Wrap(err, "failed to retrieve custom command interface name")
+	// default interface name is custom
+	if interfaceName == "" {
+		interfaceName = "custom"
 	}
 	nodes, err := tasks.GetTaskRelatedNodes(kv, t.taskID)
 	if err != nil {


### PR DESCRIPTION
# Pull Request description

## Description of the change
- Retrieve optional interface name from task data
- Remove custom CLI duplicated shorthand "c"

### Description for the changelog

## Applicable Issues
fixes #287 
