### PR TITLE
Feature/gh 373 ansible upgrade note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### ENHANCEMENTS
+
+* Add a note on ansible upgrade in documentation ([GH-373](https://github.com/ystia/yorc/issues/373))
+
 ## 3.2.0-M5 (April 19, 2019)
 
 ### FEATURES

--- a/doc/upgrade.rst
+++ b/doc/upgrade.rst
@@ -38,7 +38,7 @@ Ansible
 ~~~~~~~
 
 Although Yorc 3.2.0 can still work with Ansible 2.7.2, vulnerability issues were
-identified is this Ansible version.
+identified in this Ansible version.
 
 So, it is strongly advised to upgrade Ansible to version 2.7.9:
 

--- a/doc/upgrade.rst
+++ b/doc/upgrade.rst
@@ -29,6 +29,23 @@ current version.
 
 .. note:: A rolling upgrade without interruption feature is planned for future versions.
 
+.. _yorc_upgrades_320_section:
+
+Upgrading to Yorc 3.2.0
+-----------------------
+
+Ansible
+~~~~~~~
+
+Although Yorc 3.2.0 can still work with Ansible 2.7.2, vulnerability issues were
+identified is this Ansible version.
+
+So, it is strongly advised to upgrade Ansible to version 2.7.9:
+
+.. code-block:: bash
+
+    sudo pip install ansible==2.7.9
+
 .. _yorc_upgrades_310_section:
 
 Upgrading to Yorc 3.1.0

--- a/doc/upgrade.rst
+++ b/doc/upgrade.rst
@@ -37,7 +37,7 @@ Upgrading to Yorc 3.2.0
 Ansible
 ~~~~~~~
 
-Although Yorc 3.2.0 can still work with Ansible 2.7.2, vulnerability issues were
+Although Yorc 3.2.0 can still work with Ansible 2.7.2, security vulnerabilities were
 identified in this Ansible version.
 
 So, it is strongly advised to upgrade Ansible to version 2.7.9:


### PR DESCRIPTION
# Pull Request description

## Description of the change

Added a note in Upgrade section of documentation to ask to upgrade to Ansible 2.7.9 for security reasons

### Description for the changelog

Add a note on ansible upgrade in documentation ([GH-373](https://github.com/ystia/yorc/issues/373))

## Applicable Issues
https://github.com/ystia/yorc/issues/373
