### PR TITLE
Return salloc error in function error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Bootstrap Yorc with a Vault instance ([GH-282](https://github.com/ystia/yorc/issues/282))
 * Refactor Slurm jobs ([GH-220](https://github.com/ystia/yorc/issues/220))
+* Yorc does not log a slurm command error message, making diagnostic difficult ([GH-348](https://github.com/ystia/yorc/issues/348))
 
 ### FEATURES
 

--- a/helper/sshutil/sshutil.go
+++ b/helper/sshutil/sshutil.go
@@ -141,6 +141,7 @@ func (client *SSHClient) newSession() (*sshSession, error) {
 }
 
 // RunCommand allows to run a specified command from a session wrapper in order to handle stdout/stderr during long synchronous commands
+// stdout/stderr are retrieved asynchronously with SSHSessionWrapper.Stdout and SSHSessionWrapper.Stderr
 func (sw *SSHSessionWrapper) RunCommand(ctx context.Context, cmd string) error {
 	chClosed := make(chan struct{})
 	defer func() {
@@ -159,15 +160,7 @@ func (sw *SSHSessionWrapper) RunCommand(ctx context.Context, cmd string) error {
 			return
 		}
 	}()
-
-	err := sw.session.Run(cmd)
-	if err != nil {
-		// Get stderr
-		stdout, _ := ioutil.ReadAll(sw.Stdout)
-		stderr, _ := ioutil.ReadAll(sw.Stderr)
-		return errors.Wrapf(err, "failed to run ssh command, stderr: %q, stdout: %q", stderr, stdout)
-	}
-	return nil
+	return sw.session.Run(cmd)
 }
 
 // ReadPrivateKey returns an authentication method relying on private/public key pairs


### PR DESCRIPTION

# Pull Request description


## Description of the change

### What I did
- Return salloc error in the error returned by createNodeAllocation func
- Remove useless synchronous stdout/stderr retrieval 

### How to verify it
Deploy a slurm compute with a fake partition to get Slurm error messagMae
Error logged and returned must contain salloc error message 

### Description for the changelog

## Applicable Issues
fixes #348 