### PR TITLE
Bugfix/gh 326 panic destroy slurm computes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### BUG FIXES
 
 * Yorc panics on segmentation violation attempting to deploy Ystia Forge Slurm topology ([GH-321](https://github.com/ystia/yorc/issues/321))
+* Panic can append when undeploying Slurm computes ([GH-326](https://github.com/ystia/yorc/issues/326))
 
 ### FEATURES
 

--- a/prov/slurm/executor.go
+++ b/prov/slurm/executor.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ystia/yorc/v3/config"
 	"github.com/ystia/yorc/v3/deployments"
 	"github.com/ystia/yorc/v3/events"
-	"github.com/ystia/yorc/v3/helper/sshutil"
 	"github.com/ystia/yorc/v3/log"
 	"github.com/ystia/yorc/v3/prov"
 	"github.com/ystia/yorc/v3/tasks"
@@ -138,19 +137,11 @@ func (e *defaultExecutor) uninstallNode(ctx context.Context, kv *api.KV, cfg con
 
 func (e *defaultExecutor) createInfrastructure(ctx context.Context, kv *api.KV, cfg config.Configuration, deploymentID, nodeName string, infra *infrastructure) error {
 	events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelINFO, deploymentID).RegisterAsString("Creating the slurm infrastructure")
-
-	// Return an sshClient configured using the user credentials provided in the yorc.nodes.slurm.Compute node definition,
-	// or if not provided, the user credentials specified in the Yorc configuration
-	sshClient, err := getSSHClient(infra.nodes[0].credentials.UserName, infra.nodes[0].credentials.PrivateKey, infra.nodes[0].credentials.Password, cfg)
-	if err != nil {
-		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, deploymentID).RegisterAsString(err.Error())
-		return err
-	}
 	var g errgroup.Group
 	for _, compute := range infra.nodes {
 		func(ctx context.Context, comp *nodeAllocation) {
 			g.Go(func() error {
-				return e.createNodeAllocation(ctx, kv, comp, deploymentID, nodeName, sshClient)
+				return e.createNodeAllocation(ctx, cfg, kv, comp, deploymentID, nodeName)
 			})
 		}(events.AddLogOptionalFields(ctx, events.LogOptionalFields{events.InstanceID: compute.instanceName}), compute)
 	}
@@ -168,19 +159,11 @@ func (e *defaultExecutor) createInfrastructure(ctx context.Context, kv *api.KV, 
 
 func (e *defaultExecutor) destroyInfrastructure(ctx context.Context, kv *api.KV, cfg config.Configuration, deploymentID, nodeName string, infra *infrastructure) error {
 	events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelINFO, deploymentID).RegisterAsString("Destroying the slurm infrastructure")
-
-	// Return an sshClient configured using the user credentials provided in the yorc.nodes.slurm.Compute node definition,
-	// or if not provided, the user credentials specified in the Yorc configuration
-	sshClient, err := getSSHClient(infra.nodes[0].credentials.UserName, infra.nodes[0].credentials.PrivateKey, infra.nodes[0].credentials.Password, cfg)
-	if err != nil {
-		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, deploymentID).RegisterAsString(err.Error())
-		return err
-	}
 	var g errgroup.Group
 	for _, compute := range infra.nodes {
 		func(ctx context.Context, comp *nodeAllocation) {
 			g.Go(func() error {
-				return e.destroyNodeAllocation(ctx, kv, comp, deploymentID, nodeName, sshClient)
+				return e.destroyNodeAllocation(ctx, cfg, kv, comp, deploymentID, nodeName)
 			})
 		}(events.AddLogOptionalFields(ctx, events.LogOptionalFields{events.InstanceID: compute.instanceName}), compute)
 	}
@@ -196,8 +179,17 @@ func (e *defaultExecutor) destroyInfrastructure(ctx context.Context, kv *api.KV,
 	return nil
 }
 
-func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, nodeAlloc *nodeAllocation, deploymentID, nodeName string, sshClient *sshutil.SSHClient) error {
+func (e *defaultExecutor) createNodeAllocation(ctx context.Context, cfg config.Configuration, kv *api.KV, nodeAlloc *nodeAllocation, deploymentID, nodeName string) error {
 	events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelINFO, deploymentID).RegisterAsString(fmt.Sprintf("Creating node allocation for: deploymentID:%q, node name:%q", deploymentID, nodeName))
+
+	// Return an sshClient configured using the user credentials provided in the yorc.nodes.slurm.Compute node definition,
+	// or if not provided, the user credentials specified in the Yorc configuration
+	sshClient, err := getSSHClient(nodeAlloc.credentials.UserName, nodeAlloc.credentials.PrivateKey, nodeAlloc.credentials.Password, cfg)
+	if err != nil {
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, deploymentID).RegisterAsString(err.Error())
+		return err
+	}
+
 	// salloc cmd
 	var sallocCPUFlag, sallocMemFlag, sallocPartitionFlag, sallocGresFlag, sallocConstraintFlag, sallocReservationFlag string
 	if nodeAlloc.cpu != "" {
@@ -336,8 +328,17 @@ func (e *defaultExecutor) createNodeAllocation(ctx context.Context, kv *api.KV, 
 	return nil
 }
 
-func (e *defaultExecutor) destroyNodeAllocation(ctx context.Context, kv *api.KV, nodeAlloc *nodeAllocation, deploymentID, nodeName string, sshClient *sshutil.SSHClient) error {
+func (e *defaultExecutor) destroyNodeAllocation(ctx context.Context, cfg config.Configuration, kv *api.KV, nodeAlloc *nodeAllocation, deploymentID, nodeName string) error {
 	events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelINFO, deploymentID).RegisterAsString(fmt.Sprintf("Destroying node allocation for: deploymentID:%q, node name:%q, instance name:%q", deploymentID, nodeName, nodeAlloc.instanceName))
+
+	// Return an sshClient configured using the user credentials provided in the yorc.nodes.slurm.Compute node definition,
+	// or if not provided, the user credentials specified in the Yorc configuration
+	sshClient, err := getSSHClient(nodeAlloc.credentials.UserName, nodeAlloc.credentials.PrivateKey, nodeAlloc.credentials.Password, cfg)
+	if err != nil {
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, deploymentID).RegisterAsString(err.Error())
+		return err
+	}
+
 	// scancel cmd
 	jobID, err := deployments.GetInstanceAttributeValue(kv, deploymentID, nodeName, nodeAlloc.instanceName, "job_id")
 	if err != nil {


### PR DESCRIPTION
# Pull Request description

## Description of the change
 Get its own SSH agent for each infra node allocation on creation and destruction.

### How to verify it
Load tests
### Description for the changelog
* Panic can append when undeploying Slurm computes ([GH-326](https://github.com/ystia/yorc/issues/326))
## Applicable Issues
fixes #326 