### PR TITLE
Set deployment status to initial before unmarshalling topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Unexpected deployment deletion during topology unmarshalling([GH-375](https://github.com/ystia/yorc/issues/375))
+
 ### ENHANCEMENTS
 
 * Add a note on ansible upgrade in documentation ([GH-373](https://github.com/ystia/yorc/issues/373))

--- a/deployments/deployments.go
+++ b/deployments/deployments.go
@@ -163,12 +163,12 @@ RETRY:
 			events.PublishAndLogDeploymentStatusChange(ctx, kv, deploymentID, strings.ToLower(status.String()))
 		}
 		return nil
-	} else {
-		// Set the status to INITIAL: no need to handle concurrency and to check previous status
-		if err = consulutil.StoreConsulKeyAsString(path.Join(consulutil.DeploymentKVPrefix, deploymentID, "status"), status.String()); err != nil {
-			return errors.Wrapf(err, "Failed to set deployment status to %q for deploymentID:%q", status.String(), deploymentID)
-		}
-		events.PublishAndLogDeploymentStatusChange(ctx, kv, deploymentID, strings.ToLower(status.String()))
 	}
+
+	// Set the status to INITIAL: no need to handle concurrency and to check previous status
+	if err = consulutil.StoreConsulKeyAsString(path.Join(consulutil.DeploymentKVPrefix, deploymentID, "status"), status.String()); err != nil {
+		return errors.Wrapf(err, "Failed to set deployment status to %q for deploymentID:%q", status.String(), deploymentID)
+	}
+	events.PublishAndLogDeploymentStatusChange(ctx, kv, deploymentID, strings.ToLower(status.String()))
 	return nil
 }


### PR DESCRIPTION
# Pull Request description

## Description of the change
- Set deployment status to initial before unmarshalling topology
- Use SetDeploymentStatus func to do it (this allows to publish an event among others) and idem in case of failure


### Description for the changelog
* Unexpected deployment deletion during topology unmarshalling([GH-375]
## Applicable Issues
#375 