### PR TITLE
Bugfix 306 for release 3.2 undeploy in progress event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Instances are adding into topology before creating task ([GH-289](https://github.com/ystia/yorc/issues/289)
 * Missing events for uninstall workflow in purge task ([GH-302](https://github.com/ystia/yorc/issues/302)
 * All ssh connections to Slurm are killed if ssh server has reached the max number of allowed sessions ([GH-291](https://github.com/ystia/yorc/issues/291)
+* It can take a considerable delay for a deployment to change status to UNDEPLOYMENT_IN_PROGRESS ([GH-306](https://github.com/ystia/yorc/issues/306)
 
 ### ENHANCEMENTS
 

--- a/helper/sshutil/sshutil.go
+++ b/helper/sshutil/sshutil.go
@@ -135,7 +135,14 @@ func (sw *SSHSessionWrapper) RunCommand(ctx context.Context, cmd string) error {
 		}
 	}()
 
-	return errors.Wrap(sw.session.Run(cmd), "failed to run ssh command")
+	err := sw.session.Run(cmd)
+	if err != nil {
+		// Get stderr
+		stdout, _ := ioutil.ReadAll(sw.Stdout)
+		stderr, _ := ioutil.ReadAll(sw.Stderr)
+		return errors.Wrapf(err, "failed to run ssh command, stderr: %q, stdout: %q", stderr, stdout)
+	}
+	return nil
 }
 
 // ReadPrivateKey returns an authentication method relying on private/public key pairs

--- a/prov/slurm/executor.go
+++ b/prov/slurm/executor.go
@@ -246,12 +246,15 @@ func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, 
 
 	// Listen to potential cancellation in case of pending allocation
 	ctxAlloc, cancelAlloc := context.WithCancel(ctx)
+	defer cancelAlloc()
 	chEnd := make(chan struct{})
+	defer close(chEnd)
 	go func() {
 		select {
 		case <-ctx.Done():
 			if &allocResponse != nil && allocResponse.jobID != "" {
-				log.Debug("Cancellation message has been sent: the pending job allocation has to be removed")
+				log.Debug("%s: Cancellation message has been sent: the pending job allocation (%s) has to be removed", deploymentID, allocResponse.jobID)
+				log.Debug("%s: %+v", ctx.Err())
 				if err := cancelJobID(allocResponse.jobID, e.client); err != nil {
 					log.Printf("[Warning] an error occurred during cancelling jobID:%q", allocResponse.jobID)
 					return
@@ -317,8 +320,6 @@ func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, 
 	if err != nil {
 		return err
 	}
-
-	close(chEnd)
 	return nil
 }
 

--- a/prov/slurm/executor.go
+++ b/prov/slurm/executor.go
@@ -254,7 +254,7 @@ func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, 
 		case <-ctx.Done():
 			if &allocResponse != nil && allocResponse.jobID != "" {
 				log.Debug("%s: Cancellation message has been sent: the pending job allocation (%s) has to be removed", deploymentID, allocResponse.jobID)
-				log.Debug("%s: %+v", ctx.Err())
+				log.Debug("%s: %+v", deploymentID, ctx.Err())
 				if err := cancelJobID(allocResponse.jobID, e.client); err != nil {
 					log.Printf("[Warning] an error occurred during cancelling jobID:%q", allocResponse.jobID)
 					return

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -44,7 +44,7 @@ func (e anotherLivingTaskAlreadyExistsError) Error() string {
 
 // NewAnotherLivingTaskAlreadyExistsError allows to create a new anotherLivingTaskAlreadyExistsError error
 func NewAnotherLivingTaskAlreadyExistsError(taskID, targetID, status string) error {
-	return &anotherLivingTaskAlreadyExistsError{taskID: taskID, targetID: targetID, status: status}
+	return anotherLivingTaskAlreadyExistsError{taskID: taskID, targetID: targetID, status: status}
 }
 
 // IsAnotherLivingTaskAlreadyExistsError checks if an error is due to the fact that another task is currently running


### PR DESCRIPTION
# Pull Request description

Port of PR #307 to develop.

## Description of the change


Change deployment status to UNDEPLOYMENT_IN_PROGRESS as soon as possible.

That means that instead of changing status when the corresponding task is processed by  a worker, do it as soon as the task is registered. This way the user sees its requested as acknowledged.

Also corrected some issues slurm allocation (potential goroutines leaks)

### Description for the changelog

* It can take a considerable delay for a deployment to change status to UNDEPLOYMENT_IN_PROGRESS ([GH-306](https://github.com/ystia/yorc/issues/306)

## Applicable Issues

Fixes #306 