### PR TITLE
Bugfix/gh 291 ssh connection killed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Interface name is not retrieved from custom command Rest request ([GH-287](https://github.com/ystia/yorc/issues/287))
 * Instances are adding into topology before creating task ([GH-289](https://github.com/ystia/yorc/issues/289)
 * Missing events for uninstall workflow in purge task ([GH-302](https://github.com/ystia/yorc/issues/302)
+* All ssh connections to Slurm are killed if ssh server has reached the max number of allowed sessions ([GH-291](https://github.com/ystia/yorc/issues/291)
 
 ## 3.2.0-M1 (January 28, 2019)
 

--- a/doc/telemetry.rst
+++ b/doc/telemetry.rst
@@ -164,7 +164,7 @@ Yorc SSH connection pool
 | ``yorc.ssh-connections-pool.<connection_id>.sessions.open-failed`` | This tracks the number of failures when opening an SSH session       | number of            | counter     |
 |                                                                    | (multiplexed on top of an existing connection).                      | failures             |             |
 +--------------------------------------------------------------------+----------------------------------------------------------------------+----------------------+-------------+
-| ``yorc.ssh-connections-pool.<connection_id>.sessions.creation``    | This measures the number of sessions created for a given connection. | number of sessions   | counter     |
+| ``yorc.ssh-connections-pool.<connection_id>.sessions.creations``   | This measures the number of sessions created for a given connection. | number of sessions   | counter     |
 +--------------------------------------------------------------------+----------------------------------------------------------------------+----------------------+-------------+
 | ``yorc.ssh-connections-pool.<connection_id>.sessions.closes``      | This measures the number of sessions closed for a given connection.  | number of sessions   | counter     |
 +--------------------------------------------------------------------+----------------------------------------------------------------------+----------------------+-------------+

--- a/doc/telemetry.rst
+++ b/doc/telemetry.rst
@@ -153,5 +153,25 @@ dashes and <OpName> the TOSCA operation name where dots where replaced by dashes
 +--------------------------------------------------------------------+--------------------------------------------------+---------------------+-------------+
 | ``yorc.executor.<ExecType>.<DepID>.<NodeType>.<OpName>.successes`` | This counts the number of successful executions. | number of successes | counter     |
 +--------------------------------------------------------------------+--------------------------------------------------+---------------------+-------------+
- 
 
+Yorc SSH connection pool
+~~~~~~~~~~~~~~~~~~~~~~~~
+
++--------------------------------------------------------------------+----------------------------------------------------------------------+----------------------+-------------+
+|                            Metric Name                             |                             Description                              |         Unit         | Metric Type |
+|                                                                    |                                                                      |                      |             |
++====================================================================+======================================================================+======================+=============+
+| ``yorc.ssh-connections-pool.<connection_id>.sessions.open-failed`` | This tracks the number of failures when opening an SSH session       | number of            | counter     |
+|                                                                    | (multiplexed on top of an existing connection).                      | failures             |             |
++--------------------------------------------------------------------+----------------------------------------------------------------------+----------------------+-------------+
+| ``yorc.ssh-connections-pool.<connection_id>.sessions.creation``    | This measures the number of sessions created for a given connection. | number of sessions   | counter     |
++--------------------------------------------------------------------+----------------------------------------------------------------------+----------------------+-------------+
+| ``yorc.ssh-connections-pool.<connection_id>.sessions.closes``      | This measures the number of sessions closed for a given connection.  | number of sessions   | counter     |
++--------------------------------------------------------------------+----------------------------------------------------------------------+----------------------+-------------+
+| ``yorc.ssh-connections-pool.<connection_id>.sessions.open``        | This tracks the number of currently open sessions per connection     | number of sessions   | gauge       |
+|                                                                    |                                                                      |                      |             |
++--------------------------------------------------------------------+----------------------------------------------------------------------+----------------------+-------------+
+| ``yorc.ssh-connections-pool.creations.<connection_id>``            | This measures the number of created connections.                     | number of connection | counter     |
++--------------------------------------------------------------------+----------------------------------------------------------------------+----------------------+-------------+
+| ``yorc.ssh-connections-pool.closes.<connection_id>``               | This measures the number of closed connections.                      | number of connection | counter     |
++--------------------------------------------------------------------+----------------------------------------------------------------------+----------------------+-------------+

--- a/helper/metricsutil/metric_key.go
+++ b/helper/metricsutil/metric_key.go
@@ -28,6 +28,8 @@ func CleanupMetricKey(key []string) []string {
 		res[i] = strings.Replace(res[i], "_", "-", -1)
 		res[i] = strings.Replace(res[i], "|", "-", -1)
 		res[i] = strings.Replace(res[i], ":", "-", -1)
+		// " should be banned from keys
+		res[i] = strings.Replace(res[i], "\"", "", -1)
 	}
 	return res
 }

--- a/helper/sshutil/con_test.go
+++ b/helper/sshutil/con_test.go
@@ -1,0 +1,71 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sshutil
+
+// import (
+// 	"context"
+// 	"sync"
+// 	"testing"
+
+// 	"golang.org/x/crypto/ssh"
+
+// 	"github.com/ystia/yorc/log"
+// )
+
+// var sc = &SSHClient{
+// 	Config: &ssh.ClientConfig{
+// 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+// 		User:            "user",
+// 		Auth:            []ssh.AuthMethod{ssh.Password("*pass*")},
+// 	},
+// 	Host: "host",
+// 	Port: 22,
+// }
+
+// func TestConnectionSW(t *testing.T) {
+
+// 	var wg sync.WaitGroup
+// 	for i := 0; i < 55; i++ {
+// 		sw, err := sc.GetSessionWrapper()
+// 		if err != nil {
+// 			t.Errorf("%+v", err)
+// 		}
+// 		wg.Add(1)
+// 		go func() {
+// 			defer wg.Done()
+// 			err := sw.RunCommand(context.Background(), "sleep 6")
+// 			if err != nil {
+// 				t.Errorf("%+v", err)
+// 			}
+// 		}()
+// 	}
+// 	wg.Wait()
+// }
+
+// func TestConnectionDirect(t *testing.T) {
+// 	log.SetDebug(true)
+// 	var wg sync.WaitGroup
+// 	for i := 0; i < 55; i++ {
+// 		wg.Add(1)
+// 		go func() {
+// 			defer wg.Done()
+// 			_, err := sc.RunCommand("sleep 10")
+// 			if err != nil {
+// 				t.Errorf("Err: %+v", err)
+// 			}
+// 		}()
+// 	}
+// 	wg.Wait()
+// }

--- a/helper/sshutil/session_pool.go
+++ b/helper/sshutil/session_pool.go
@@ -146,7 +146,7 @@ func (p *pool) getConn(k, addr string, config *ssh.ClientConfig) *conn {
 	p.tab[k] = c
 	p.mu.Unlock()
 	c.netC, c.c, c.err = p.dial("tcp", addr, config)
-	c.name = fmt.Sprintf("%s-%x", k, c.c.SessionID())
+	c.name = fmt.Sprintf("%s-%s-%x", addr, config.User, c.c.SessionID())
 	metrics.IncrCounter(metricsutil.CleanupMetricKey([]string{"ssh-connections-pool", "creations", c.name}), 1)
 	close(c.ok)
 	return c

--- a/helper/sshutil/session_pool.go
+++ b/helper/sshutil/session_pool.go
@@ -16,19 +16,16 @@ package sshutil
 
 import (
 	"fmt"
-	"golang.org/x/crypto/ssh"
 	"net"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh"
 )
 
 type pool struct {
-	// Timeout for Open (for both new and existing
-	// connections). If Dial is not nil, it is up to the Dial func
-	// to enforce the timeout for new connections.
-	Timeout time.Duration
-
 	tab map[string]*conn
 	mu  sync.Mutex
 }
@@ -37,57 +34,93 @@ type pool struct {
 // an existing connection if possible. If no connection exists,
 // or if opening the session fails, Open attempts to dial a new
 // connection. If dialing fails, Open returns the error from Dial.
-func (p *pool) openSession(client *SSHClient) (*ssh.Session, error) {
-	var deadline, sessionDeadline time.Time
-	if p.Timeout > 0 {
-		now := time.Now()
-		deadline = now.Add(p.Timeout)
-
-		// First time, use a NewSession deadline at half of the
-		// overall timeout, to try to leave time for a subsequent
-		// Dial and NewSession.
-		sessionDeadline = now.Add(p.Timeout / 2)
-	}
-
+func (p *pool) openSession(client *SSHClient) (*sshSession, error) {
 	addr := fmt.Sprintf("%s:%d", client.Host, client.Port)
 	k := getUserKey(addr, client.Config)
 	for {
-		c := p.getConn(k, addr, client.Config, deadline)
+		// The algorithm here is to get a connection by reusing existing if any
+		// Then if we open a session. Sometimes open fails due to too many sessions open
+		// in this case we remove the connection from cache and teardown it (wait for other sessions
+		// to be closed and finally close the underlying connection) on next try a new connection is created.
+		c := p.getConn(k, addr, client.Config)
 		if c.err != nil {
+			// Can't open connection stop here
 			p.removeConn(k, c)
 			return nil, c.err
 		}
-		s, err := c.newSession(sessionDeadline)
+		s, err := c.newSession()
 		if err == nil {
 			return s, nil
 		}
-		sessionDeadline = deadline
+		// can't open session this is probably due to too many session open
+		// remove this connection from cache
 		p.removeConn(k, c)
-		c.c.Close()
-		if p.Timeout > 0 && time.Now().After(deadline) {
-			return nil, err
-		}
+		// Gracefully teardown it wait for all sessions to finish and then close
+		// the connection. Teardown is asynchronous/non-blocking
+		c.teardown()
 	}
+}
+
+type sshSession struct {
+	*ssh.Session
+
+	conn *conn
+}
+
+func (s *sshSession) Close() error {
+	err := s.Session.Close()
+	s.conn.lockSessionsCount.Lock()
+	defer s.conn.lockSessionsCount.Unlock()
+	s.conn.opennedSessions--
+	return errors.Wrap(err, "failed to close ssh session")
 }
 
 type conn struct {
-	netC net.Conn
-	c    *ssh.Client
-	ok   chan bool
-	err  error
+	netC              net.Conn
+	c                 *ssh.Client
+	ok                chan bool
+	err               error
+	lockSessionsCount sync.Mutex
+	opennedSessions   uint
 }
 
-func (c *conn) newSession(deadline time.Time) (*ssh.Session, error) {
-	if !deadline.IsZero() {
-		c.netC.SetDeadline(deadline)
-		defer c.netC.SetDeadline(time.Time{})
+// closes the ssh client
+func (c *conn) close() {
+	c.c.Close()
+}
+
+// asynchronously wait for all openned sessions to finish and then close the connection.
+// Actually it closes the ssh client which in turn closes the network connection.
+func (c *conn) teardown() {
+	go func(c *conn) {
+
+		for {
+			<-time.After(5 * time.Second)
+			c.lockSessionsCount.Lock()
+			if c.opennedSessions == 0 {
+				c.close()
+				c.lockSessionsCount.Unlock()
+				return
+			}
+			c.lockSessionsCount.Unlock()
+		}
+	}(c)
+}
+
+func (c *conn) newSession() (*sshSession, error) {
+	ss, err := c.c.NewSession()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open session")
 	}
-	return c.c.NewSession()
+	c.lockSessionsCount.Lock()
+	defer c.lockSessionsCount.Unlock()
+	c.opennedSessions++
+	return &sshSession{Session: ss, conn: c}, nil
 }
 
 // getConn gets an ssh connection from the pool for key.
 // If none is available, it dials anew.
-func (p *pool) getConn(k, addr string, config *ssh.ClientConfig, deadline time.Time) *conn {
+func (p *pool) getConn(k, addr string, config *ssh.ClientConfig) *conn {
 	p.mu.Lock()
 	if p.tab == nil {
 		p.tab = make(map[string]*conn)
@@ -101,7 +134,7 @@ func (p *pool) getConn(k, addr string, config *ssh.ClientConfig, deadline time.T
 	c = &conn{ok: make(chan bool)}
 	p.tab[k] = c
 	p.mu.Unlock()
-	c.netC, c.c, c.err = p.dial("tcp", addr, config, deadline)
+	c.netC, c.c, c.err = p.dial("tcp", addr, config)
 	close(c.ok)
 	return c
 }
@@ -116,8 +149,8 @@ func (p *pool) removeConn(k string, c1 *conn) {
 	}
 }
 
-func (p *pool) dial(network, addr string, config *ssh.ClientConfig, deadline time.Time) (net.Conn, *ssh.Client, error) {
-	dialer := net.Dialer{Deadline: deadline}
+func (p *pool) dial(network, addr string, config *ssh.ClientConfig) (net.Conn, *ssh.Client, error) {
+	dialer := net.Dialer{}
 	dial := dialer.Dial
 	netC, err := dial(network, addr)
 	if err != nil {

--- a/helper/sshutil/sshutil.go
+++ b/helper/sshutil/sshutil.go
@@ -15,27 +15,27 @@
 package sshutil
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
+	"os/exec"
 	"path"
-
-	"github.com/bramvdbogaerde/go-scp"
+	"path/filepath"
+	"strconv"
 	"strings"
 
-	"bytes"
+	"github.com/bramvdbogaerde/go-scp"
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
-	"github.com/ystia/yorc/helper/executil"
-	"github.com/ystia/yorc/log"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/net/context"
-	"net"
-	"os/exec"
-	"path/filepath"
-	"strconv"
+
+	"github.com/ystia/yorc/helper/executil"
+	"github.com/ystia/yorc/log"
 )
 
 // Client is interface allowing running command
@@ -45,7 +45,7 @@ type Client interface {
 
 // SSHSessionWrapper is a wrapper with a piped SSH session
 type SSHSessionWrapper struct {
-	Session *ssh.Session
+	session *sshSession
 	Stdout  io.Reader
 	Stderr  io.Reader
 }
@@ -72,18 +72,18 @@ var sessionsPool = &pool{}
 func (client *SSHClient) GetSessionWrapper() (*SSHSessionWrapper, error) {
 	var ps = &SSHSessionWrapper{}
 	var err error
-	ps.Session, err = client.newSession()
+	ps.session, err = client.newSession()
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to prepare SSH command")
 	}
 
 	log.Debug("[SSHSession] Add Stderr/Stdout pipelines")
-	ps.Stdout, err = ps.Session.StdoutPipe()
+	ps.Stdout, err = ps.session.StdoutPipe()
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to setup stdout for session")
 	}
 
-	ps.Stderr, err = ps.Session.StderrPipe()
+	ps.Stderr, err = ps.session.StderrPipe()
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to setup stderr for session")
 	}
@@ -97,15 +97,16 @@ func (client *SSHClient) RunCommand(cmd string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "Unable to create new session")
 	}
+	defer session.Close()
 
 	log.Debugf("[SSHSession] cmd: %q", cmd)
 	stdOutErrBytes, err := session.CombinedOutput(cmd)
 	stdOutErrStr := strings.Trim(string(stdOutErrBytes[:]), "\x00")
 	log.Debugf("[SSHSession] stdout/stderr: %q", stdOutErrStr)
-	return stdOutErrStr, err
+	return stdOutErrStr, errors.WithStack(err)
 }
 
-func (client *SSHClient) newSession() (*ssh.Session, error) {
+func (client *SSHClient) newSession() (*sshSession, error) {
 	session, err := sessionsPool.openSession(client)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to create session")
@@ -118,7 +119,7 @@ func (client *SSHClient) newSession() (*ssh.Session, error) {
 func (sw *SSHSessionWrapper) RunCommand(ctx context.Context, cmd string) error {
 	chClosed := make(chan struct{})
 	defer func() {
-		sw.Session.Close()
+		sw.session.Close()
 		close(chClosed)
 	}()
 	log.Debugf("[SSHSession] running command: %q", cmd)
@@ -126,16 +127,15 @@ func (sw *SSHSessionWrapper) RunCommand(ctx context.Context, cmd string) error {
 		select {
 		case <-ctx.Done():
 			log.Debug("[SSHSession] Cancellation has been sent: a sigkill signal is sent to remote process")
-			sw.Session.Signal(ssh.SIGKILL)
-			sw.Session.Close()
+			sw.session.Signal(ssh.SIGKILL)
+			sw.session.Close()
 			return
 		case <-chClosed:
 			return
 		}
 	}()
 
-	err := sw.Session.Run(cmd)
-	return err
+	return errors.Wrap(sw.session.Run(cmd), "failed to run ssh command")
 }
 
 // ReadPrivateKey returns an authentication method relying on private/public key pairs


### PR DESCRIPTION
# Pull Request description

This is a port to develop of PR #304 that fixes #291 on top of release 3.1

## Description of the change

(Currently only used) For Slurm we use a mechanism to multiplex ssh session on top of a same connection. But if the server reaches its max open sessions threshold then yorc simply kill the connection.

Now, when we can't open a ssh session to the host, instead of killing the underlying connection that could be used by others sessions, just remove it from the connection cache and wait for all sessions to be closed before closing the connection. As there is no more connection in cache a new one will be open.

Also added some metrics to monitor this behavior.

### Description for the changelog

All ssh connections to Slurm are killed if ssh server has reached the max number of allowed sessions ([GH-291](https://github.com/ystia/yorc/issues/291)

## Applicable Issues

Fixes #291 
