### PR TITLE
Feature/gh 104 app monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Implement an anti-affinity placement policy for Openstack ([GH-84](https://github.com/ystia/yorc/issues/84))
 * Allow to configure Ansible configuration file ([GH-346](https://github.com/ystia/yorc/issues/346))
+* Monitor deployed services liveness ([GH-104](https://github.com/ystia/yorc/issues/104))
 
 ## 3.2.0-M4 (March 29, 2019)
 

--- a/data/tosca/yorc-openstack-types.yml
+++ b/data/tosca/yorc-openstack-types.yml
@@ -17,6 +17,42 @@ capability_types:
   yorc.capabilities.openstack.FIPConnectivity:
     derived_from: tosca.capabilities.Connectivity
 
+policy_types:
+  yorc.openstack.policies.ServerGroupAffinity:
+    derived_from:  org.alien4cloud.policies.Affinity
+    description: >
+      Allows to apply a server group affinity placement policy to OpenStack compute instances
+    metadata:
+      # pluginId:pluginBean:phase
+      a4c_policy_impl: alien4cloud-yorc-plugin:yorc-openstack-server-group-modifier:post-node-match
+    targets: [ tosca.nodes.Compute ]
+    properties:
+      strict:
+        type: boolean
+        description: >
+          If true, the scheduling is stopped if the policy can't be applied.
+          If false, the policy is applied if possible according to the OpenStack environment resources. If it's not possible, the scheduling is still done.
+          To use a non-strict policy, the OpenStack environment should support Compute service API 2.15 or above.
+        required: false
+        default: true
+  yorc.openstack.policies.ServerGroupAntiAffinity:
+    derived_from:  org.alien4cloud.policies.AntiAffinity
+    description: >
+      Allows to apply a server group anti-affinity placement policy to OpenStack compute instances
+    metadata:
+      # pluginId:pluginBean:phase
+      a4c_policy_impl: alien4cloud-yorc-plugin:yorc-openstack-server-group-modifier:post-node-match
+    targets: [ tosca.nodes.Compute ]
+    properties:
+      strict:
+        type: boolean
+        description: >
+          If true, the scheduling is stopped if the policy can't be applied.
+          If false, the policy is applied if possible according to the OpenStack environment resources. If it's not possible, the scheduling is still done.
+          To use a non-strict policy, the OpenStack environment should support Compute service API 2.15 or above.
+        required: false
+        default: true
+
 node_types:
   yorc.nodes.openstack.Compute:
     derived_from: yorc.nodes.Compute

--- a/data/tosca/yorc-types.yml
+++ b/data/tosca/yorc-types.yml
@@ -93,4 +93,72 @@ node_types:
           description: Monitor a submitted job for completion.
         cancel:
           description: Cancel a submitted job.
+
+policy_types:
+  yorc.policies.Monitoring:
+    abstract: true
+    derived_from: tosca.policies.Root
+    description: The yorc TOSCA Policy Type definition that is used to monitor computes and applications.
+    properties:
+      period:
+        type: string
+        description: >
+          Time interval duration used for monitoring as "5s" or "300ms"
+          Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+        required: true
+        default: "5s"
+      initial_delay:
+        type: integer
+        description: Number of seconds after the node has started before monitoring is initiated
+        default: 0
+        required: false
+        constraints:
+          - greater_or_equal: 0
+      timeout:
+        type: integer
+        description: Number of seconds after which the monitoring check times out.
+        default: 1
+        required: false
+        constraints:
+          - greater_or_equal: 1
+  yorc.policies.monitoring.HTTPMonitoring:
+    derived_from: yorc.policies.Monitoring
+    description: The yorc TOSCA Policy that is used to monitor applications with HTTP checks.
+    targets: [ tosca.nodes.SoftwareComponent ]
+    properties:
+      scheme:
+        type: string
+        description: Scheme to use for connecting to the target endpoint. Defaults to HTTP.
+        required: true
+        default: http
+        constraints:
+          - valid_values: [ http, https ]
+      port:
+        type: integer
+        description: Port to use for connecting the target endpoint.
+        required: true
+        default: 80
+        constraints:
+          - in_range: [ 1, 65535 ]
+      path:
+        type: string
+        description: Path to access on the target endpoint.
+        required: false
+      http_headers:
+        type: list
+        description: Custom headers to set in the request.
+        required: false
+        entry_schema:
+          type: string
+  yorc.policies.monitoring.TCPMonitoring:
+    derived_from: yorc.policies.Monitoring
+    description: The yorc TOSCA Policy that is used to monitor computes and applications with TCP checks.
+    targets: [ tosca.nodes.Compute, tosca.nodes.SoftwareComponent ]
+    properties:
+      port:
+        type: integer
+        description: Port to use for opening a socket.
+        required: true
+        constraints:
+          - in_range: [ 1, 65535 ]
           

--- a/data/tosca/yorc-types.yml
+++ b/data/tosca/yorc-types.yml
@@ -3,7 +3,7 @@ tosca_definitions_version: yorc_tosca_simple_yaml_1_0
 metadata:
   template_name: yorc-types
   template_author: yorc
-  template_version: 1.0.0
+  template_version: 1.1.0
 
 imports:
   - normative: <normative-types.yml>
@@ -100,27 +100,13 @@ policy_types:
     derived_from: tosca.policies.Root
     description: The yorc TOSCA Policy Type definition that is used to monitor computes and applications.
     properties:
-      period:
+      time_interval:
         type: string
         description: >
           Time interval duration used for monitoring as "5s" or "300ms"
           Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
         required: true
         default: "5s"
-      initial_delay:
-        type: integer
-        description: Number of seconds after the node has started before monitoring is initiated
-        default: 0
-        required: false
-        constraints:
-          - greater_or_equal: 0
-      timeout:
-        type: integer
-        description: Number of seconds after which the monitoring check times out.
-        default: 1
-        required: false
-        constraints:
-          - greater_or_equal: 1
   yorc.policies.monitoring.HTTPMonitoring:
     derived_from: yorc.policies.Monitoring
     description: The yorc TOSCA Policy that is used to monitor applications with HTTP checks.
@@ -145,7 +131,7 @@ policy_types:
         description: Path to access on the target endpoint.
         required: false
       http_headers:
-        type: list
+        type: map
         description: Custom headers to set in the request.
         required: false
         entry_schema:

--- a/data/tosca/yorc-types.yml
+++ b/data/tosca/yorc-types.yml
@@ -36,6 +36,31 @@ data_types:
         type: string
         required: true
         description: The user (name or ID) used as a credential for authorization or access to a networked resource.
+  yorc.datatypes.TLSClientConfig:
+    derived_from: tosca.datatypes.Root
+    properties:
+      client_cert:
+        type: string
+        required: false
+        description: File path to the PEM-encoded client certificate.
+      client_key:
+        type: string
+        required: false
+        description: File path to the PEM-encoded client private key.
+      ca_cert:
+        type: string
+        required: false
+        description: File path to the PEM-encoded client certificate authority.
+      ca_path:
+        type: string
+        required: false
+        description: Path to a directory of PEM-encoded certificates authorities.
+      skip_verify:
+        type: boolean
+        required: false
+        description: >
+          Controls whether a client verifies the server’s certificate chain and host name.
+          If set to true, TLS accepts any certificate presented by the server and any host name in that certificate
 
 capability_types:
   yorc.capabilities.Endpoint.ProvisioningAdmin:
@@ -143,6 +168,11 @@ policy_types:
         required: false
         entry_schema:
           type: string
+      tls_client:
+        type: yorc.datatypes.TLSClientConfig
+        description: TLS client configuration used for HTTP checks.
+        required: false
+
   yorc.policies.monitoring.TCPMonitoring:
     derived_from: yorc.policies.Monitoring
     description: The yorc TOSCA Policy that is used to monitor computes and applications with TCP checks.

--- a/data/tosca/yorc-types.yml
+++ b/data/tosca/yorc-types.yml
@@ -42,19 +42,15 @@ data_types:
       client_cert:
         type: string
         required: false
-        description: File path to the PEM-encoded client certificate.
+        description: PEM-encoded client certificate content used for TLS configuration.
       client_key:
         type: string
         required: false
-        description: File path to the PEM-encoded client private key.
+        description: PEM-encoded client private key content used for TLS configuration.
       ca_cert:
         type: string
         required: false
-        description: File path to the PEM-encoded client certificate authority.
-      ca_path:
-        type: string
-        required: false
-        description: Path to a directory of PEM-encoded certificates authorities.
+        description: PEM-encoded client certificate authority content used for TLS configuration.
       skip_verify:
         type: boolean
         required: false

--- a/deployments/policies.go
+++ b/deployments/policies.go
@@ -1,0 +1,187 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployments
+
+import (
+	"github.com/hashicorp/consul/api"
+	"github.com/pkg/errors"
+	"github.com/ystia/yorc/v3/helper/collections"
+	"github.com/ystia/yorc/v3/helper/consulutil"
+	"path"
+	"strings"
+)
+
+// GetPoliciesForTypeAndNode retrieves all policies with or derived from policyTypeName and with nodeName as target
+func GetPoliciesForTypeAndNode(kv *api.KV, deploymentID, policyTypeName, nodeName string) ([]string, error) {
+	p := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology", "policies")
+	keys, _, err := kv.Keys(p+"/", "/", nil)
+	if err != nil {
+		return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+	}
+
+	policies := make([]string, 0)
+	for _, key := range keys {
+		policyName := path.Base(key)
+		kvp, _, err := kv.Get(path.Join(key, "type"), nil)
+		if err != nil {
+			return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+		}
+		if kvp == nil || len(kvp.Value) == 0 {
+			return nil, errors.Errorf("Missing mandatory attribute \"type\" for policy %q", path.Base(key))
+		}
+		policyType := string(kvp.Value)
+		// Check policy type
+		isType, err := IsTypeDerivedFrom(kv, deploymentID, policyType, policyTypeName)
+		if err != nil {
+			return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+		}
+		// Check policy targets
+		if isType {
+			is, err := IsTargetForPolicy(kv, deploymentID, policyName, nodeName)
+			if err != nil {
+				return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+			}
+			if is {
+				policies = append(policies, policyName)
+			}
+		}
+	}
+	return policies, nil
+}
+
+// GetPolicyPropertyValue retrieves the value for a given property in a given policy
+//
+// It returns true if a value is found false otherwise as first return parameter.
+// If the property is not found in the policy then the type hierarchy is explored to find a default value.
+func GetPolicyPropertyValue(kv *api.KV, deploymentID, policyName, propertyName string, nestedKeys ...string) (*TOSCAValue, error) {
+	policyType, err := GetPolicyType(kv, deploymentID, policyName)
+	if err != nil {
+		return nil, err
+	}
+	var propDataType string
+	hasProp, err := TypeHasProperty(kv, deploymentID, policyType, propertyName, true)
+	if err != nil {
+		return nil, err
+	}
+	if hasProp {
+		propDataType, err = GetTypePropertyDataType(kv, deploymentID, policyType, propertyName)
+		if err != nil {
+			return nil, err
+		}
+	}
+	p := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology", "policies", policyName)
+
+	result, err := getValueAssignmentWithDataType(kv, deploymentID, path.Join(p, "properties", propertyName), policyName, "", "", propDataType, nestedKeys...)
+	if err != nil || result != nil {
+		return result, errors.Wrapf(err, "Failed to get property %q for policy %q", propertyName, policyName)
+	}
+	// Not found look at policy type
+	value, isFunction, err := getTypeDefaultProperty(kv, deploymentID, policyType, propertyName, nestedKeys...)
+	if err != nil {
+		return nil, err
+	}
+	if value != nil {
+		if !isFunction {
+			return value, nil
+		}
+		return resolveValueAssignment(kv, deploymentID, policyName, "", "", value, nestedKeys...)
+	}
+	// Not found anywhere
+	return nil, nil
+}
+
+// GetPolicyType returns the type of the policy
+func GetPolicyType(kv *api.KV, deploymentID, policyName string) (string, error) {
+	p := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology", "policies", policyName)
+	kvp, _, err := kv.Get(path.Join(p, "type"), nil)
+	if err != nil {
+		return "", errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+	}
+	if kvp == nil || len(kvp.Value) == 0 {
+		return "", errors.Errorf("Missing mandatory attribute \"type\" for policy %q", policyName)
+	}
+	return string(kvp.Value), nil
+}
+
+// IsTargetForPolicy returns true if the node name is a policy target
+func IsTargetForPolicy(kv *api.KV, deploymentID, policyName, nodeName string) (bool, error) {
+	targets, err := GetPolicyTargets(kv, deploymentID, policyName)
+	if err != nil {
+		return false, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+	}
+	if targets != nil {
+		return collections.ContainsString(targets, nodeName), nil
+	}
+
+	nodeType, err := GetNodeType(kv, deploymentID, nodeName)
+	if err != nil {
+		return false, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+	}
+
+	policyType, err := GetPolicyType(kv, deploymentID, policyName)
+	if err != nil {
+		return false, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+	}
+	targets, err = GetPolicyTargetsForType(kv, deploymentID, policyType)
+	if err != nil {
+		return false, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+	}
+	for _, target := range targets {
+		is, err := IsTypeDerivedFrom(kv, deploymentID, nodeType, target)
+		if err != nil {
+			return false, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+		}
+		if is {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// GetPolicyTargetsForType retrieves the policy template targets
+// this targets are node names
+func GetPolicyTargets(kv *api.KV, deploymentID, policyName string) ([]string, error) {
+	p := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology", "policies", policyName, "targets")
+	kvp, _, err := kv.Get(p, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+	}
+	if kvp != nil && len(kvp.Value) != 0 {
+		return strings.Split(string(kvp.Value), ","), nil
+	}
+	return nil, nil
+}
+
+// GetPolicyTargetsForType retrieves the policy type targets
+// this targets are node types
+func GetPolicyTargetsForType(kv *api.KV, deploymentID, policyType string) ([]string, error) {
+	p := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology", "types", policyType, "targets")
+	kvp, _, err := kv.Get(p, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+	}
+	if kvp != nil || len(kvp.Value) != 0 {
+		return strings.Split(string(kvp.Value), ","), nil
+	}
+
+	parentType, err := GetParentType(kv, deploymentID, policyType)
+	if err != nil {
+		return nil, err
+	}
+	if parentType == "" {
+		return nil, nil
+	}
+	return GetPolicyTargetsForType(kv, deploymentID, parentType)
+}

--- a/deployments/policies.go
+++ b/deployments/policies.go
@@ -49,7 +49,7 @@ func GetPoliciesForTypeAndNode(kv *api.KV, deploymentID, policyTypeName, nodeNam
 		}
 		// Check policy targets
 		if isType {
-			is, err := IsTargetForPolicy(kv, deploymentID, policyName, nodeName)
+			is, err := IsTargetForPolicy(kv, deploymentID, policyName, nodeName, false)
 			if err != nil {
 				return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 			}
@@ -116,12 +116,12 @@ func GetPolicyType(kv *api.KV, deploymentID, policyName string) (string, error) 
 }
 
 // IsTargetForPolicy returns true if the node name is a policy target
-func IsTargetForPolicy(kv *api.KV, deploymentID, policyName, nodeName string) (bool, error) {
+func IsTargetForPolicy(kv *api.KV, deploymentID, policyName, nodeName string, recursive bool) (bool, error) {
 	targets, err := GetPolicyTargets(kv, deploymentID, policyName)
 	if err != nil {
 		return false, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 	}
-	if targets != nil {
+	if !recursive {
 		return collections.ContainsString(targets, nodeName), nil
 	}
 

--- a/deployments/policies.go
+++ b/deployments/policies.go
@@ -150,7 +150,7 @@ func IsTargetForPolicy(kv *api.KV, deploymentID, policyName, nodeName string, re
 	return false, nil
 }
 
-// GetPolicyTargetsForType retrieves the policy template targets
+// GetPolicyTargets retrieves the policy template targets
 // this targets are node names
 func GetPolicyTargets(kv *api.KV, deploymentID, policyName string) ([]string, error) {
 	p := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology", "policies", policyName, "targets")

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/goware/urlx v0.0.0-20160722204212-8bb4a2e4339f55b15164907177e96e9faf885504
 	github.com/gregjones/httpcache v0.0.0-20190203031600-7a902570cb17 // indirect
 	github.com/hashicorp/consul v1.2.3
-	github.com/hashicorp/go-cleanhttp v0.0.0-20171218145408-d5fe4b57a186c716b0e00b8c301cbd9b4182694d // indirect
+	github.com/hashicorp/go-cleanhttp v0.0.0-20171218145408-d5fe4b57a186c716b0e00b8c301cbd9b4182694d
 	github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e // indirect
 	github.com/hashicorp/go-memdb v0.0.0-20181108192425-032f93b25bec // indirect
 	github.com/hashicorp/go-multierror v1.0.0

--- a/prov/monitoring/check.go
+++ b/prov/monitoring/check.go
@@ -130,7 +130,7 @@ func (c *Check) checkHTTP() {
 	url := fmt.Sprintf("%s://%s:%d", c.httpConn.scheme, c.httpConn.address, c.httpConn.port)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		log.Debugf("[WARN] check HTTP request (id:%q) failed for url:%s", c.ID, url)
+		log.Debugf("[WARN] check HTTP request (id:%q) failed for url:%q", c.ID, url)
 		c.updateStatus(CheckStatusCRITICAL)
 		return
 	}
@@ -151,7 +151,7 @@ func (c *Check) checkHTTP() {
 	// Send request
 	resp, err := c.httpConn.httpClient.Do(req)
 	if err != nil {
-		log.Debugf("[WARN] check HTTP request (id:%q) failed for url:%s", c.ID, url)
+		log.Debugf("[WARN] check HTTP request (id:%q) failed for url:%q", c.ID, url)
 		c.updateStatus(CheckStatusCRITICAL)
 		return
 	}
@@ -163,10 +163,10 @@ func (c *Check) checkHTTP() {
 
 	} else if resp.StatusCode == 429 {
 		// 429 Too Many Requests (RFC 6585)
-		log.Debugf("[WARN] check HTTP request (id:%q) failed for url:%s", c.ID, url)
+		log.Debugf("[WARN] check HTTP request (id:%q) failed for url:%q", c.ID, url)
 		c.updateStatus(CheckStatusWARNING)
 	} else {
-		log.Debugf("[WARN] check HTTP request (id:%q) failed for url:%s", c.ID, url)
+		log.Debugf("[WARN] check HTTP request (id:%q) failed for url:%q", c.ID, url)
 		c.updateStatus(CheckStatusCRITICAL)
 	}
 }

--- a/prov/monitoring/check.go
+++ b/prov/monitoring/check.go
@@ -111,8 +111,19 @@ func (c *Check) updateStatus(status CheckStatus, message string) {
 		if !c.exist() {
 			return
 		}
+		// Ideally, the check should follow the node lifecycle and stopped when the node is stopped
+		// For the moment, only update status when the node is active (started) or on error
+		instanceState, err := deployments.GetInstanceState(defaultMonManager.cc.KV(), c.Report.DeploymentID, c.Report.NodeName, c.Report.Instance)
+		if err != nil {
+			log.Printf("[WARN] Failed to retrieve node state with node:%q, instance:%q due to error:%+v", c.Report.NodeName, c.Report.Instance, err)
+			return
+		}
+		if instanceState != tosca.NodeStateStarted && instanceState != tosca.NodeStateError {
+			return
+		}
+
 		log.Debugf("Update check status from %q to %q", c.Report.Status.String(), status.String())
-		err := consulutil.StoreConsulKeyAsString(path.Join(consulutil.MonitoringKVPrefix, "reports", c.ID, "status"), status.String())
+		err = consulutil.StoreConsulKeyAsString(path.Join(consulutil.MonitoringKVPrefix, "reports", c.ID, "status"), status.String())
 		if err != nil {
 			log.Printf("[WARN] TCP check updating status failed for check ID:%q due to error:%+v", c.ID, err)
 		}

--- a/prov/monitoring/check.go
+++ b/prov/monitoring/check.go
@@ -17,9 +17,6 @@ package monitoring
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-cleanhttp"
-	"net"
-	"net/http"
 	"path"
 	"strings"
 	"time"
@@ -89,85 +86,9 @@ func (c *Check) run() {
 			ticker.Stop()
 			return
 		case <-ticker.C:
-			c.check()
+			status := c.execution.execute(c.timeout)
+			c.updateStatus(status)
 		}
-	}
-}
-
-func (c *Check) check() {
-	if c.CheckType == CheckTypeTCP {
-		c.checkTCP()
-	} else if c.CheckType == CheckTypeHTTP {
-		c.checkHTTP()
-	}
-}
-
-func (c *Check) checkTCP() {
-	tcpAddr := fmt.Sprintf("%s:%d", c.tcpConn.address, c.tcpConn.port)
-	conn, err := net.DialTimeout("tcp", tcpAddr, c.timeout)
-	if err != nil {
-		log.Debugf("[WARN] TCP check (id:%q) connection failed for address:%s", c.ID, tcpAddr)
-		c.updateStatus(CheckStatusCRITICAL)
-		return
-	}
-	conn.Close()
-	c.updateStatus(CheckStatusPASSING)
-}
-
-func (c *Check) checkHTTP() {
-	// instantiate httpClient if not already done
-	if c.httpConn.httpClient == nil {
-		trans := cleanhttp.DefaultTransport()
-		trans.DisableKeepAlives = true
-
-		c.httpConn.httpClient = &http.Client{
-			Timeout:   c.timeout,
-			Transport: trans,
-		}
-	}
-
-	// Create HTTP Request
-	url := fmt.Sprintf("%s://%s:%d", c.httpConn.scheme, c.httpConn.address, c.httpConn.port)
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		log.Debugf("[WARN] check HTTP request (id:%q) failed for url:%q", c.ID, url)
-		c.updateStatus(CheckStatusCRITICAL)
-		return
-	}
-
-	// instantiate headers
-	if c.httpConn.header == nil {
-		c.httpConn.header = make(http.Header)
-		for k, v := range c.httpConn.headersMap {
-			c.httpConn.header.Add(k, v)
-		}
-
-		if c.httpConn.header.Get("Accept") == "" {
-			c.httpConn.header.Set("Accept", "text/plain, text/*, */*")
-		}
-	}
-	req.Header = c.httpConn.header
-
-	// Send request
-	resp, err := c.httpConn.httpClient.Do(req)
-	if err != nil {
-		log.Debugf("[WARN] check HTTP request (id:%q) failed for url:%q", c.ID, url)
-		c.updateStatus(CheckStatusCRITICAL)
-		return
-	}
-	defer resp.Body.Close()
-
-	// Check response status code
-	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
-		c.updateStatus(CheckStatusPASSING)
-
-	} else if resp.StatusCode == 429 {
-		// 429 Too Many Requests (RFC 6585)
-		log.Debugf("[WARN] check HTTP request (id:%q) failed for url:%q", c.ID, url)
-		c.updateStatus(CheckStatusWARNING)
-	} else {
-		log.Debugf("[WARN] check HTTP request (id:%q) failed for url:%q", c.ID, url)
-		c.updateStatus(CheckStatusCRITICAL)
 	}
 }
 

--- a/prov/monitoring/check_execution.go
+++ b/prov/monitoring/check_execution.go
@@ -90,8 +90,6 @@ func newHTTPCheckExecution(address string, port int, scheme, urlPath string, hea
 	execution.httpClient = &http.Client{
 		Transport: trans,
 	}
-
-	log.Debugf("TLSClientConfig=%+v", trans.TLSClientConfig)
 	return execution, nil
 }
 

--- a/prov/monitoring/check_execution.go
+++ b/prov/monitoring/check_execution.go
@@ -97,7 +97,7 @@ func (ce *httpCheckExecution) execute(timeout time.Duration) (CheckStatus, strin
 	// Create HTTP Request
 	req, err := http.NewRequest("GET", ce.url, nil)
 	if err != nil {
-		log.Debugf("[WARN] check HTTP execution failed for url:%q due to error:%v", ce.url, err)
+		log.Debugf("[WARN] check HTTP execution failed creating request to url:%q due to error:%v", ce.url, err)
 		return CheckStatusCRITICAL, fmt.Sprintf("[WARN] check HTTP execution failed for url:%q due to error:%v", ce.url, err)
 	}
 	req.Header = ce.header
@@ -106,7 +106,7 @@ func (ce *httpCheckExecution) execute(timeout time.Duration) (CheckStatus, strin
 	ce.httpClient.Timeout = timeout
 	resp, err := ce.httpClient.Do(req)
 	if err != nil {
-		log.Debugf("[WARN] check HTTP execution failed for url:%q due to error:%v", ce.url, err)
+		log.Debugf("[WARN] check HTTP execution failed sending request to url:%q due to error:%v", ce.url, err)
 		return CheckStatusCRITICAL, fmt.Sprintf("[WARN] check HTTP execution failed for url:%q due to error:%v", ce.url, err)
 	}
 	defer resp.Body.Close()

--- a/prov/monitoring/check_execution.go
+++ b/prov/monitoring/check_execution.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ystia/yorc/v3/log"
 	"net"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -67,6 +68,9 @@ func (ce *httpCheckExecution) execute(timeout time.Duration) CheckStatus {
 
 	// Create HTTP Request
 	url := fmt.Sprintf("%s://%s:%d", ce.scheme, ce.address, ce.port)
+	if ce.path != "" {
+		url = path.Join(url, ce.path)
+	}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		log.Debugf("[WARN] check HTTP execution failed for url:%q due to error:%+v", url, err)

--- a/prov/monitoring/check_execution.go
+++ b/prov/monitoring/check_execution.go
@@ -97,6 +97,7 @@ func (ce *httpCheckExecution) execute(timeout time.Duration) (CheckStatus, strin
 	// Create HTTP Request
 	req, err := http.NewRequest("GET", ce.url, nil)
 	if err != nil {
+		log.Debugf("[WARN] check HTTP execution failed for url:%q due to error:%v", ce.url, err)
 		return CheckStatusCRITICAL, fmt.Sprintf("[WARN] check HTTP execution failed for url:%q due to error:%v", ce.url, err)
 	}
 	req.Header = ce.header
@@ -105,6 +106,7 @@ func (ce *httpCheckExecution) execute(timeout time.Duration) (CheckStatus, strin
 	ce.httpClient.Timeout = timeout
 	resp, err := ce.httpClient.Do(req)
 	if err != nil {
+		log.Debugf("[WARN] check HTTP execution failed for url:%q due to error:%v", ce.url, err)
 		return CheckStatusCRITICAL, fmt.Sprintf("[WARN] check HTTP execution failed for url:%q due to error:%v", ce.url, err)
 	}
 	defer resp.Body.Close()
@@ -114,8 +116,10 @@ func (ce *httpCheckExecution) execute(timeout time.Duration) (CheckStatus, strin
 		return CheckStatusPASSING, ""
 	} else if resp.StatusCode == 429 {
 		// 429 Too Many Requests (RFC 6585)
+		log.Debugf("[WARN] check HTTP execution failed for url:%q with status code:%d", ce.url, resp.StatusCode)
 		return CheckStatusWARNING, fmt.Sprintf("[WARN] check HTTP execution failed for url:%q with status code:%d", ce.url, resp.StatusCode)
 	} else {
+		log.Debugf("[WARN] check HTTP execution failed for url:%q with status code:%d", ce.url, resp.StatusCode)
 		return CheckStatusCRITICAL, fmt.Sprintf("[WARN] check HTTP execution failed for url:%q with status code:%d", ce.url, resp.StatusCode)
 	}
 }

--- a/prov/monitoring/check_execution.go
+++ b/prov/monitoring/check_execution.go
@@ -1,0 +1,108 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"fmt"
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/ystia/yorc/v3/log"
+	"net"
+	"net/http"
+	"time"
+)
+
+type checkExecution interface {
+	execute(timeout time.Duration) CheckStatus
+}
+
+type tcpCheckExecution struct {
+	address string
+	port    int
+}
+
+type httpCheckExecution struct {
+	httpClient *http.Client
+	scheme     string
+	address    string
+	port       int
+	path       string
+	headersMap map[string]string
+	header     http.Header
+}
+
+func (ce *tcpCheckExecution) execute(timeout time.Duration) CheckStatus {
+	tcpAddr := fmt.Sprintf("%s:%d", ce.address, ce.port)
+	conn, err := net.DialTimeout("tcp", tcpAddr, timeout)
+	if err != nil {
+		log.Debugf("[WARN] TCP check execution failed for address:%s", tcpAddr)
+		return CheckStatusCRITICAL
+	}
+	conn.Close()
+	return CheckStatusPASSING
+}
+
+func (ce *httpCheckExecution) execute(timeout time.Duration) CheckStatus {
+	// instantiate httpClient if not already done
+	if ce.httpClient == nil {
+		trans := cleanhttp.DefaultTransport()
+		trans.DisableKeepAlives = true
+
+		ce.httpClient = &http.Client{
+			Timeout:   timeout,
+			Transport: trans,
+		}
+	}
+
+	// Create HTTP Request
+	url := fmt.Sprintf("%s://%s:%d", ce.scheme, ce.address, ce.port)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.Debugf("[WARN] check HTTP execution failed for url:%q due to error:%+v", url, err)
+		return CheckStatusCRITICAL
+	}
+
+	// instantiate headers
+	if ce.header == nil {
+		ce.header = make(http.Header)
+		for k, v := range ce.headersMap {
+			ce.header.Add(k, v)
+		}
+
+		if ce.header.Get("Accept") == "" {
+			ce.header.Set("Accept", "text/plain, text/*, */*")
+		}
+	}
+	req.Header = ce.header
+
+	// Send request
+	resp, err := ce.httpClient.Do(req)
+	if err != nil {
+		log.Debugf("[WARN] check HTTP execution failed for url:%q due to error:%+v", url, err)
+		return CheckStatusCRITICAL
+	}
+	defer resp.Body.Close()
+
+	// Check response status code
+	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+		return CheckStatusPASSING
+	} else if resp.StatusCode == 429 {
+		// 429 Too Many Requests (RFC 6585)
+		log.Debugf("[WARN] check HTTP execution failed for url:%q with status code:%d", url, resp.StatusCode)
+		return CheckStatusWARNING
+	} else {
+		log.Debugf("[WARN] check HTTP execution failed for url:%q with status code:%d", url, resp.StatusCode)
+		return CheckStatusCRITICAL
+	}
+}

--- a/prov/monitoring/consul_test.go
+++ b/prov/monitoring/consul_test.go
@@ -24,7 +24,6 @@ import (
 
 // The aim of this function is to run all package tests with consul server dependency with only one consul server start
 func TestRunConsulMonitoringPackageTests(t *testing.T) {
-	t.Skip()
 	srv, client := testutil.NewTestConsulInstance(t)
 
 	cfg := config.Configuration{
@@ -44,14 +43,39 @@ func TestRunConsulMonitoringPackageTests(t *testing.T) {
 	}()
 
 	srv.PopulateKV(t, map[string][]byte{
-		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/tosca.nodes.Root/name":                      []byte("tosca.nodes.Root"),
-		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/tosca.nodes.Compute/derived_from":           []byte("tosca.nodes.Root"),
-		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/yorc.nodes.Compute/derived_from":            []byte("tosca.nodes.Compute"),
-		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/yorc.nodes.openstack.Compute/derived_from":  []byte("yorc.nodes.Compute"),
-		consulutil.DeploymentKVPrefix + "/monitoring1/topology/nodes/Compute1/type":                              []byte("yorc.nodes.openstack.Compute"),
-		consulutil.DeploymentKVPrefix + "/monitoring1/topology/nodes/Compute1/metadata/monitoring_time_interval": []byte("1"),
-		consulutil.DeploymentKVPrefix + "/monitoring1/topology/instances/Compute1/0/attributes/ip_address":       []byte("1.2.3.4"),
-		consulutil.DeploymentKVPrefix + "/monitoring1/topology/instances/Compute1/0/attributes/state":            []byte("started"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/yorc.policies.Monitoring/properties/time_interval/default":  []byte("5s"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/yorc.policies.Monitoring/properties/time_interval/type":     []byte("string"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/yorc.policies.Monitoring/properties/time_interval/required": []byte("true"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/yorc.policies.Monitoring/properties/time_interval/name":     []byte("time_interval"),
+
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/yorc.policies.monitoring.TCPMonitoring/derived_from": []byte("yorc.policies.Monitoring"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/yorc.policies.monitoring.TCPMonitoring/targets": []byte("		tosca.nodes.Compute,tosca.nodes.SoftwareComponent"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/policies/TCPMonitoring/properties/port":          []byte("22"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/policies/TCPMonitoring/properties/time_interval": []byte("1s"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/policies/TCPMonitoring/targets":                  []byte("Compute1"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/policies/TCPMonitoring/type":                     []byte("yorc.policies.monitoring.TCPMonitoring"),
+
+		consulutil.DeploymentKVPrefix + "/monitoring3/topology/types/yorc.policies.monitoring.TCPMonitoring/derived_from": []byte("yorc.policies.Monitoring"),
+		consulutil.DeploymentKVPrefix + "/monitoring3/topology/types/yorc.policies.monitoring.TCPMonitoring/targets": []byte("		tosca.nodes.Compute,tosca.nodes.SoftwareComponent"),
+		consulutil.DeploymentKVPrefix + "/monitoring3/topology/policies/TCPMonitoring/properties/port":          []byte("22"),
+		consulutil.DeploymentKVPrefix + "/monitoring3/topology/policies/TCPMonitoring/properties/time_interval": []byte("1s"),
+		consulutil.DeploymentKVPrefix + "/monitoring3/topology/policies/TCPMonitoring/targets":                  []byte("Compute"),
+		consulutil.DeploymentKVPrefix + "/monitoring3/topology/policies/TCPMonitoring/type":                     []byte("yorc.policies.monitoring.TCPMonitoring"),
+
+		consulutil.DeploymentKVPrefix + "/monitoring5/topology/types/yorc.policies.monitoring.TCPMonitoring/derived_from": []byte("yorc.policies.Monitoring"),
+		consulutil.DeploymentKVPrefix + "/monitoring5/topology/types/yorc.policies.monitoring.TCPMonitoring/targets": []byte("		tosca.nodes.Compute,tosca.nodes.SoftwareComponent"),
+		consulutil.DeploymentKVPrefix + "/monitoring5/topology/policies/TCPMonitoring/properties/port":          []byte("22"),
+		consulutil.DeploymentKVPrefix + "/monitoring5/topology/policies/TCPMonitoring/properties/time_interval": []byte("1s"),
+		consulutil.DeploymentKVPrefix + "/monitoring5/topology/policies/TCPMonitoring/targets":                  []byte("Compute1"),
+		consulutil.DeploymentKVPrefix + "/monitoring5/topology/policies/TCPMonitoring/type":                     []byte("yorc.policies.monitoring.TCPMonitoring"),
+
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/tosca.nodes.Root/name":                     []byte("tosca.nodes.Root"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/tosca.nodes.Compute/derived_from":          []byte("tosca.nodes.Root"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/yorc.nodes.Compute/derived_from":           []byte("tosca.nodes.Compute"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/yorc.nodes.openstack.Compute/derived_from": []byte("yorc.nodes.Compute"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/nodes/Compute1/type":                             []byte("yorc.nodes.openstack.Compute"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/instances/Compute1/0/attributes/ip_address":      []byte("1.2.3.4"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/instances/Compute1/0/attributes/state":           []byte("started"),
 
 		consulutil.DeploymentKVPrefix + "/monitoring2/topology/types/tosca.nodes.Root/name":                     []byte("tosca.nodes.Root"),
 		consulutil.DeploymentKVPrefix + "/monitoring2/topology/types/tosca.nodes.Compute/derived_from":          []byte("tosca.nodes.Root"),
@@ -59,21 +83,19 @@ func TestRunConsulMonitoringPackageTests(t *testing.T) {
 		consulutil.DeploymentKVPrefix + "/monitoring2/topology/types/yorc.nodes.openstack.Compute/derived_from": []byte("yorc.nodes.Compute"),
 		consulutil.DeploymentKVPrefix + "/monitoring2/topology/nodes/Compute1/type":                             []byte("yorc.nodes.openstack.Compute"),
 
-		consulutil.DeploymentKVPrefix + "/monitoring3/topology/types/tosca.nodes.Root/name":                      []byte("tosca.nodes.Root"),
-		consulutil.DeploymentKVPrefix + "/monitoring3/topology/types/tosca.nodes.Compute/derived_from":           []byte("tosca.nodes.Root"),
-		consulutil.DeploymentKVPrefix + "/monitoring3/topology/types/yorc.nodes.Compute/derived_from":            []byte("tosca.nodes.Compute"),
-		consulutil.DeploymentKVPrefix + "/monitoring3/topology/types/yorc.nodes.openstack.Compute/derived_from":  []byte("yorc.nodes.Compute"),
-		consulutil.DeploymentKVPrefix + "/monitoring3/topology/nodes/Compute1/type":                              []byte("yorc.nodes.openstack.Compute"),
-		consulutil.DeploymentKVPrefix + "/monitoring3/topology/nodes/Compute1/metadata/monitoring_time_interval": []byte("0"),
+		consulutil.DeploymentKVPrefix + "/monitoring3/topology/types/tosca.nodes.Root/name":                     []byte("tosca.nodes.Root"),
+		consulutil.DeploymentKVPrefix + "/monitoring3/topology/types/tosca.nodes.Compute/derived_from":          []byte("tosca.nodes.Root"),
+		consulutil.DeploymentKVPrefix + "/monitoring3/topology/types/yorc.nodes.Compute/derived_from":           []byte("tosca.nodes.Compute"),
+		consulutil.DeploymentKVPrefix + "/monitoring3/topology/types/yorc.nodes.openstack.Compute/derived_from": []byte("yorc.nodes.Compute"),
+		consulutil.DeploymentKVPrefix + "/monitoring3/topology/nodes/Compute1/type":                             []byte("yorc.nodes.openstack.Compute"),
 
-		consulutil.DeploymentKVPrefix + "/monitoring5/topology/types/tosca.nodes.Root/name":                      []byte("tosca.nodes.Root"),
-		consulutil.DeploymentKVPrefix + "/monitoring5/topology/types/tosca.nodes.Compute/derived_from":           []byte("tosca.nodes.Root"),
-		consulutil.DeploymentKVPrefix + "/monitoring5/topology/types/yorc.nodes.Compute/derived_from":            []byte("tosca.nodes.Compute"),
-		consulutil.DeploymentKVPrefix + "/monitoring5/topology/types/yorc.nodes.openstack.Compute/derived_from":  []byte("yorc.nodes.Compute"),
-		consulutil.DeploymentKVPrefix + "/monitoring5/topology/nodes/Compute1/type":                              []byte("yorc.nodes.openstack.Compute"),
-		consulutil.DeploymentKVPrefix + "/monitoring5/topology/nodes/Compute1/metadata/monitoring_time_interval": []byte("1"),
-		consulutil.DeploymentKVPrefix + "/monitoring5/topology/instances/Compute1/0/attributes/ip_address":       []byte("1.2.3.4"),
-		consulutil.DeploymentKVPrefix + "/monitoring5/topology/instances/Compute1/0/attributes/state":            []byte("started"),
+		consulutil.DeploymentKVPrefix + "/monitoring5/topology/types/tosca.nodes.Root/name":                     []byte("tosca.nodes.Root"),
+		consulutil.DeploymentKVPrefix + "/monitoring5/topology/types/tosca.nodes.Compute/derived_from":          []byte("tosca.nodes.Root"),
+		consulutil.DeploymentKVPrefix + "/monitoring5/topology/types/yorc.nodes.Compute/derived_from":           []byte("tosca.nodes.Compute"),
+		consulutil.DeploymentKVPrefix + "/monitoring5/topology/types/yorc.nodes.openstack.Compute/derived_from": []byte("yorc.nodes.Compute"),
+		consulutil.DeploymentKVPrefix + "/monitoring5/topology/nodes/Compute1/type":                             []byte("yorc.nodes.openstack.Compute"),
+		consulutil.DeploymentKVPrefix + "/monitoring5/topology/instances/Compute1/0/attributes/ip_address":      []byte("1.2.3.4"),
+		consulutil.DeploymentKVPrefix + "/monitoring5/topology/instances/Compute1/0/attributes/state":           []byte("started"),
 	})
 
 	t.Run("groupMonitoring", func(t *testing.T) {
@@ -83,7 +105,7 @@ func TestRunConsulMonitoringPackageTests(t *testing.T) {
 		t.Run("testIsMonitoringRequiredWithNoPolicy", func(t *testing.T) {
 			testIsMonitoringRequiredWithNoPolicy(t, client)
 		})
-		t.Run("testIsMonitoringRequiredWithNoPolicy", func(t *testing.T) {
+		t.Run("testIsMonitoringRequiredWithNoPolicyForTarget", func(t *testing.T) {
 			testIsMonitoringRequiredWithNoPolicyForTarget(t, client)
 		})
 		t.Run("testAddAndRemoveCheck", func(t *testing.T) {

--- a/prov/monitoring/consul_test.go
+++ b/prov/monitoring/consul_test.go
@@ -24,6 +24,7 @@ import (
 
 // The aim of this function is to run all package tests with consul server dependency with only one consul server start
 func TestRunConsulMonitoringPackageTests(t *testing.T) {
+	t.Skip()
 	srv, client := testutil.NewTestConsulInstance(t)
 
 	cfg := config.Configuration{
@@ -79,11 +80,11 @@ func TestRunConsulMonitoringPackageTests(t *testing.T) {
 		t.Run("testComputeMonitoringHook", func(t *testing.T) {
 			testComputeMonitoringHook(t, client, config.Configuration{})
 		})
-		t.Run("testHandleMonitoringWithoutMonitoringRequiredWithNoTimeInterval", func(t *testing.T) {
-			testIsMonitoringRequiredWithNoTimeInterval(t, client)
+		t.Run("testIsMonitoringRequiredWithNoPolicy", func(t *testing.T) {
+			testIsMonitoringRequiredWithNoPolicy(t, client)
 		})
-		t.Run("testHandleMonitoringWithoutMonitoringRequiredWithZeroTimeInterval", func(t *testing.T) {
-			testIsMonitoringRequiredWithZeroTimeInterval(t, client)
+		t.Run("testIsMonitoringRequiredWithNoPolicy", func(t *testing.T) {
+			testIsMonitoringRequiredWithNoPolicyForTarget(t, client)
 		})
 		t.Run("testAddAndRemoveCheck", func(t *testing.T) {
 			testAddAndRemoveCheck(t, client)

--- a/prov/monitoring/monitoring_hooks.go
+++ b/prov/monitoring/monitoring_hooks.go
@@ -1,0 +1,117 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"context"
+	"github.com/ystia/yorc/v3/config"
+	"github.com/ystia/yorc/v3/deployments"
+	"github.com/ystia/yorc/v3/events"
+	"github.com/ystia/yorc/v3/tasks"
+	"github.com/ystia/yorc/v3/tasks/workflow"
+	"github.com/ystia/yorc/v3/tasks/workflow/builder"
+	"github.com/ystia/yorc/v3/tosca"
+	"strings"
+)
+
+func init() {
+	workflow.RegisterPreActivityHook(removeMonitoringHook)
+	workflow.RegisterPostActivityHook(addMonitoringHook)
+}
+
+func addMonitoringHook(ctx context.Context, cfg config.Configuration, taskID, deploymentID, target string, activity builder.Activity) {
+	// Monitoring check are added after (post-hook):
+	// - Delegate activity and install operation
+	// - SetState activity and node state "Started"
+
+	switch {
+	case activity.Type() == builder.ActivityTypeDelegate && strings.ToLower(activity.Value()) == "install",
+		activity.Type() == builder.ActivityTypeSetState && activity.Value() == tosca.NodeStateStarted.String():
+
+		// Check if monitoring is required
+		isMonitorReq, monitoringInterval, err := defaultMonManager.isMonitoringRequired(deploymentID, target)
+		if err != nil {
+			events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
+				Registerf("Failed to check if monitoring is required for node name:%q due to: %v", target, err)
+			return
+		}
+		if !isMonitorReq {
+			return
+		}
+
+		instances, err := tasks.GetInstances(defaultMonManager.cc.KV(), taskID, deploymentID, target)
+		if err != nil {
+			events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
+				Registerf("Failed to retrieve instances for node name:%q due to: %v", target, err)
+			return
+		}
+
+		for _, instance := range instances {
+			ipAddress, err := deployments.GetInstanceAttributeValue(defaultMonManager.cc.KV(), deploymentID, target, instance, "ip_address")
+			if err != nil {
+				events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
+					Registerf("Failed to retrieve ip_address for node name:%q due to: %v", target, err)
+				return
+			}
+			if ipAddress == nil || ipAddress.RawString() == "" {
+				events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
+					Registerf("No attribute ip_address has been found for nodeName:%q, instance:%q with deploymentID:%q", target, instance, deploymentID)
+				return
+			}
+
+			if err := defaultMonManager.registerTCPCheck(deploymentID, target, instance, ipAddress.RawString(), 22, monitoringInterval); err != nil {
+				events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
+					Registerf("Failed to register check for node name:%q due to: %v", target, err)
+				return
+			}
+		}
+	}
+}
+
+func removeMonitoringHook(ctx context.Context, cfg config.Configuration, taskID, deploymentID, target string, activity builder.Activity) {
+	// Monitoring check are removed before (pre-hook):
+	// - Delegate activity and uninstall operation
+	// - SetState activity and node state "Deleted"
+	switch {
+	case activity.Type() == builder.ActivityTypeDelegate && strings.ToLower(activity.Value()) == "uninstall",
+		activity.Type() == builder.ActivityTypeSetState && activity.Value() == tosca.NodeStateDeleted.String():
+
+		// Check if monitoring has been required
+		isMonitorReq, _, err := defaultMonManager.isMonitoringRequired(deploymentID, target)
+		if err != nil {
+			events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
+				Registerf("Failed to check if monitoring is required for node name:%q due to: %v", target, err)
+			return
+		}
+		if !isMonitorReq {
+			return
+		}
+
+		instances, err := tasks.GetInstances(defaultMonManager.cc.KV(), taskID, deploymentID, target)
+		if err != nil {
+			events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
+				Registerf("Failed to retrieve instances for node name:%q due to: %v", target, err)
+			return
+		}
+
+		for _, instance := range instances {
+			if err := defaultMonManager.flagCheckForRemoval(deploymentID, target, instance); err != nil {
+				events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
+					Registerf("Failed to unregister check for node name:%q due to: %v", target, err)
+				return
+			}
+		}
+	}
+}

--- a/prov/monitoring/monitoring_hooks.go
+++ b/prov/monitoring/monitoring_hooks.go
@@ -16,20 +16,31 @@ package monitoring
 
 import (
 	"context"
+	"github.com/hashicorp/consul/api"
+	"github.com/pkg/errors"
 	"github.com/ystia/yorc/v3/config"
 	"github.com/ystia/yorc/v3/deployments"
 	"github.com/ystia/yorc/v3/events"
+	"github.com/ystia/yorc/v3/log"
 	"github.com/ystia/yorc/v3/tasks"
 	"github.com/ystia/yorc/v3/tasks/workflow"
 	"github.com/ystia/yorc/v3/tasks/workflow/builder"
 	"github.com/ystia/yorc/v3/tosca"
+	"strconv"
 	"strings"
+	"time"
 )
 
 func init() {
 	workflow.RegisterPreActivityHook(removeMonitoringHook)
 	workflow.RegisterPostActivityHook(addMonitoringHook)
 }
+
+const (
+	httpMonitoring = "yorc.policies.monitoring.HTTPMonitoring"
+	tcpMonitoring  = "yorc.policies.monitoring.TCPMonitoring"
+	baseMonitoring = "yorc.policies.Monitoring"
+)
 
 func addMonitoringHook(ctx context.Context, cfg config.Configuration, taskID, deploymentID, target string, activity builder.Activity) {
 	// Monitoring check are added after (post-hook):
@@ -41,7 +52,7 @@ func addMonitoringHook(ctx context.Context, cfg config.Configuration, taskID, de
 		activity.Type() == builder.ActivityTypeSetState && activity.Value() == tosca.NodeStateStarted.String():
 
 		// Check if monitoring is required
-		isMonitorReq, monitoringInterval, err := defaultMonManager.isMonitoringRequired(deploymentID, target)
+		isMonitorReq, policyName, err := checkExistingMonitoringPolicy(defaultMonManager.cc.KV(), deploymentID, target)
 		if err != nil {
 			events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
 				Registerf("Failed to check if monitoring is required for node name:%q due to: %v", target, err)
@@ -51,31 +62,10 @@ func addMonitoringHook(ctx context.Context, cfg config.Configuration, taskID, de
 			return
 		}
 
-		instances, err := tasks.GetInstances(defaultMonManager.cc.KV(), taskID, deploymentID, target)
+		err = addMonitoringPolicyForTarget(defaultMonManager.cc.KV(), taskID, deploymentID, target, policyName)
 		if err != nil {
 			events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
-				Registerf("Failed to retrieve instances for node name:%q due to: %v", target, err)
-			return
-		}
-
-		for _, instance := range instances {
-			ipAddress, err := deployments.GetInstanceAttributeValue(defaultMonManager.cc.KV(), deploymentID, target, instance, "ip_address")
-			if err != nil {
-				events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
-					Registerf("Failed to retrieve ip_address for node name:%q due to: %v", target, err)
-				return
-			}
-			if ipAddress == nil || ipAddress.RawString() == "" {
-				events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
-					Registerf("No attribute ip_address has been found for nodeName:%q, instance:%q with deploymentID:%q", target, instance, deploymentID)
-				return
-			}
-
-			if err := defaultMonManager.registerTCPCheck(deploymentID, target, instance, ipAddress.RawString(), 22, monitoringInterval); err != nil {
-				events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
-					Registerf("Failed to register check for node name:%q due to: %v", target, err)
-				return
-			}
+				Registerf("Failed to add monitoring policy for node name:%q due to: %v", target, err)
 		}
 	}
 }
@@ -89,7 +79,7 @@ func removeMonitoringHook(ctx context.Context, cfg config.Configuration, taskID,
 		activity.Type() == builder.ActivityTypeSetState && activity.Value() == tosca.NodeStateDeleted.String():
 
 		// Check if monitoring has been required
-		isMonitorReq, _, err := defaultMonManager.isMonitoringRequired(deploymentID, target)
+		isMonitorReq, _, err := checkExistingMonitoringPolicy(defaultMonManager.cc.KV(), deploymentID, target)
 		if err != nil {
 			events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
 				Registerf("Failed to check if monitoring is required for node name:%q due to: %v", target, err)
@@ -114,4 +104,77 @@ func removeMonitoringHook(ctx context.Context, cfg config.Configuration, taskID,
 			}
 		}
 	}
+}
+
+func checkExistingMonitoringPolicy(kv *api.KV, deploymentID, target string) (bool, string, error) {
+	policies, err := deployments.GetPoliciesForTypeAndNode(kv, deploymentID, baseMonitoring, target)
+	if err != nil {
+		return false, "", err
+	}
+	if len(policies) == 0 {
+		return false, "", nil
+	}
+	if len(policies) > 1 {
+		return false, "", errors.Errorf("Found more than one monitoring policy to apply to node name:%q. No monitoring policy will be applied", target)
+	}
+
+	return true, policies[0], nil
+}
+
+func addMonitoringPolicyForTarget(kv *api.KV, taskID, deploymentID, target, policyName string) error {
+	log.Debugf("Add monitoring policy:%q for deploymentID:%q, node name:%q", policyName, deploymentID, target)
+	policyType, err := deployments.GetPolicyType(kv, deploymentID, policyName)
+	if err != nil {
+		return err
+	}
+
+	// Retrieve time_interval and port
+	tiValue, err := deployments.GetPolicyPropertyValue(kv, deploymentID, policyName, "time_interval")
+	if err != nil || tiValue == nil || tiValue.RawString() == "" {
+		return errors.Errorf("Failed to retrieve time_interval for monitoring policy:%q due to: %v", policyName, err)
+	}
+
+	timeInterval, err := time.ParseDuration(tiValue.RawString())
+	if err != nil {
+		return errors.Errorf("Failed to retrieve time_interval as correct duration for monitoring policy:%q due to: %v", policyName, err)
+	}
+	portValue, err := deployments.GetPolicyPropertyValue(kv, deploymentID, policyName, "port")
+	if err != nil || portValue == nil || portValue.RawString() == "" {
+		return errors.Errorf("Failed to retrieve port for monitoring policy:%q due to: %v", policyName, err)
+	}
+	port, err := strconv.Atoi(portValue.RawString())
+	if err != nil {
+		return errors.Errorf("Failed to retrieve port as correct integer for monitoring policy:%q due to: %v", policyName, err)
+	}
+	instances, err := tasks.GetInstances(defaultMonManager.cc.KV(), taskID, deploymentID, target)
+	if err != nil {
+		return err
+	}
+
+	switch policyType {
+	case httpMonitoring:
+		//TODO
+		return nil
+	case tcpMonitoring:
+		return applyTCPMonitoringPolicy(deploymentID, target, timeInterval, port, instances)
+	default:
+		return errors.Errorf("Unsupported policy type:%q for policy:%q", policyType, policyName)
+	}
+}
+
+func applyTCPMonitoringPolicy(deploymentID, target string, timeInterval time.Duration, port int, instances []string) error {
+	for _, instance := range instances {
+		ipAddress, err := deployments.GetInstanceAttributeValue(defaultMonManager.cc.KV(), deploymentID, target, instance, "ip_address")
+		if err != nil {
+			return errors.Errorf("Failed to retrieve ip_address for node name:%q due to: %v", target, err)
+		}
+		if ipAddress == nil || ipAddress.RawString() == "" {
+			return errors.Errorf("No attribute ip_address has been found for nodeName:%q, instance:%q with deploymentID:%q", target, instance, deploymentID)
+		}
+
+		if err := defaultMonManager.registerTCPCheck(deploymentID, target, instance, ipAddress.RawString(), port, timeInterval); err != nil {
+			return errors.Errorf("Failed to register check for node name:%q due to: %v", target, err)
+		}
+	}
+	return nil
 }

--- a/prov/monitoring/monitoring_mgr.go
+++ b/prov/monitoring/monitoring_mgr.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 // Package monitoring is responsible for handling node monitoring (tcp and http checks) especially for tosca.nodes.Compute and tosca.nodes.SoftwareComponent node templates
 // Present limitation : only one monitoring check by node instance is allowed
 package monitoring

--- a/prov/monitoring/monitoring_mgr.go
+++ b/prov/monitoring/monitoring_mgr.go
@@ -349,6 +349,15 @@ func (mgr *monitoringMgr) registerHTTPCheck(deploymentID, nodeName, instance, ip
 	checkPath := path.Join(consulutil.MonitoringKVPrefix, "checks", id)
 	checkReportPath := path.Join(consulutil.MonitoringKVPrefix, "reports", id)
 
+	kvps, _, err := mgr.cc.KV().List(checkPath, nil)
+	if err != nil {
+		return err
+	}
+	if kvps != nil {
+		log.Debugf("HTTP check with id:%q is already registered: nothing to do", id)
+		return nil
+	}
+
 	checkOps := api.KVTxnOps{
 		&api.KVTxnOp{
 			Verb:  api.KVSet,

--- a/prov/monitoring/monitoring_mgr.go
+++ b/prov/monitoring/monitoring_mgr.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Known limitations
-// only public ip is used (no private ip)
-// only one monitoring check by node instance
+
+// Package monitoring is responsible for handling node monitoring (tcp and http checks) especially for tosca.nodes.Compute and tosca.nodes.SoftwareComponent node templates
+// Present limitation : only one monitoring check by node instance is allowed
 package monitoring
 
 import (

--- a/prov/monitoring/monitoring_mgr.go
+++ b/prov/monitoring/monitoring_mgr.go
@@ -321,7 +321,7 @@ func (mgr *monitoringMgr) registerTCPCheck(deploymentID, nodeName, instance, ipA
 		&api.KVTxnOp{
 			Verb:  api.KVSet,
 			Key:   path.Join(checkReportPath, "status"),
-			Value: []byte(CheckStatusPASSING.String()),
+			Value: []byte(CheckStatusINITIAL.String()),
 		},
 	}
 
@@ -378,7 +378,7 @@ func (mgr *monitoringMgr) registerHTTPCheck(deploymentID, nodeName, instance, ip
 		&api.KVTxnOp{
 			Verb:  api.KVSet,
 			Key:   path.Join(checkReportPath, "status"),
-			Value: []byte(CheckStatusPASSING.String()),
+			Value: []byte(CheckStatusINITIAL.String()),
 		},
 	}
 

--- a/prov/monitoring/monitoring_mgr.go
+++ b/prov/monitoring/monitoring_mgr.go
@@ -378,12 +378,12 @@ func (mgr *monitoringMgr) flagCheckForRemoval(deploymentID, nodeName, instance s
 	id := buildID(deploymentID, nodeName, instance)
 	log.Debugf("PreUnregisterCheck check with id:%q", id)
 	checkPath := path.Join(consulutil.MonitoringKVPrefix, "checks", id)
-	kvp, _, err := mgr.cc.KV().Get(checkPath, nil)
+	kvps, _, err := mgr.cc.KV().List(checkPath, nil)
 	if err != nil {
 		return err
 	}
-	if kvp == nil || string(kvp.Value) == "" {
-		// nothing to do : the check hasn't been registered
+	if kvps == nil || len(kvps) == 0 {
+		// nothing to do : the check hasn't been registered or has already been removed
 		return nil
 	}
 	return consulutil.StoreConsulKeyAsString(path.Join(checkPath, ".unregisterFlag"), "true")

--- a/prov/monitoring/monitoring_mgr_test.go
+++ b/prov/monitoring/monitoring_mgr_test.go
@@ -112,7 +112,7 @@ func testAddAndRemoveCheck(t *testing.T, client *api.Client) {
 	instance := "0"
 	expectedCheck := NewCheck(dep, node, instance)
 
-	err := defaultMonManager.registerCheck(dep, node, instance, "1.2.3.4", 22, 1*time.Second)
+	err := defaultMonManager.registerTCPCheck(dep, node, instance, "1.2.3.4", 22, 1*time.Second)
 	require.Nil(t, err, "Unexpected error while adding check")
 
 	time.Sleep(2 * time.Second)

--- a/prov/monitoring/monitoring_mgr_test.go
+++ b/prov/monitoring/monitoring_mgr_test.go
@@ -90,16 +90,16 @@ func testComputeMonitoringHook(t *testing.T, client *api.Client, cfg config.Conf
 	require.Len(t, defaultMonManager.checks, 0, "0 check is expected in work map")
 }
 
-func testIsMonitoringRequiredWithNoTimeInterval(t *testing.T, client *api.Client) {
+func testIsMonitoringRequiredWithNoPolicy(t *testing.T, client *api.Client) {
 	t.Parallel()
-	is, _, err := defaultMonManager.isMonitoringRequired("monitoring2", "Compute1")
+	is, _, err := checkExistingMonitoringPolicy(client.KV(), "monitoring2", "Compute1")
 	require.Nil(t, err, "Unexpected error during isMonitoringRequired function")
 	require.Equal(t, false, is, "unexpected monitoring required")
 }
 
-func testIsMonitoringRequiredWithZeroTimeInterval(t *testing.T, client *api.Client) {
+func testIsMonitoringRequiredWithNoPolicyForTarget(t *testing.T, client *api.Client) {
 	t.Parallel()
-	is, _, err := defaultMonManager.isMonitoringRequired("monitoring3", "Compute1")
+	is, _, err := checkExistingMonitoringPolicy(client.KV(), "monitoring3", "Compute1")
 	require.Nil(t, err, "Unexpected error during isMonitoringRequired function")
 	require.Equal(t, false, is, "unexpected monitoring required")
 }

--- a/prov/monitoring/monitoring_structs.go
+++ b/prov/monitoring/monitoring_structs.go
@@ -16,7 +16,6 @@ package monitoring
 
 import (
 	"context"
-	"net/http"
 	"sync"
 	"time"
 )
@@ -36,21 +35,6 @@ type CheckStatus int
 // )
 type CheckType int
 
-type tcpConnection struct {
-	address string
-	port    int
-}
-
-type httpConnection struct {
-	httpClient *http.Client
-	scheme     string
-	address    string
-	port       int
-	path       string
-	headersMap map[string]string
-	header     http.Header
-}
-
 // Check represents a registered check
 type Check struct {
 	ID           string
@@ -58,13 +42,12 @@ type Check struct {
 	Report       CheckReport
 	CheckType    CheckType
 
-	tcpConn  tcpConnection
-	httpConn httpConnection
-	stop     bool
-	stopLock sync.Mutex
-	chStop   chan struct{}
-	timeout  time.Duration
-	ctx      context.Context
+	stop      bool
+	stopLock  sync.Mutex
+	chStop    chan struct{}
+	timeout   time.Duration
+	ctx       context.Context
+	execution checkExecution
 }
 
 // CheckReport represents a node check report including its status

--- a/prov/monitoring/monitoring_structs.go
+++ b/prov/monitoring/monitoring_structs.go
@@ -23,6 +23,7 @@ import (
 //go:generate go-enum -f=monitoring_structs.go --lower
 
 // CheckStatus x ENUM(
+// INITIAL,
 // PASSING,
 // CRITICAL
 // WARNING

--- a/prov/monitoring/monitoring_structs.go
+++ b/prov/monitoring/monitoring_structs.go
@@ -44,8 +44,10 @@ type Check struct {
 	CheckType    CheckType
 
 	stop      bool
+	enabled   bool
 	stopLock  sync.Mutex
 	chStop    chan struct{}
+	chDisable chan struct{}
 	timeout   time.Duration
 	ctx       context.Context
 	execution checkExecution

--- a/prov/monitoring/monitoring_structs.go
+++ b/prov/monitoring/monitoring_structs.go
@@ -16,6 +16,7 @@ package monitoring
 
 import (
 	"context"
+	"net/http"
 	"sync"
 	"time"
 )
@@ -25,23 +26,40 @@ import (
 // CheckStatus x ENUM(
 // PASSING,
 // CRITICAL
+// WARNING
 // )
 type CheckStatus int
 
-const (
-	// PASSING is the status of a passing check
-	PASSING CheckStatus = iota
-	// CRITICAL is the status of a critical check
-	CRITICAL
-)
+// CheckType x ENUM(
+// TCP,
+// HTTP
+// )
+type CheckType int
+
+type tcpConnection struct {
+	address string
+	port    int
+}
+
+type httpConnection struct {
+	httpClient *http.Client
+	scheme     string
+	address    string
+	port       int
+	path       string
+	headersMap map[string]string
+	header     http.Header
+}
 
 // Check represents a registered check
 type Check struct {
 	ID           string
-	TCPAddress   string
 	TimeInterval time.Duration
 	Report       CheckReport
+	CheckType    CheckType
 
+	tcpConn  tcpConnection
+	httpConn httpConnection
 	stop     bool
 	stopLock sync.Mutex
 	chStop   chan struct{}

--- a/prov/monitoring/monitoring_structs_enum.go
+++ b/prov/monitoring/monitoring_structs_enum.go
@@ -23,20 +23,23 @@ import (
 )
 
 const (
+	// CheckStatusINITIAL is a CheckStatus of type INITIAL
+	CheckStatusINITIAL CheckStatus = iota
 	// CheckStatusPASSING is a CheckStatus of type PASSING
-	CheckStatusPASSING CheckStatus = iota
+	CheckStatusPASSING
 	// CheckStatusCRITICAL is a CheckStatus of type CRITICAL
 	CheckStatusCRITICAL
 	// CheckStatusWARNING is a CheckStatus of type WARNING
 	CheckStatusWARNING
 )
 
-const _CheckStatusName = "PASSINGCRITICALWARNING"
+const _CheckStatusName = "INITIALPASSINGCRITICALWARNING"
 
 var _CheckStatusMap = map[CheckStatus]string{
 	0: _CheckStatusName[0:7],
-	1: _CheckStatusName[7:15],
-	2: _CheckStatusName[15:22],
+	1: _CheckStatusName[7:14],
+	2: _CheckStatusName[14:22],
+	3: _CheckStatusName[22:29],
 }
 
 func (i CheckStatus) String() string {
@@ -49,10 +52,12 @@ func (i CheckStatus) String() string {
 var _CheckStatusValue = map[string]CheckStatus{
 	_CheckStatusName[0:7]:                    0,
 	strings.ToLower(_CheckStatusName[0:7]):   0,
-	_CheckStatusName[7:15]:                   1,
-	strings.ToLower(_CheckStatusName[7:15]):  1,
-	_CheckStatusName[15:22]:                  2,
-	strings.ToLower(_CheckStatusName[15:22]): 2,
+	_CheckStatusName[7:14]:                   1,
+	strings.ToLower(_CheckStatusName[7:14]):  1,
+	_CheckStatusName[14:22]:                  2,
+	strings.ToLower(_CheckStatusName[14:22]): 2,
+	_CheckStatusName[22:29]:                  3,
+	strings.ToLower(_CheckStatusName[22:29]): 3,
 }
 
 // ParseCheckStatus attempts to convert a string to a CheckStatus

--- a/prov/monitoring/monitoring_structs_enum.go
+++ b/prov/monitoring/monitoring_structs_enum.go
@@ -27,13 +27,16 @@ const (
 	CheckStatusPASSING CheckStatus = iota
 	// CheckStatusCRITICAL is a CheckStatus of type CRITICAL
 	CheckStatusCRITICAL
+	// CheckStatusWARNING is a CheckStatus of type WARNING
+	CheckStatusWARNING
 )
 
-const _CheckStatusName = "PASSINGCRITICAL"
+const _CheckStatusName = "PASSINGCRITICALWARNING"
 
 var _CheckStatusMap = map[CheckStatus]string{
 	0: _CheckStatusName[0:7],
 	1: _CheckStatusName[7:15],
+	2: _CheckStatusName[15:22],
 }
 
 func (i CheckStatus) String() string {
@@ -44,10 +47,12 @@ func (i CheckStatus) String() string {
 }
 
 var _CheckStatusValue = map[string]CheckStatus{
-	_CheckStatusName[0:7]:                   0,
-	strings.ToLower(_CheckStatusName[0:7]):  0,
-	_CheckStatusName[7:15]:                  1,
-	strings.ToLower(_CheckStatusName[7:15]): 1,
+	_CheckStatusName[0:7]:                    0,
+	strings.ToLower(_CheckStatusName[0:7]):   0,
+	_CheckStatusName[7:15]:                   1,
+	strings.ToLower(_CheckStatusName[7:15]):  1,
+	_CheckStatusName[15:22]:                  2,
+	strings.ToLower(_CheckStatusName[15:22]): 2,
 }
 
 // ParseCheckStatus attempts to convert a string to a CheckStatus
@@ -56,4 +61,40 @@ func ParseCheckStatus(name string) (CheckStatus, error) {
 		return CheckStatus(x), nil
 	}
 	return CheckStatus(0), fmt.Errorf("%s is not a valid CheckStatus", name)
+}
+
+const (
+	// CheckTypeTCP is a CheckType of type TCP
+	CheckTypeTCP CheckType = iota
+	// CheckTypeHTTP is a CheckType of type HTTP
+	CheckTypeHTTP
+)
+
+const _CheckTypeName = "TCPHTTP"
+
+var _CheckTypeMap = map[CheckType]string{
+	0: _CheckTypeName[0:3],
+	1: _CheckTypeName[3:7],
+}
+
+func (i CheckType) String() string {
+	if str, ok := _CheckTypeMap[i]; ok {
+		return str
+	}
+	return fmt.Sprintf("CheckType(%d)", i)
+}
+
+var _CheckTypeValue = map[string]CheckType{
+	_CheckTypeName[0:3]:                  0,
+	strings.ToLower(_CheckTypeName[0:3]): 0,
+	_CheckTypeName[3:7]:                  1,
+	strings.ToLower(_CheckTypeName[3:7]): 1,
+}
+
+// ParseCheckType attempts to convert a string to a CheckType
+func ParseCheckType(name string) (CheckType, error) {
+	if x, ok := _CheckTypeValue[name]; ok {
+		return CheckType(x), nil
+	}
+	return CheckType(0), fmt.Errorf("%s is not a valid CheckType", name)
 }

--- a/prov/terraform/openstack/osinstance.go
+++ b/prov/terraform/openstack/osinstance.go
@@ -352,11 +352,11 @@ func (g *osGenerator) generateOSInstance(ctx context.Context, kv *api.KV, cfg co
 	accessIPKey := nodeName + "-" + instanceName + "-IPAddress"
 	commons.AddOutput(infrastructure, accessIPKey, &commons.Output{Value: accessIP})
 	outputs[path.Join(instancesKey, instanceName, "/capabilities/endpoint/attributes/ip_address")] = accessIPKey
+	outputs[path.Join(instancesKey, instanceName, "/attributes/ip_address")] = accessIPKey
 
 	privateIPKey := nodeName + "-" + instanceName + "-privateIP"
 	privateIP := fmt.Sprintf("${openstack_compute_instance_v2.%s.network.%d.fixed_ip_v4}", instance.Name, len(instance.Networks)-1) // Use latest provisioned network for private access
 	commons.AddOutput(infrastructure, privateIPKey, &commons.Output{Value: privateIP})
-	outputs[path.Join(instancesKey, instanceName, "/attributes/ip_address")] = privateIPKey
 	outputs[path.Join(instancesKey, instanceName, "/attributes/private_address")] = privateIPKey
 
 	err = addServerGroupMembership(ctx, kv, deploymentID, nodeName, &instance)

--- a/tosca/topology.go
+++ b/tosca/topology.go
@@ -59,7 +59,7 @@ type TopologyTemplate struct {
 	Outputs            map[string]ParameterDefinition `yaml:"outputs,omitempty"`
 	SubstitionMappings *SubstitutionMapping           `yaml:"substitution_mappings,omitempty"`
 	Workflows          map[string]Workflow
-	Policies           []PolicyMap                    `yaml:"policies,omitempty"`
+	Policies           []PolicyMap `yaml:"policies,omitempty"`
 	//RelationshipTemplates []RelationshipTemplate `yaml:"relationship_templates,omitempty"`
 	//Groups                []Group `yaml:",omitempty"`
 }

--- a/tosca/topology.go
+++ b/tosca/topology.go
@@ -44,7 +44,7 @@ type Topology struct {
 	CapabilityTypes   map[string]CapabilityType   `yaml:"capability_types,omitempty"`
 	RelationshipTypes map[string]RelationshipType `yaml:"relationship_types,omitempty"`
 	// TODO Group Types
-	// TODO Policy Types
+	PolicyTypes map[string]PolicyType `yaml:"policy_types,omitempty"`
 
 	TopologyTemplate TopologyTemplate `yaml:"topology_template"`
 }

--- a/tosca/topology.go
+++ b/tosca/topology.go
@@ -59,9 +59,9 @@ type TopologyTemplate struct {
 	Outputs            map[string]ParameterDefinition `yaml:"outputs,omitempty"`
 	SubstitionMappings *SubstitutionMapping           `yaml:"substitution_mappings,omitempty"`
 	Workflows          map[string]Workflow
+	Policies           []PolicyMap                    `yaml:"policies,omitempty"`
 	//RelationshipTemplates []RelationshipTemplate `yaml:"relationship_templates,omitempty"`
 	//Groups                []Group `yaml:",omitempty"`
-	//Policies              []Policy                 `yaml:",omitempty"`
 }
 
 // An NodeTemplate is the representation of a TOSCA Node Template
@@ -98,3 +98,17 @@ type Credential struct {
 	Protocol  string            `yaml:"protocol,omitempty"`
 	Keys      map[string]string `yaml:"keys,omitempty"`
 }
+
+// A Policy represents a Tosca Policy definition
+// See https://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.2/os/TOSCA-Simple-Profile-YAML-v1.2-os.html#DEFN_ELEMENT_POLICY_DEF
+// for the first implementation, we don't handle triggers
+type Policy struct {
+	Type        string                      `yaml:"type"`
+	Description string                      `yaml:"description,omitempty"`
+	Targets     []string                    `yaml:"targets,omitempty"`
+	Properties  map[string]*ValueAssignment `yaml:"properties,omitempty"`
+	Metadata    map[string]string           `yaml:"metadata,omitempty"`
+}
+
+// PolicyMap is a map of Policy indexed by policy name
+type PolicyMap map[string]Policy

--- a/tosca/types.go
+++ b/tosca/types.go
@@ -108,3 +108,14 @@ type DataType struct {
 	// Constraints not enforced in Yorc so we don't parse them
 	// Constraints []ConstraintClause
 }
+
+// A PolicyType is the representation of a TOSCA Policy Type
+//
+// See http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.2/TOSCA-Simple-Profile-YAML-v1.2.html#DEFN_ENTITY_POLICY_TYPE
+// Triggers are not supported
+// for more details
+type PolicyType struct {
+	Type       `yaml:",inline"`
+	Properties map[string]PropertyDefinition `yaml:"properties,omitempty"`
+	Targets    []string                      `yaml:"targets,omitempty,flow"`
+}


### PR DESCRIPTION
# Pull Request description
Monitor deployed services liveness#104
As: an app manager
I want to: know which of my deployed services are up and down
So that: I can trigger some operations to get them up

AC1: statuses could be retrieved using the REST API for an integration with other systems (may be A4C)
AC2: limited to HTTP/TCP checks for this first version
AC3: Based on TOSCA policies applied to nodes

## Description of the change
#### Yorc side
- Add **yorc.policies.Monitoring** policy type
- Add **yorc.policies.monitoring.HTTPMonitoring** policy type
- Add **yorc.policies.monitoring.TCPMonitoring** policy type
- Pass yorc-types to 1.1.0 version
- Store policies (types and templates) in Consul
- Add policies API to handle deployment policies (GetPoliciesForTypeAndNode, GetPolicyPropertyValue, GetPolicyType, IsTargetForPolicy, GetPolicyTargets, GetPolicyTargetsForType)
- Refactor monitoring hooks to lookup deployment policies and register TCP/HTTP checks (remove the previous compute TCP monitoring version)
- Add tcpCheckExecution and httpCheckExecution to execute check
#### Alien side
- Add modifier to check only one policy is applied on a node name and targets field is set and are valids
- Add documentation on how-to use HTTP monitoring policy
### How to verify it
- Follow the Alien plugin documentation to monitor Welcome Application.
- Use secured yorc topology to check HTTP monitoring with TLS client config
(for example, if you check the /health url, you need to add a HTTP header in the policy config in order to accept appllcation/json content)

### Description for the changelog
* Monitor deployed services liveness ([GH-104](https://github.com/ystia/yorc/issues/104))
## Applicable Issues
#104 