### PR TITLE
Quote strings in filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### BUG FIXES
 
+* Can't deploy applications using compute instances filters on Hosts Pools ([GH-385](https://github.com/ystia/yorc/issues/385))
 * Unexpected deployment deletion during topology unmarshalling ([GH-375](https://github.com/ystia/yorc/issues/375))
 * Parsing of a description field of an TOSCA interface is interpreted as an operation ([GH-372](https://github.com/ystia/yorc/issues/372))
 * Yorc does not support python3 ([GH-319](https://github.com/ystia/yorc/issues/319))

--- a/prov/hostspool/executor.go
+++ b/prov/hostspool/executor.go
@@ -248,7 +248,23 @@ func appendCapabilityFilter(kv *api.KV, deploymentID, nodeName, capName, propNam
 		return filters, err
 	}
 	if p != nil && p.RawString() != "" {
-		f, err := labelsutil.CreateFilter(capName + "." + propName + " " + op + " " + p.RawString())
+		var sb strings.Builder
+		sb.WriteString(capName)
+		sb.WriteString(".")
+		sb.WriteString(propName)
+		sb.WriteString(" ")
+		sb.WriteString(op)
+		sb.WriteString(" ")
+		switch t := p.Value.(type) {
+		case string:
+			// Strings need to be quoted in filters
+			sb.WriteString("'")
+			sb.WriteString(t)
+			sb.WriteString("'")
+		default:
+			sb.WriteString(p.RawString())
+		}
+		f, err := labelsutil.CreateFilter(sb.String())
 		if err != nil {
 			return filters, err
 		}


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fixed an issue that should have been introduced after a change in filters for issue https://github.com/ystia/yorc/issues/89, where strings in filters have to be quoted now.

Yorc code was still creating filters without quoting compute capability filters, making deployments with such capability filters fail on this internal Yorc error:

```
error details: <source>:1:11: expected ( ValueS:String | Number ) not "linux"
failed to parse given filter string : os.type = linux
github.com/ystia/yorc/v3/helper/labelsutil/internal.FilterFromString
        /home/vscode/dev/src/github.com/ystia/yorc/helper/labelsutil/internal/filters.go:39
github.com/ystia/yorc/v3/helper/labelsutil.CreateFilter
        /home/vscode/dev/src/github.com/ystia/yorc/helper/labelsutil/filters_api.go:44
github.com/ystia/yorc/v3/prov/hostspool.appendCapabilityFilter
        /home/vscode/dev/src/github.com/ystia/yorc/prov/hostspool/executor.go:251
github.com/ystia/yorc/v3/prov/hostspool.createFiltersFromComputeCapabilities
        /home/vscode/dev/src/github.com/ystia/yorc/prov/hostspool/executor.go:283
github.com/ystia/yorc/v3/prov/hostspool.(*defaultExecutor).hostsPoolCreate
        /home/vscode/dev/src/github.com/ystia/yorc/prov/hostspool/executor.go:96
github.com/ystia/yorc/v3/prov/hostspool.(*defaultExecutor).ExecDelegate
        /home/vscode/dev/src/github.com/ystia/yorc/prov/hostspool/executor.go:58
```
  
### What I did

When the filter value is a string, Yorc internal code now creates a filter with the string value quoted.

### How to verify it

Bootstrap Yorc on a Hosts Pool (the bootstrap topology has a compute instance capability requirement os.type which must be linux)

### Description for the changelog

Can't deploy applications using compute instances filters on Hosts Pools ([GH-385](https://github.com/ystia/yorc/issues/385))

## Applicable Issues

https://github.com/ystia/yorc/issues/385)
