### PR TITLE
Bugfix/gh 334 consul maxconns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Deployment fails on error "socket: too many open files" ([GH-334](https://github.com/ystia/yorc/issues/334))
+
 ## 3.2.0-M3 (March 11, 2019)
 
 ### BUG FIXES

--- a/config/consul.go
+++ b/config/consul.go
@@ -46,6 +46,7 @@ func (cfg Configuration) buildConsulClientInstance() (*api.Client, error) {
 	consulCustomConfig := api.DefaultConfig()
 	consulCustomConfig.Transport.MaxIdleConnsPerHost = cfg.Consul.PubMaxRoutines
 	consulCustomConfig.Transport.MaxIdleConns = cfg.Consul.PubMaxRoutines
+	consulCustomConfig.Transport.MaxConnsPerHost = cfg.Consul.PubMaxRoutines
 	consulCustomConfig.Transport.IdleConnTimeout = 10 * time.Second
 	consulCustomConfig.Transport.TLSHandshakeTimeout = cfg.Consul.TLSHandshakeTimeout
 	log.Debugf("consul http Transport config: %+v", consulCustomConfig.Transport)


### PR DESCRIPTION
# Pull Request description

## Description of the change

When the failure occured, as Yorc was storing a TOSCA definition of the deployment in consul, the number of open TCP connections went above the system default number of open file descriptors of 1024.

Will use a new HTTP transport tunable introduced in Go 1.11 to limit the number of consul connections open by Yorc.

### What I did

A limit was already set by Yorc on Consul HTTP transport max number of idle connections, thanks to the parameter ``consul_publisher_max_routines`` set to 500 by default.
But this is a limit on idle connections, not on non-idle connections.
Go 1.11 introduced a new option ``MaxConnsPerHost``, that permits to limit the maximum number of connections per host.

Using this new option in Yorc code, we can verify that the number of TCP connections open when Yorc stores its TOSCA definition in Consul is as expected limited to ``consul_publisher_max_routines`` tunable.

### How to verify it

Deploy an application on an environment where this issue was easily reproduced: Alien4Cloud/Yorc stack deployed in secure mode on Google Cloud.

### Description for the changelog

Deployment fails on error "socket: too many open files" ([GH-334](https://github.com/ystia/yorc/issues/334))

## Applicable Issues

https://github.com/ystia/yorc/issues/334
