### PR TITLE
Feature/gh 346 ansible config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -119,16 +119,17 @@ func (ho HostedOperations) Format(s fmt.State, verb rune) {
 
 // Ansible configuration
 type Ansible struct {
-	UseOpenSSH              bool             `yaml:"use_openssh,omitempty" mapstructure:"use_openssh" json:"use_open_ssh,omitempty"`
-	DebugExec               bool             `yaml:"debug,omitempty" mapstructure:"debug" json:"debug_exec,omitempty"`
-	ConnectionRetries       int              `yaml:"connection_retries,omitempty" mapstructure:"connection_retries" json:"connection_retries,omitempty"`
-	OperationRemoteBaseDir  string           `yaml:"operation_remote_base_dir,omitempty" mapstructure:"operation_remote_base_dir" json:"operation_remote_base_dir,omitempty"`
-	KeepOperationRemotePath bool             `yaml:"keep_operation_remote_path,omitempty" mapstructure:"keep_operation_remote_path" json:"keep_operation_remote_path,omitempty"`
-	KeepGeneratedRecipes    bool             `yaml:"keep_generated_recipes,omitempty" mapstructure:"keep_generated_recipes" json:"keep_generated_recipes,omitempty"`
-	ArchiveArtifacts        bool             `yaml:"archive_artifacts,omitempty" mapstructure:"archive_artifacts" json:"archive_artifacts,omitempty"`
-	CacheFacts              bool             `yaml:"cache_facts,omitempty" mapstructure:"cache_facts" json:"cache_facts,omitempty"`
-	HostedOperations        HostedOperations `yaml:"hosted_operations,omitempty" mapstructure:"hosted_operations" json:"hosted_operations,omitempty"`
-	JobsChecksPeriod        time.Duration    `yaml:"job_monitoring_time_interval,omitempty" mapstructure:"job_monitoring_time_interval" json:"job_monitoring_time_interval,omitempty"`
+	UseOpenSSH              bool                         `yaml:"use_openssh,omitempty" mapstructure:"use_openssh" json:"use_open_ssh,omitempty"`
+	DebugExec               bool                         `yaml:"debug,omitempty" mapstructure:"debug" json:"debug_exec,omitempty"`
+	ConnectionRetries       int                          `yaml:"connection_retries,omitempty" mapstructure:"connection_retries" json:"connection_retries,omitempty"`
+	OperationRemoteBaseDir  string                       `yaml:"operation_remote_base_dir,omitempty" mapstructure:"operation_remote_base_dir" json:"operation_remote_base_dir,omitempty"`
+	KeepOperationRemotePath bool                         `yaml:"keep_operation_remote_path,omitempty" mapstructure:"keep_operation_remote_path" json:"keep_operation_remote_path,omitempty"`
+	KeepGeneratedRecipes    bool                         `yaml:"keep_generated_recipes,omitempty" mapstructure:"keep_generated_recipes" json:"keep_generated_recipes,omitempty"`
+	ArchiveArtifacts        bool                         `yaml:"archive_artifacts,omitempty" mapstructure:"archive_artifacts" json:"archive_artifacts,omitempty"`
+	CacheFacts              bool                         `yaml:"cache_facts,omitempty" mapstructure:"cache_facts" json:"cache_facts,omitempty"`
+	HostedOperations        HostedOperations             `yaml:"hosted_operations,omitempty" mapstructure:"hosted_operations" json:"hosted_operations,omitempty"`
+	JobsChecksPeriod        time.Duration                `yaml:"job_monitoring_time_interval,omitempty" mapstructure:"job_monitoring_time_interval" json:"job_monitoring_time_interval,omitempty"`
+	Config                  map[string]map[string]string `yaml:"config,omitempty" mapstructure:"config"`
 }
 
 // Consul configuration

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -424,6 +424,20 @@ All available configuration options for Ansible are:
         special_context_filesystems: "nfs,vboxsf,fuse,ramfs,myspecialfs"
         timeout: "60"
 
+By default, the Orchestrator will define these Ansible Configuration settings :
+
+  * ``host_key_checking: "False"``, to avoid host key checking by the underlying tools Ansible uses to connect to the host
+  * ``timeout: "30"``, to set the connection timeout to 30 seconds
+  * ``stdout_callback: "yaml"``, to display ansible output in yaml format
+  * ``nocows: "1"``, to disable cowsay messages that can cause parsing issues in the Orchestrator
+
+And when :ref:`ansible fact caching <option_ansible_cache_facts_cmd>` is enabled, the Orchestrator adds these settings :
+
+  * ``gathering: "smart"``, to set Ansible fact gathering to smart: each new host that has no facts discovered will be scanned
+  * ``fact_caching: "jsonfile"``, to use a json file-based cache plugin
+	
+Be careful when overriding these settings defined by default by the Orchestrator, as it might lead to unpredictable results.
+
 
 Ansible performance considerations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -410,9 +410,9 @@ All available configuration options for Ansible are:
 
   * ``config``: This is a complex structure allowing to define `Ansible configuration settings <https://docs.ansible.com/ansible/latest/reference_appendices/config.html>`_  if you need a specific Ansible Configuration.
     
-    * You should first provide the Ansible Configuration section (for example ``defaults``, ``inventory``, ``ssh_connection``...),
-    * You should the provide the list of parameters within this section; ie. what `Ansible documentation <https://docs.ansible.com/ansible/latest/reference_appendices/config.html>`_ describes as ``Ini key`` within the ``Ini Section``.
-      These parameters values must be provided here as strings : for a boolean parameter, you would provide the string ``False`` or ``True`` as expected in Ansible Confiugration.
+    * You should first provide the Ansible Configuration section (for example ``defaults``, ``inventory``, ``ssh_connection``...).
+    * You should then provide the list of parameters within this section, ie. what `Ansible documentation <https://docs.ansible.com/ansible/latest/reference_appendices/config.html>`_ describes as the ``Ini key`` within the ``Ini Section``.
+      Each parameter value must be provided here as a string : for a boolean parameter, you would provide the string ``False`` or ``True`` as expected in Ansible Confiugration.
       For example, it would give in Yaml:
 
 .. code-block:: YAML

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -409,9 +409,11 @@ All available configuration options for Ansible are:
 .. _option_ansible_config_cfg:
 
   * ``config``: This is a complex structure allowing to define `Ansible configuration settings <https://docs.ansible.com/ansible/latest/reference_appendices/config.html>`_  if you need a specific Ansible Configuration.
-    You should first provide the Ansible Configuration section (for example ``defaults``, ``inventory``, ``ssh_connection``...),
-    then the list of parameters belonging to this section; ie. the ``Ini key`` within the ``Ini Section`` as described in `Ansible documentation <https://docs.ansible.com/ansible/latest/reference_appendices/config.html>`_ , these parameters value being provided as a string : for a boolean parameter, you would provide the string False or True.
-    For example, it would give in Yaml:
+    
+    * You should first provide the Ansible Configuration section (for example ``defaults``, ``inventory``, ``ssh_connection``...),
+    * You should the provide the list of parameters within this section; ie. what `Ansible documentation <https://docs.ansible.com/ansible/latest/reference_appendices/config.html>`_ describes as ``Ini key`` within the ``Ini Section``.
+      These parameters values must be provided here as strings : for a boolean parameter, you would provide the string ``False`` or ``True`` as expected in Ansible Confiugration.
+      For example, it would give in Yaml:
 
 .. code-block:: YAML
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -325,6 +325,13 @@ Below is an example of configuration file with Ansible configuration options.
             "entrypoint": ["python", "-c"],
             "command": ["import time;time.sleep(31536000);"]                                                   
           }            
+        },
+        "config": {
+          "defaults": {
+            "display_skipped_hosts": "False",
+            "special_context_filesystems": "nfs,vboxsf,fuse,ramfs,myspecialfs",
+            "timeout": "60"
+          }            
         }  
       }
     }
@@ -398,6 +405,21 @@ All available configuration options for Ansible are:
       .. _option_ansible_sandbox_hosted_ops_default_sandbox_env_cfg:
 
       * ``env``: An optional list environment variables to set when creating the container. The format of each variable is ``var_name=value``.
+
+.. _option_ansible_config_cfg:
+
+  * ``config``: This is a complex structure allowing to define `Ansible configuration settings <https://docs.ansible.com/ansible/latest/reference_appendices/config.html>`_  if you need a specific Anisble Configuration.
+    You should provide the Ansible Configuration section (for example ``defaults``, ``inventory``, ``ssh_connection``...),
+    then the list of parameters with their value provided as a string : for a boolean parameter, you would provide the string False or True. For example in a yaml, it would give in Yaml:
+
+.. code-block:: YAML
+
+  ansible:
+    config:
+      defaults:
+        display_skipped_hosts: "False"
+        special_context_filesystems: "nfs,vboxsf,fuse,ramfs,myspecialfs"
+        timeout: "60"
 
 
 Ansible performance considerations

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -408,9 +408,10 @@ All available configuration options for Ansible are:
 
 .. _option_ansible_config_cfg:
 
-  * ``config``: This is a complex structure allowing to define `Ansible configuration settings <https://docs.ansible.com/ansible/latest/reference_appendices/config.html>`_  if you need a specific Anisble Configuration.
-    You should provide the Ansible Configuration section (for example ``defaults``, ``inventory``, ``ssh_connection``...),
-    then the list of parameters with their value provided as a string : for a boolean parameter, you would provide the string False or True. For example in a yaml, it would give in Yaml:
+  * ``config``: This is a complex structure allowing to define `Ansible configuration settings <https://docs.ansible.com/ansible/latest/reference_appendices/config.html>`_  if you need a specific Ansible Configuration.
+    You should first provide the Ansible Configuration section (for example ``defaults``, ``inventory``, ``ssh_connection``...),
+    then the list of parameters belonging to this section; ie. the ``Ini key`` within the ``Ini Section`` as described in `Ansible documentation <https://docs.ansible.com/ansible/latest/reference_appendices/config.html>`_ , these parameters value being provided as a string : for a boolean parameter, you would provide the string False or True.
+    For example, it would give in Yaml:
 
 .. code-block:: YAML
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -436,8 +436,9 @@ And when :ref:`ansible fact caching <option_ansible_cache_facts_cmd>` is enabled
   * ``gathering: "smart"``, to set Ansible fact gathering to smart: each new host that has no facts discovered will be scanned
   * ``fact_caching: "jsonfile"``, to use a json file-based cache plugin
 	
-Be careful when overriding these settings defined by default by the Orchestrator, as it might lead to unpredictable results.
-
+.. warning::
+    Be careful when overriding these settings defined by default by the Orchestrator,
+    as it might lead to unpredictable results.
 
 Ansible performance considerations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -1312,6 +1312,9 @@ func (e *executionCommon) generateAnsibleConfigurationFile(
 	// Ansible configuration user-defined values provided in Yorc Server configuration
 	// can override default settings
 	for header, settings := range e.cfg.Ansible.Config {
+		if _, ok := ansibleConfig[header]; !ok {
+			ansibleConfig[header] = make(map[string]string, len(settings))
+		}
 		for k, v := range settings {
 			ansibleConfig[header][k] = v
 		}

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-yorc_version: 3.2.0-M4
+yorc_version: 3.2.0-SNAPSHOT
 # Alien4Cloud version used by the bootstrap as the default version to download/install
 alien4cloud_version: 2.1.1
 consul_version: 1.2.3


### PR DESCRIPTION
# Pull Request description

## Description of the change

Allow the user to configure the Ansible configuration file generated by Yorc

### What I did

Added a new parameter `config` to yorc server ansible configuration structure to allow the user to:
  * define new Ansible Configuration settings,
  * override Ansible Configuration settings defined by Yorc.

in any section of the Ansible Configuration file:  `defaults`, `inventory`, `ssh_connection`, etc...

Updated the doc to describe the new config parameter allowing to specify with examples adding ansible configuration parameters in section `defaults`, in json:
```json
"ansible": {
    "connection_retries": 3,
    "config": {
      "defaults": {
        "display_skipped_hosts": "False",
        "special_context_filesystems": "nfs,vboxsf,fuse,ramfs,myspecialfs",
        "timeout": "60"
      }
    }
  }
```

or in yaml :
```yaml
  ansible:
    connection_retries: 3
    ...
    config:
      defaults:
        display_skipped_hosts: "False"
        special_context_filesystems: "nfs,vboxsf,fuse,ramfs,myspecialfs"
        timeout: "60"
```


### How to verify it

Add these settings in yorc configuration file, for example with yaml syntax, add in config.yorc.yaml:

```yaml
ansible:
  keep_generated_recipes: true
  config:
    defaults:
      display_skipped_hosts: "False"
      special_context_filesystems: "nfs,vboxsf,fuse,ramfs,myspecialfs"
      timeout: "60"
```

Restart yorc

On Alien4Cloud, upload a component archive in Alien4Cloud catalog, for example https://github.com/ystia/yorc-a4c-plugin/tree/develop/tosca-samples/org/ystia/yorc/samples/python
Create an an application with this component hosted on a compute instance. Deploy this application.

On Yorc host check files at `work/deployments/yorc*Environment/ansible/*/*/*/ansible.cfg`

The content of these files should show:
  * the new parameters we have defined above : `display_skipped_hosts`and `special_context_filesystems`
  * the `timeout` parameter set to 60 while Yorc set it to 30 by default when the user doesn't override this value:

```
[defaults]
special_context_filesystems=nfs,vboxsf,fuse,ramfs,myspecialfs
display_skipped_hosts=False
timeout=60
...
```


### Description for the changelog

Allow to configure Ansible configuration file ([GH-346](https://github.com/ystia/yorc/issues/346))

## Applicable Issues

https://github.com/ystia/yorc/issues/346
