### PR TITLE
Force purge to delete deployment with inconsistent topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 * Upgrade Ansible to 2.7.9 ([GH-364](https://github.com/ystia/yorc/issues/364))
 
+### BUG FIXES
+
+* Unable to delete a deployment with non-conform topology ([GH-368](https://github.com/ystia/yorc/issues/368))
+
 ## 3.2.0-M4 (March 29, 2019)
 
 ### ENHANCEMENTS

--- a/deployments/deployments.go
+++ b/deployments/deployments.go
@@ -43,6 +43,26 @@ func IsDeploymentNotFoundError(err error) bool {
 	return ok
 }
 
+type inconsistentDeploymentError struct {
+	deploymentID string
+}
+
+func (t inconsistentDeploymentError) Error() string {
+	return fmt.Sprintf("Inconsistent deployment with ID %q", t.deploymentID)
+}
+
+// IsInconsistentDeploymentError checks if an error is an inconsistent deployment error
+func IsInconsistentDeploymentError(err error) bool {
+	cause := errors.Cause(err)
+	_, ok := cause.(inconsistentDeploymentError)
+	return ok
+}
+
+// NewInconsistentDeploymentError allows to create a new inconsistentDeploymentError error
+func NewInconsistentDeploymentError(deploymentID string) error {
+	return inconsistentDeploymentError{deploymentID: deploymentID}
+}
+
 // DeploymentStatusFromString returns a DeploymentStatus from its textual representation.
 //
 // If ignoreCase is 'true' the given status is upper cased to match the generated status strings.

--- a/rest/deployments.go
+++ b/rest/deployments.go
@@ -258,7 +258,7 @@ func (s *Server) deleteDeploymentHandler(w http.ResponseWriter, r *http.Request)
 		}
 
 		// Inconsistent deployment: force purge enters in action
-		if ok := tasks.IsInconsistentDeployment(err); ok {
+		if ok := tasks.IsInconsistentDeploymentError(err); ok {
 			log.Debugf("inconsistent deployment with ID:%q. We force purge it.", id)
 			newTaskID, err := s.tasksCollector.RegisterTask(id, tasks.TaskTypeForcePurge)
 			if err != nil {

--- a/rest/deployments.go
+++ b/rest/deployments.go
@@ -258,7 +258,7 @@ func (s *Server) deleteDeploymentHandler(w http.ResponseWriter, r *http.Request)
 		}
 
 		// Inconsistent deployment: force purge enters in action
-		if ok := tasks.IsInconsistentDeploymentError(err); ok {
+		if ok := deployments.IsInconsistentDeploymentError(err); ok {
 			log.Debugf("inconsistent deployment with ID:%q. We force purge it.", id)
 			newTaskID, err := s.tasksCollector.RegisterTask(id, tasks.TaskTypeForcePurge)
 			if err != nil {

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -47,11 +47,6 @@ func NewAnotherLivingTaskAlreadyExistsError(taskID, targetID, status string) err
 	return anotherLivingTaskAlreadyExistsError{taskID: taskID, targetID: targetID, status: status}
 }
 
-// NewInconsistentDeploymentError allows to create a new inconsistentDeploymentError error
-func NewInconsistentDeploymentError(deploymentID string) error {
-	return inconsistentDeploymentError{deploymentID: deploymentID}
-}
-
 // IsAnotherLivingTaskAlreadyExistsError checks if an error is due to the fact that another task is currently running
 // If true, it returns the taskID of the currently running task
 func IsAnotherLivingTaskAlreadyExistsError(err error) (bool, string) {
@@ -74,21 +69,6 @@ type taskDataNotFound struct {
 
 func (t taskDataNotFound) Error() string {
 	return fmt.Sprintf("Data %q not found for task %q", t.name, t.taskID)
-}
-
-type inconsistentDeploymentError struct {
-	deploymentID string
-}
-
-func (t inconsistentDeploymentError) Error() string {
-	return fmt.Sprintf("Inconsistent deployment with ID %q", t.deploymentID)
-}
-
-// IsInconsistentDeploymentError checks if an error is an inconsistent deployment error
-func IsInconsistentDeploymentError(err error) bool {
-	cause := errors.Cause(err)
-	_, ok := cause.(inconsistentDeploymentError)
-	return ok
 }
 
 // IsTaskDataNotFoundError checks if an error is a task data not found error

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -47,6 +47,11 @@ func NewAnotherLivingTaskAlreadyExistsError(taskID, targetID, status string) err
 	return anotherLivingTaskAlreadyExistsError{taskID: taskID, targetID: targetID, status: status}
 }
 
+// NewInconsistentDeploymentError allows to create a new inconsistentDeployment error
+func NewInconsistentDeploymentError(deploymentID string) error {
+	return inconsistentDeployment{deploymentID: deploymentID}
+}
+
 // IsAnotherLivingTaskAlreadyExistsError checks if an error is due to the fact that another task is currently running
 // If true, it returns the taskID of the currently running task
 func IsAnotherLivingTaskAlreadyExistsError(err error) (bool, string) {
@@ -69,6 +74,21 @@ type taskDataNotFound struct {
 
 func (t taskDataNotFound) Error() string {
 	return fmt.Sprintf("Data %q not found for task %q", t.name, t.taskID)
+}
+
+type inconsistentDeployment struct {
+	deploymentID string
+}
+
+func (t inconsistentDeployment) Error() string {
+	return fmt.Sprintf("Inconsistent deployment with ID %q", t.deploymentID)
+}
+
+// IsInconsistentDeployment checks if an error is an inconsistent deployment error
+func IsInconsistentDeployment(err error) bool {
+	cause := errors.Cause(err)
+	_, ok := cause.(inconsistentDeployment)
+	return ok
 }
 
 // IsTaskDataNotFoundError checks if an error is a task data not found error

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -47,9 +47,9 @@ func NewAnotherLivingTaskAlreadyExistsError(taskID, targetID, status string) err
 	return anotherLivingTaskAlreadyExistsError{taskID: taskID, targetID: targetID, status: status}
 }
 
-// NewInconsistentDeploymentError allows to create a new inconsistentDeployment error
+// NewInconsistentDeploymentError allows to create a new inconsistentDeploymentError error
 func NewInconsistentDeploymentError(deploymentID string) error {
-	return inconsistentDeployment{deploymentID: deploymentID}
+	return inconsistentDeploymentError{deploymentID: deploymentID}
 }
 
 // IsAnotherLivingTaskAlreadyExistsError checks if an error is due to the fact that another task is currently running
@@ -76,18 +76,18 @@ func (t taskDataNotFound) Error() string {
 	return fmt.Sprintf("Data %q not found for task %q", t.name, t.taskID)
 }
 
-type inconsistentDeployment struct {
+type inconsistentDeploymentError struct {
 	deploymentID string
 }
 
-func (t inconsistentDeployment) Error() string {
+func (t inconsistentDeploymentError) Error() string {
 	return fmt.Sprintf("Inconsistent deployment with ID %q", t.deploymentID)
 }
 
-// IsInconsistentDeployment checks if an error is an inconsistent deployment error
-func IsInconsistentDeployment(err error) bool {
+// IsInconsistentDeploymentError checks if an error is an inconsistent deployment error
+func IsInconsistentDeploymentError(err error) bool {
 	cause := errors.Cause(err)
-	_, ok := cause.(inconsistentDeployment)
+	_, ok := cause.(inconsistentDeploymentError)
 	return ok
 }
 

--- a/tasks/workflow/builder/builder.go
+++ b/tasks/workflow/builder/builder.go
@@ -38,6 +38,10 @@ func BuildWorkFlow(kv *api.KV, deploymentID, wfName string) (map[string]*Step, e
 		return nil, err
 	}
 
+	if wf.Steps == nil || len(wf.Steps) == 0 {
+		return nil, tasks.NewInconsistentDeploymentError(deploymentID)
+	}
+
 	steps := make(map[string]*Step, len(wf.Steps))
 	visitedMap := make(map[string]*visitStep, len(wf.Steps))
 	for stepName := range wf.Steps {

--- a/tasks/workflow/builder/builder.go
+++ b/tasks/workflow/builder/builder.go
@@ -39,7 +39,7 @@ func BuildWorkFlow(kv *api.KV, deploymentID, wfName string) (map[string]*Step, e
 	}
 
 	if wf.Steps == nil || len(wf.Steps) == 0 {
-		return nil, tasks.NewInconsistentDeploymentError(deploymentID)
+		return nil, deployments.NewInconsistentDeploymentError(deploymentID)
 	}
 
 	steps := make(map[string]*Step, len(wf.Steps))


### PR DESCRIPTION
# Pull Request description

## Description of the change
When a deployment with non-conform topology is submitted to yorc, no topology template is stored.
When we try to undeploy it, no task execution is created as no workflow steps has been found. Only the main task is created and so nothing is done.

### What has been done

An "inconsistentDeploymentError" error is returned by task collector when no workflows step is detected.
A "Force purge task" is ordered to allow removing the deployment.

### How to verify it
See https://github.com/ystia/yorc/issues/368
### Description for the changelog
* Unable to delete a deployment with non-conform topology ([GH-368](https://github.com/ystia/yorc/issues/368))
## Applicable Issues
#368 
