### PR TITLE
Handle host notifier for get_attribute function with Host keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### BUG FIXES
 
 * Deployment fails on error "socket: too many open files" ([GH-334](https://github.com/ystia/yorc/issues/334))
+* Attribute notification is not correctly set with HOST keyword ([GH-338](https://github.com/ystia/yorc/issues/338))
 
 ## 3.2.0-M3 (March 11, 2019)
 

--- a/deployments/definition_store_test.go
+++ b/deployments/definition_store_test.go
@@ -1035,9 +1035,10 @@ func testAttributeNotifications(t *testing.T, kv *api.KV) {
 
 	// Check the attributes notifications
 	expectedKeyValuePairs := map[string]string{
-		"topology/instances/TestContainer/0/attribute_notifications/public_ip_address/0":                "TestComponent/0/attributes/url",
-		"topology/instances/TestContainer/0/capabilities/endpoint/attribute_notifications/ip_address/0": "TestComponent/0/attributes/url_from_cap",
-		"topology/instances/TestComponent/0/outputs/standard/create/attribute_notifications/URL/0":      "TestComponent/0/attributes/url_from_output",
+		"topology/instances/TestCompute/0/attribute_notifications/public_ip_address/0":                "TestComponent/0/attributes/url",
+		"topology/instances/TestCompute/0/capabilities/endpoint/attribute_notifications/ip_address/0": "TestComponent/0/attributes/url_from_cap",
+		"topology/instances/TestContainer/0/attribute_notifications/my_attribute/0":                   "TestComponent/0/attributes/url_from_my_attribute",
+		"topology/instances/TestComponent/0/outputs/standard/create/attribute_notifications/URL/0":    "TestComponent/0/attributes/url_from_output",
 	}
 	for key, expectedValue := range expectedKeyValuePairs {
 		consulKey := path.Join(consulutil.DeploymentKVPrefix, deploymentID, key)

--- a/deployments/testdata/test_component.yml
+++ b/deployments/testdata/test_component.yml
@@ -34,6 +34,7 @@ node_types:
         - ':'
         - get_property: [HOST, port]
       url_from_cap: { concat: ["http://", get_attribute: [HOST, endpoint, ip_address], ":", get_property: [SELF, endpoint, port] ] }
+      url_from_my_attribute: { concat: ["http://", get_attribute: [HOST, my_attribute], ":", get_property: [SELF, endpoint, port] ] }
       url_from_output: { get_operation_output: [ SELF, standard, create, URL ] }
     requirements:
     - host: {capability: yorc.test.capabilities.TestContainerCapability, relationship: yorc.test.relationships.TestComponentOnContainer}

--- a/deployments/testdata/test_container.yml
+++ b/deployments/testdata/test_container.yml
@@ -12,6 +12,9 @@ node_types:
       Test Container definition
     capabilities: {host: yorc.test.capabilities.TestContainerCapability}
     attributes:
+      my_attribute:
+        type: string
+        description: My attribute
       apache_url:
         concat:
         - http://


### PR DESCRIPTION
# Pull Request description

## Description of the change
When get_attribute function with HOST keyword is parsed, the attribute notifier node is resolved recursively attempting to find any hosting node with the related attribute.
If none is found, the root hosting node is returned.

### How to verify it
Deploy topology with tomcat server and check server_url property is updated in events
### Description for the changelog
* Attribute notification is not correctly set with HOST keyword ([GH-338](https://github.com/ystia/yorc/issues/338))
## Applicable Issues
fixes #338 