### PR TITLE
Remove attribute notification handler use with kv and consulStore ins…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Attribute notification is not correctly set with HOST keyword ([GH-338](https://github.com/ystia/yorc/issues/338))
 * Custom command events doesn't provide enough information ([GH-324](https://github.com/ystia/yorc/issues/324))
 * Update Default Oracle JDK download URL as the previous one is not available for download anymore ([GH-341](https://github.com/ystia/yorc/issues/341))
+* Bad notifications storage with several notified for one attribute notifier ([GH-343](https://github.com/ystia/yorc/issues/343))
 
 ## 3.2.0-M3 (March 11, 2019)
 

--- a/deployments/definition_store.go
+++ b/deployments/definition_store.go
@@ -976,7 +976,7 @@ func enhanceNodes(ctx context.Context, kv *api.KV, deploymentID string) error {
 		return err
 	}
 
-	err = enhanceAttributes(consulStore, kv, deploymentID, nodes)
+	err = enhanceAttributes(kv, deploymentID, nodes)
 	if err != nil {
 		return err
 	}
@@ -1332,7 +1332,7 @@ func enhanceWorkflows(consulStore consulutil.ConsulStore, kv *api.KV, deployment
 
 // enhanceAttributes walk through the topology nodes an for each of them if needed it creates instances attributes notifications
 // to allow resolving any attribute when one is updated
-func enhanceAttributes(consulStore consulutil.ConsulStore, kv *api.KV, deploymentID string, nodes []string) error {
+func enhanceAttributes(kv *api.KV, deploymentID string, nodes []string) error {
 	for _, nodeName := range nodes {
 		// retrieve all node attributes
 		attributes, err := GetNodeAttributesNames(kv, deploymentID, nodeName)
@@ -1350,7 +1350,7 @@ func enhanceAttributes(consulStore consulutil.ConsulStore, kv *api.KV, deploymen
 		// 2. Resolve attributes and publish default values when not nil or empty
 		for _, instanceName := range instances {
 			for _, attribute := range attributes {
-				err := addAttributeNotifications(consulStore, kv, deploymentID, nodeName, instanceName, attribute)
+				err := addAttributeNotifications(kv, deploymentID, nodeName, instanceName, attribute)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
# Pull Request description

## Description of the change
Remove attribute notification handler use with kv and consulStore fields
Use unique consul store to save notifications

### Description for the changelog
* Bad notifications storage with several notified for one attribute notifier ([GH-343](https://github.com/ystia/yorc/issues/343))
## Applicable Issues
fixes #343 