### PR TITLE
Backport of GH-293: n purge in parallel - missing targetID error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### BUG FIXES
 
+* Purging n deployment in parallel, one can fail on error: Missing targetId for task with id ([GH-293](https://github.com/ystia/yorc/issues/293))
 * Can't deploy applications using a secured yorc/consul ([GH-274](https://github.com/ystia/yorc/issues/274))
 * Unable to purge an application that appears in the list ([GH-238](https://github.com/ystia/yorc/issues/238))
 * K8S jobs namespace should not be removed if its provided ([GH-245](https://github.com/ystia/yorc/issues/245))

--- a/deployments/deployments.go
+++ b/deployments/deployments.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/ystia/yorc/events"
+	"github.com/ystia/yorc/log"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/pkg/errors"
@@ -136,6 +137,8 @@ RETRY:
 		if !ok {
 			goto RETRY
 		}
+		log.Debugf("Deployment status change for %s from %s to %s",
+			deploymentID, currentStatus.String(), status.String())
 		events.PublishAndLogDeploymentStatusChange(ctx, kv, deploymentID, strings.ToLower(status.String()))
 	}
 	return nil

--- a/tasks/collector/collector.go
+++ b/tasks/collector/collector.go
@@ -16,6 +16,7 @@ package collector
 
 import (
 	"fmt"
+	"github.com/ystia/yorc/log"
 	"path"
 	"strconv"
 	"strings"
@@ -211,5 +212,8 @@ func (c *Collector) prepareForRegistration(operations api.KVTxnOps, taskType tas
 		}
 		return errors.Wrapf(err, "Failed to register task with targetID:%q, taskType:%q due to error:%s", targetID, taskType.String(), strings.Join(errs, ", "))
 	}
+
+	log.Debugf("Registered task %s type %q for target %s\n", taskID, taskType.String(), targetID)
+
 	return nil
 }


### PR DESCRIPTION
# Pull Request description

Backport of pull request https://github.com/ystia/yorc/pull/295 fixing issue https://github.com/ystia/yorc/issues/293 about an error happening intermittently on a purge operation on a deployment, when other purge operations on other deployments are run in parallel.

## Description of the change

Fixing an error when the undeployment-purge of n applications are performed in parrallel.
Intermittently one of these operations failed with this error:
```
 [PANIC] Missing targetId for task with id XXX
```

### What I did

Fixed the code in  function `tasks.TargetHasLivingTasks()`.
This function was first executing a Consul request to get all tasks keys.
Then for each task key, it was executing a request to Consul to get the targetID value of this task, and see if this task was related to our target.

If the targetID did not exist or was empty, the function was failing on error : "Missing targetId for task with id"

But this case can happen and should be expected:
Between the call to get all task keys and the call to get one task target ID, another deployment not related to our target could have been purged.

So replaced this code by a call to an already existing function `GetTasksIdsForTarget()` which returns the list of taskIDs for our target, ignoring other tasks.

Added also some debug logs to ease the debug analysis.

## How to test

Deploy n applications from Alien4Cloud, then undeploy them simultaneously using the REST API as follows:

1/ Login

```bash
$ curl -d "username=$myuser&password=$mypassword&submit=Login"  \
  --url http://$IPAddress:$PORT/login \
  --dump-header headers \
  --cookie-jar cookies.a4c
```
2/ Repeat the following request for all deployed applications:

```bash
$ curl --request DELETE \
 --url http://$IPAddress:$PORT/rest/v1/applications/$appName/environments/$appEnvID/deployment \
 --header 'accept: application/json' --header 'content-type: application/json' \
 --silent \
 --cookie cookies.a4c
```

### Description for the changelog

Purging n deployment in parallel, one can fail on error: Missing targetId for task with id ([GH-293](https://github.com/ystia/yorc/issues/293))

## Applicable Issues

https://github.com/ystia/yorc/issues/293

