### PR TITLE
Add description field to Tosca interface for parsing it correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### BUG FIXES
 
-* Unexpected deployment deletion during topology unmarshalling([GH-375](https://github.com/ystia/yorc/issues/375))
+* Unexpected deployment deletion during topology unmarshalling ([GH-375](https://github.com/ystia/yorc/issues/375))
+* Parsing of a description field of an TOSCA interface is interpreted as an operation ([GH-372](https://github.com/ystia/yorc/issues/372))
 
 ### ENHANCEMENTS
 

--- a/tosca/interfaces.go
+++ b/tosca/interfaces.go
@@ -18,9 +18,10 @@ package tosca
 //
 // See http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.2/TOSCA-Simple-Profile-YAML-v1.2.html#DEFN_ELEMENT_INTERFACE_DEF for more details
 type InterfaceDefinition struct {
-	Type       string                         `yaml:"type,omitempty"`
-	Inputs     map[string]Input               `yaml:"inputs,omitempty"`
-	Operations map[string]OperationDefinition `yaml:",inline,omitempty"`
+	Type        string                         `yaml:"type,omitempty"`
+	Description string                         `yaml:"description,omitempty"`
+	Inputs      map[string]Input               `yaml:"inputs,omitempty"`
+	Operations  map[string]OperationDefinition `yaml:",inline,omitempty"`
 }
 
 // An OperationDefinition is the representation of a TOSCA Operation Definition

--- a/tosca/interfaces_test.go
+++ b/tosca/interfaces_test.go
@@ -39,6 +39,8 @@ func TestInterfaceSimpleGrammar(t *testing.T) {
 func TestInterfaceComplexGrammar(t *testing.T) {
 	t.Parallel()
 	var inputYaml = `
+description: >
+  The lifecycle interfaces define the essential, normative operations that each TOSCA Relationship Types may support.
 start:
   inputs:
     X: "Y"
@@ -54,6 +56,7 @@ start:
 	require.Contains(t, opDef.Inputs, "X")
 	require.Equal(t, "Y", fmt.Sprint(opDef.Inputs["X"].ValueAssign.String()))
 	require.Equal(t, "scripts/start_server.sh", opDef.Implementation.Primary)
+	require.Equal(t, "The lifecycle interfaces define the essential, normative operations that each TOSCA Relationship Types may support.\n", ifDef.Description)
 }
 
 func TestInterfaceExpressionInputs(t *testing.T) {


### PR DESCRIPTION
# Pull Request description

## Description of the change
### What I did
Add description field to Tosca interface for parsing it correctly

### How to verify it
Deploy a simple application (compute + python component)
Check consul:
$ consul kv get -recurse _yorc/ | grep -v events | grep -v logs  | grep description
$ (nothing except google components descriptions if location is GCP)
### Description for the changelog
* Parsing of a description field of an TOSCA interface is interpreted as an operation
## Applicable Issues
#372 