### PR TITLE
Feature/gh 132 slurm reservation

### DIFF
--- a/data/tosca/yorc-slurm-types.yml
+++ b/data/tosca/yorc-slurm-types.yml
@@ -47,6 +47,10 @@ node_types:
         type: string
         required: false
         description: Specify a name for the job allocation. The specified name will appear along with the job id.
+      reservation:
+        type: string
+        description: >
+          Allocate resources from the named reservation.
     attributes:
       cuda_visible_devices:
         type: string
@@ -119,6 +123,10 @@ node_types:
         description: >
            Provide user credentials for connection to slurm client node
         required: false
+      reservation:
+        type: string
+        description: >
+          Allocate resources for the job from the named reservation.
     attributes:
       job_id:
         type: string

--- a/prov/slurm/execution.go
+++ b/prov/slurm/execution.go
@@ -419,6 +419,13 @@ func (e *executionCommon) buildJobInfo(ctx context.Context) error {
 		return err
 	}
 
+	// Reservation
+	if res, err := deployments.GetNodePropertyValue(e.kv, e.deploymentID, e.NodeName, "reservation"); err != nil {
+		return err
+	} else if res != nil && res.RawString() != "" {
+		job.Reservation = res.RawString()
+	}
+
 	// Set jobInfo in executionCommon
 	e.jobInfo = &job
 
@@ -448,6 +455,10 @@ func (e *executionCommon) fillJobCommandOpts() string {
 			opts += fmt.Sprintf(" --%s", opt)
 		}
 	}
+	if e.jobInfo.Reservation != "" {
+		opts += fmt.Sprintf(" --reservation=%s", e.jobInfo.Reservation)
+	}
+	log.Debugf("opts=%q", opts)
 	return opts
 }
 

--- a/prov/slurm/executor.go
+++ b/prov/slurm/executor.go
@@ -199,7 +199,7 @@ func (e *defaultExecutor) destroyInfrastructure(ctx context.Context, kv *api.KV,
 func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, nodeAlloc *nodeAllocation, deploymentID, nodeName string, sshClient *sshutil.SSHClient) error {
 	events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelINFO, deploymentID).RegisterAsString(fmt.Sprintf("Creating node allocation for: deploymentID:%q, node name:%q", deploymentID, nodeName))
 	// salloc cmd
-	var sallocCPUFlag, sallocMemFlag, sallocPartitionFlag, sallocGresFlag, sallocConstraintFlag string
+	var sallocCPUFlag, sallocMemFlag, sallocPartitionFlag, sallocGresFlag, sallocConstraintFlag, sallocReservationFlag string
 	if nodeAlloc.cpu != "" {
 		sallocCPUFlag = fmt.Sprintf(" -c %s", nodeAlloc.cpu)
 	}
@@ -214,6 +214,9 @@ func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, 
 	}
 	if nodeAlloc.constraint != "" {
 		sallocConstraintFlag = fmt.Sprintf(" --constraint=%q", nodeAlloc.constraint)
+	}
+	if nodeAlloc.reservation != "" {
+		sallocReservationFlag = fmt.Sprintf(" --reservation=%q", nodeAlloc.reservation)
 	}
 
 	// salloc command can potentially be a long synchronous command according to the slurm cluster state
@@ -281,7 +284,7 @@ func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, 
 	}()
 
 	// Run the salloc command
-	sallocCmd := strings.TrimSpace(fmt.Sprintf("salloc --no-shell -J %s%s%s%s%s%s", nodeAlloc.jobName, sallocCPUFlag, sallocMemFlag, sallocPartitionFlag, sallocGresFlag, sallocConstraintFlag))
+	sallocCmd := strings.TrimSpace(fmt.Sprintf("salloc --no-shell -J %s%s%s%s%s%s%s", nodeAlloc.jobName, sallocCPUFlag, sallocMemFlag, sallocPartitionFlag, sallocGresFlag, sallocConstraintFlag, sallocReservationFlag))
 	err = sessionWrapper.RunCommand(ctxAlloc, sallocCmd)
 	if err != nil {
 		return errors.Wrap(err, "Failed to allocate Slurm resource")

--- a/prov/slurm/slurm_node.go
+++ b/prov/slurm/slurm_node.go
@@ -106,6 +106,15 @@ func generateNodeAllocation(ctx context.Context, kv *api.KV, cfg config.Configur
 	// Check that is userName provided, then password or privateKey provided also
 	// Otherwise, raise error, event ...
 
+	// Set the node partition property from Tosca slurm.Compute property
+	reservation, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "reservation")
+	if err != nil {
+		return err
+	}
+	if reservation != nil {
+		node.reservation = reservation.RawString()
+	}
+
 	infra.nodes = append(infra.nodes, node)
 	return nil
 }

--- a/prov/slurm/slurm_node_test.go
+++ b/prov/slurm/slurm_node_test.go
@@ -53,6 +53,7 @@ func testSimpleSlurmNodeAllocation(t *testing.T, kv *api.KV, cfg config.Configur
 	require.Equal(t, "xyz", infrastructure.nodes[0].jobName)
 	require.Equal(t, "johndoe", infrastructure.nodes[0].credentials.UserName)
 	require.Equal(t, "passpass", infrastructure.nodes[0].credentials.Password)
+	require.Equal(t, "resa_123", infrastructure.nodes[0].reservation)
 }
 
 func testSimpleSlurmNodeAllocationWithoutProps(t *testing.T, kv *api.KV, cfg config.Configuration) {

--- a/prov/slurm/structs.go
+++ b/prov/slurm/structs.go
@@ -36,6 +36,7 @@ type nodeAllocation struct {
 	jobName      string
 	credentials  *UserCredentials
 	instanceName string
+	reservation  string
 }
 
 type jobInfo struct {
@@ -55,6 +56,7 @@ type jobInfo struct {
 	MonitoringTimeInterval time.Duration     `json:"monitoring_time_interval,omitempty"`
 	OperationRemoteExecDir string            `json:"operation_remote_exec_dir,omitempty"`
 	Credentials            *UserCredentials  `json:"credentials,omitempty"`
+	Reservation            string            `json:"reservation,omitempty"`
 }
 
 type jobInfoShort struct {

--- a/prov/slurm/testdata/simpleSlurmNodeAllocation.yaml
+++ b/prov/slurm/testdata/simpleSlurmNodeAllocation.yaml
@@ -20,6 +20,7 @@ topology_template:
         gres: gpu:1
         constraint: "[rack1|rack2|rack3|rack4]"
         job_name: xyz
+        reservation: resa_123
       capabilities:
         host:
           properties:

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-yorc_version: 3.2.0-M2
+yorc_version: 3.2.0-SNAPSHOT
 # Alien4Cloud version used by the bootstrap as the default version to download/install
 alien4cloud_version: 2.1.1
 consul_version: 1.2.3


### PR DESCRIPTION
# Pull Request description

As: an app designer
I want to: specify a reservation id for slurm
So that: I can

AC1: specified for SlurmNodes, SlurmJobs, SlurmBatch
AC2: check that error message if reservation id is not correct (or if another error occured)

## Description of the change

### What I did
- Create a reservation Tosca property for Slurm node and Compute
- Add this option into Slurm command (salloc, srun, sbatch)

### How to verify it
Create a Slurm reservation with a command like:
scontrol create reservation starttime=2019-02-18T14:00:00 duration=10 user=root nodes=hpda1
use the reservation id into slurm compute or job

### Description for the changelog
* Yorc supports Slurm reservation ([GH-132](https://github.com/ystia/yorc/issues/132))
## Applicable Issues
fixes #132 
