### PR TITLE
Feature/gh 280 compute account

### DIFF
--- a/data/tosca/yorc-slurm-types.yml
+++ b/data/tosca/yorc-slurm-types.yml
@@ -50,7 +50,7 @@ node_types:
       account:
         type: string
         description: >
-          Charge resources used by this allocation to specified account.
+          Charge resources used by this allocation to specified account. May be mandatory according to configuration.
       reservation:
         type: string
         description: >

--- a/data/tosca/yorc-slurm-types.yml
+++ b/data/tosca/yorc-slurm-types.yml
@@ -47,6 +47,10 @@ node_types:
         type: string
         required: false
         description: Specify a name for the job allocation. The specified name will appear along with the job id.
+      account:
+        type: string
+        description: >
+          Charge resources used by this allocation to specified account.
       reservation:
         type: string
         description: >

--- a/data/tosca/yorc-slurm-types.yml
+++ b/data/tosca/yorc-slurm-types.yml
@@ -130,7 +130,7 @@ node_types:
       account:
         type: string
         description: >
-          Charge resources used by this job to specified account.
+          Charge resources used by this job to specified account. May be mandatory according to configuration.
       reservation:
         type: string
         description: >

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1024,7 +1024,7 @@ Slurm infrastructure key name is ``slurm`` in lower case.
 +----------------------------------+------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
 | ``job_monitoring_time_interval`` | Default duration for job monitoring time interval                | string    | no                                                |   5s    |
 +----------------------------------+------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
-| ``enforce_job_accounting``       | If set to true, Tosca job account property must be set to be run | boolean   | no                                                |  false  |
+| ``enforce_accounting``           | If true, account properties are mandatory for jobs and computes  | boolean   | no                                                |  false  |
 +----------------------------------+------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
 
 An alternative way to specify user credentials for SSH connection to the Slurm Client's node (user_name, password or private_key), is to provide them as application properties.

--- a/prov/slurm/execution.go
+++ b/prov/slurm/execution.go
@@ -424,8 +424,8 @@ func (e *executionCommon) buildJobInfo(ctx context.Context) error {
 		return err
 	} else if acc != nil && acc.RawString() != "" {
 		job.Account = acc.RawString()
-	} else if e.cfg.Infrastructures[infrastructureName].GetBool("enforce_job_accounting") {
-		return errors.Errorf("Job account must be set as configuration enforced job accounting")
+	} else if e.cfg.Infrastructures[infrastructureName].GetBool("enforce_accounting") {
+		return errors.Errorf("Job account must be set as configuration enforces accounting")
 	}
 
 	// Reservation

--- a/prov/slurm/executor.go
+++ b/prov/slurm/executor.go
@@ -199,7 +199,7 @@ func (e *defaultExecutor) destroyInfrastructure(ctx context.Context, kv *api.KV,
 func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, nodeAlloc *nodeAllocation, deploymentID, nodeName string, sshClient *sshutil.SSHClient) error {
 	events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelINFO, deploymentID).RegisterAsString(fmt.Sprintf("Creating node allocation for: deploymentID:%q, node name:%q", deploymentID, nodeName))
 	// salloc cmd
-	var sallocCPUFlag, sallocMemFlag, sallocPartitionFlag, sallocGresFlag, sallocConstraintFlag, sallocReservationFlag string
+	var sallocCPUFlag, sallocMemFlag, sallocPartitionFlag, sallocGresFlag, sallocConstraintFlag, sallocReservationFlag, sallocAccountFlag string
 	if nodeAlloc.cpu != "" {
 		sallocCPUFlag = fmt.Sprintf(" -c %s", nodeAlloc.cpu)
 	}
@@ -217,6 +217,9 @@ func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, 
 	}
 	if nodeAlloc.reservation != "" {
 		sallocReservationFlag = fmt.Sprintf(" --reservation=%q", nodeAlloc.reservation)
+	}
+	if nodeAlloc.account != "" {
+		sallocAccountFlag = fmt.Sprintf(" --account=%q", nodeAlloc.account)
 	}
 
 	// salloc command can potentially be a long synchronous command according to the slurm cluster state
@@ -284,7 +287,7 @@ func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, 
 	}()
 
 	// Run the salloc command
-	sallocCmd := strings.TrimSpace(fmt.Sprintf("salloc --no-shell -J %s%s%s%s%s%s%s", nodeAlloc.jobName, sallocCPUFlag, sallocMemFlag, sallocPartitionFlag, sallocGresFlag, sallocConstraintFlag, sallocReservationFlag))
+	sallocCmd := strings.TrimSpace(fmt.Sprintf("salloc --no-shell -J %s%s%s%s%s%s%s%s", nodeAlloc.jobName, sallocCPUFlag, sallocMemFlag, sallocPartitionFlag, sallocGresFlag, sallocConstraintFlag, sallocReservationFlag, sallocAccountFlag))
 	err = sessionWrapper.RunCommand(ctxAlloc, sallocCmd)
 	if err != nil {
 		return errors.Wrap(err, "Failed to allocate Slurm resource")

--- a/prov/slurm/slurm_node.go
+++ b/prov/slurm/slurm_node.go
@@ -120,6 +120,8 @@ func generateNodeAllocation(ctx context.Context, kv *api.KV, cfg config.Configur
 	}
 	if account != nil {
 		node.account = account.RawString()
+	} else if cfg.Infrastructures[infrastructureName].GetBool("enforce_accounting") {
+		return errors.Errorf("Compute account must be set as configuration enforces accounting")
 	}
 
 	infra.nodes = append(infra.nodes, node)

--- a/prov/slurm/slurm_node.go
+++ b/prov/slurm/slurm_node.go
@@ -106,13 +106,20 @@ func generateNodeAllocation(ctx context.Context, kv *api.KV, cfg config.Configur
 	// Check that is userName provided, then password or privateKey provided also
 	// Otherwise, raise error, event ...
 
-	// Set the node partition property from Tosca slurm.Compute property
 	reservation, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "reservation")
 	if err != nil {
 		return err
 	}
 	if reservation != nil {
 		node.reservation = reservation.RawString()
+	}
+
+	account, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "account")
+	if err != nil {
+		return err
+	}
+	if account != nil {
+		node.account = account.RawString()
 	}
 
 	infra.nodes = append(infra.nodes, node)

--- a/prov/slurm/slurm_node_test.go
+++ b/prov/slurm/slurm_node_test.go
@@ -54,6 +54,7 @@ func testSimpleSlurmNodeAllocation(t *testing.T, kv *api.KV, cfg config.Configur
 	require.Equal(t, "johndoe", infrastructure.nodes[0].credentials.UserName)
 	require.Equal(t, "passpass", infrastructure.nodes[0].credentials.Password)
 	require.Equal(t, "resa_123", infrastructure.nodes[0].reservation)
+	require.Equal(t, "account_test", infrastructure.nodes[0].account)
 }
 
 func testSimpleSlurmNodeAllocationWithoutProps(t *testing.T, kv *api.KV, cfg config.Configuration) {

--- a/prov/slurm/structs.go
+++ b/prov/slurm/structs.go
@@ -36,6 +36,7 @@ type nodeAllocation struct {
 	jobName      string
 	credentials  *UserCredentials
 	instanceName string
+	account      string
 	reservation  string
 }
 

--- a/prov/slurm/testdata/simpleSlurmNodeAllocation.yaml
+++ b/prov/slurm/testdata/simpleSlurmNodeAllocation.yaml
@@ -21,6 +21,7 @@ topology_template:
         constraint: "[rack1|rack2|rack3|rack4]"
         job_name: xyz
         reservation: resa_123
+        account: account_test
       capabilities:
         host:
           properties:


### PR DESCRIPTION
# Pull Request description
**As:** a admin
**I want to:** follow accounting for Slurm Jobs/Computes
**So that:** I can go ahead with the billing

**AC1:** Allow to customize billing account in TOSCA
**AC2:** No account by default
**AC3:** Should provide a config option that enforces accounting (disabled by default).
**AC4:** Doc update

## Description of the change
- Add Tosca property "account" to yorc.nodes.slurm.compute node
- Rename Slurm infrastructure key "enforce_job_accounting"  into "enforce_accounting" and use it for compute node.
- Update doc

### Description for the changelog
* Yorc supports Slurm Accounting ([GH-280](https://github.com/ystia/yorc/issues/280))
## Applicable Issues
fixes #280 
