### PR TITLE
Feature/gh 329 plugin logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### ENHANCEMENTS
+
+* Print plugin logs in higher level than DEBUG ([GH-329](https://github.com/ystia/yorc/issues/329))
+
 ## 3.2.0-RC1 (May 10, 2019)
 
 ### BUG FIXES

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -346,6 +346,28 @@ Again, this could be done by altering ``ServeOpts`` in your main function.
     })
   }
 
+Logging
+~~~~~~~
+
+Using the `log` standard library or Yorc log module `github.com/ystia/yorc/v3/log`
+in plugin code, log data from the plugin will be automatically sent to the Yorc
+Server parent process.
+Yorc will parse these plugin logs to infer their log level and filter
+them according to its enabled log level. It will then display these messages,
+prefixed by the plugin name and suffixed by the timestamp of their creation on the plugin.
+
+Plugin log messages levels are inferred this way by Yorc Server :
+
+  * A message sent by the plugin using Yorc log module `github.com/ystia/yorc/v3/log`
+    function `log.Debug()`, `log.Debugf()` or `log.Debugln()` will have the level
+    `DEBUG`, all other messages will have the level `INFO` on Yorc server.
+
+  * A message sent by the plugin using the `log` standard library will have the
+    level INFO, except if this message is prefixed by one of these values:
+    [DEBUG], [INFO], [WARN], [ERROR], in which case the message will have the log
+    level corresponding to this value on Yorc server.
+
+See an example in next section of a plugin logs with debug logging enabled on Yorc server.
 
 Using Your Plugin
 ~~~~~~~~~~~~~~~~~
@@ -354,7 +376,9 @@ First your plugin should be dropped into Yorc's plugins directory before startin
 directory is configurable <option_terraform_plugins_dir_cmd>` but by default it's a directory named ``plugins`` in
 the current directory when Yorc is launched.
 
-By exporting an environment variable ``YORC_LOG=1`` before running Yorc, debug logs will be displayed.
+By exporting an environment variable ``YORC_LOG=1`` before running Yorc, plugin
+debug logs will be displayed, else these debug logs will be filtered and other
+plugin logs will be displayed, as described in previous section.
 
 .. code-block:: Bash
 
@@ -369,8 +393,8 @@ By exporting an environment variable ``YORC_LOG=1`` before running Yorc, debug l
   2019/02/12 14:28:23 [INFO]  30 workers started
   2019/02/12 14:28:23 [DEBUG] plugin: starting plugin: /tmp/yorc/plugins/my-custom-plugin []string{"/tmp/yorc/plugins/my-custom-plugin"}
   2019/02/12 14:28:23 [DEBUG] plugin: waiting for RPC address for: /tmp/yorc/plugins/my-custom-plugin
-  2019/02/12 14:28:23 [DEBUG] plugin: my-custom-plugin: 2019/02/12 14:28:23 [DEBUG] plugin: plugin address: unix /tmp/plugin262069315
-  2019/02/12 14:28:23 [DEBUG] plugin: my-custom-plugin: 2019/02/12 14:28:23 [DEBUG] Consul Publisher created with a maximum of 500 parallel routines.
+  2019/02/12 14:28:23 [DEBUG] plugin: my-custom-plugin: 2019/02/12 14:28:23 [DEBUG] plugin: plugin address: unix /tmp/plugin262069315 timestamp=2019-02-12T14:28:23.499Z
+  2019/02/12 14:28:23 [DEBUG] plugin: my-custom-plugin: 2019/02/12 14:28:23 [DEBUG] Consul Publisher created with a maximum of 500 parallel routines. timestamp=2019-02-12T14:28:23.499Z
   2019/02/12 14:28:23 [DEBUG] Registering supported node types [mytosca\.types\..*] into registry for plugin "my-custom-plugin"
   2019/02/12 14:28:23 [DEBUG] Registering supported implementation artifact types [mytosca.artifacts.Implementation.MyImplementation] into registry for plugin "my-custom-plugin"
   2019/02/12 14:28:23 [DEBUG] Registering TOSCA definition "mycustom-types.yml" into registry for plugin "my-custom-plugin"

--- a/go.mod
+++ b/go.mod
@@ -57,16 +57,15 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190203031600-7a902570cb17 // indirect
 	github.com/hashicorp/consul v1.2.3
 	github.com/hashicorp/go-cleanhttp v0.0.0-20171218145408-d5fe4b57a186c716b0e00b8c301cbd9b4182694d
-	github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e // indirect
+	github.com/hashicorp/go-hclog v0.8.0
 	github.com/hashicorp/go-memdb v0.0.0-20181108192425-032f93b25bec // indirect
 	github.com/hashicorp/go-multierror v1.0.0
-	github.com/hashicorp/go-plugin v0.0.0-20170419161244-1ffca25a1118
+	github.com/hashicorp/go-plugin v1.0.0
 	github.com/hashicorp/go-rootcerts v1.0.0
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/memberlist v0.1.3 // indirect
 	github.com/hashicorp/serf v0.0.0-20170419221626-65c2babe73c7a096cd24e9eeec67613eb4e436c9 // indirect
 	github.com/hashicorp/vault v0.9.0
-	github.com/hashicorp/yamux v0.0.0-20160720233140-d1caa6c97c9fc1cc9e83bbe34d0603f9ff0ce8bd // indirect
 	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
@@ -91,7 +90,6 @@ require (
 	github.com/mgutz/logxi v0.0.0-20161027140823-aebf8a7d67ab // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.0.0
-	github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 // indirect
 	github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee // indirect
 	github.com/mkideal/cli v0.0.2 // indirect
 	github.com/mkideal/pkg v0.0.0-20170503154153-3e188c9e7ecc // indirect
@@ -124,7 +122,7 @@ require (
 	github.com/spf13/pflag v1.0.1 // indirect
 	github.com/spf13/viper v1.0.2
 	github.com/stevedomin/termtable v0.0.0-20150929082024-09d29f3fd628
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.3.0
 	github.com/tmc/dot v0.0.0-20140217084426-2ca5f650b7700041dd0a689af81eb8e46c5158d1
 	github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 // indirect
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,7 @@ github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/containerd/continuity v0.0.0-20181203112020-004b46473808 h1:4BX8f882bXEDKfWIf0wa8HRvpnBoPszJJXL+TVbBw4M=
 github.com/containerd/continuity v0.0.0-20181203112020-004b46473808/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20190204142019-df6d76eb9289 h1:U+DzmGUpc/dOjREgbyyChPhdDIFwPYnVk+/5YcAa194=
@@ -126,8 +127,11 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.0.0-20171218145408-d5fe4b57a186c716b0e00b8c301cbd9b4182694d h1:e2mZzg22eywzVQVmZyrCXiGdRwTvQwgMIvdzYpvMj8g=
 github.com/hashicorp/go-cleanhttp v0.0.0-20171218145408-d5fe4b57a186c716b0e00b8c301cbd9b4182694d/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e h1:SS6R03q1M5bxjbOL2JziQUUu7opiRocL4R2H5Y2I6rY=
 github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-hclog v0.8.0 h1:z3ollgGRg8RjfJH6UVBaG54R70GFd++QOkvnJH3VSBY=
+github.com/hashicorp/go-hclog v0.8.0/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-memdb v0.0.0-20181108192425-032f93b25bec h1:A1nDk9UOKWPTQh5YcCnbwNbqj23e5pggf4HxGBulhr8=
@@ -138,6 +142,8 @@ github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-plugin v0.0.0-20170419161244-1ffca25a1118 h1:hoRFbZMiTJDHsPnu1sXIjIjUirYz0EHSELHfNmZxBx0=
 github.com/hashicorp/go-plugin v0.0.0-20170419161244-1ffca25a1118/go.mod h1:JSqWYsict+jzcj0+xElxyrBQRPNoiWQuddnxArJ7XHQ=
+github.com/hashicorp/go-plugin v1.0.0 h1:/gQ1sNR8/LHpoxKRQq4PmLBuacfZb4tC93e9B30o/7c=
+github.com/hashicorp/go-plugin v1.0.0/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-rootcerts v1.0.0 h1:Rqb66Oo1X/eSV1x66xbDccZjhJigjg0+e82kpwzSwCI=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
@@ -156,6 +162,8 @@ github.com/hashicorp/vault v0.9.0 h1:Q0mhuwDGu2pvJPpHLrSCHeYjJZ5rR3Q6pAL8ZXKkA+Q
 github.com/hashicorp/vault v0.9.0/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bAbosPMpP0=
 github.com/hashicorp/yamux v0.0.0-20160720233140-d1caa6c97c9fc1cc9e83bbe34d0603f9ff0ce8bd h1:b2syle42fnHe2zpHYKayIiZGZMCpv59e2aCOW4N6mao=
 github.com/hashicorp/yamux v0.0.0-20160720233140-d1caa6c97c9fc1cc9e83bbe34d0603f9ff0ce8bd/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
+github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c h1:kp3AxgXgDOmIJFR7bIwqFhwJ2qWar8tEQSE5XXhCfVk=
 github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -230,6 +238,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
+github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -289,9 +299,12 @@ github.com/spf13/viper v1.0.2 h1:Ncr3ZIuJn322w2k1qmzXDnkLAdQMlJqBa9kfAH+irso=
 github.com/spf13/viper v1.0.2/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
 github.com/stevedomin/termtable v0.0.0-20150929082024-09d29f3fd628 h1:f6X87W9rf8gQrniE11U1Go6YrlA/alLC0WCX70ITUaI=
 github.com/stevedomin/termtable v0.0.0-20150929082024-09d29f3fd628/go.mod h1:GSXnO3zhIxojyt7AVBvVpeQB7fbSCFOUo/0q5zz142A=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tmc/dot v0.0.0-20140217084426-2ca5f650b7700041dd0a689af81eb8e46c5158d1 h1:HNeCDcnwmxb0ZjR1e5ZJBPxRJlJ5eq5snttG5cTDqxw=
 github.com/tmc/dot v0.0.0-20140217084426-2ca5f650b7700041dd0a689af81eb8e46c5158d1/go.mod h1:S7t2g417AjtCWMwli446SApYIbTSpd+2z1kDFLVP2Vs=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 h1:j2hhcujLRHAg872RWAV5yaUrEjHEObwDv3aImCaNLek=
@@ -320,6 +333,7 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5 h1:x6r4Jo0KNzOOzYd8lbcRsqjuqEASK6ob3auvWYM4/8U=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
@@ -332,6 +346,7 @@ google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRS
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0NQvRW8DG4Yk3Q6T9cu9RcFQDu1tc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
+google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.18.0 h1:IZl7mfBGfbhYx2p2rKRtYgDFw6SBz+kclmxYrCksPPA=
 google.golang.org/grpc v1.18.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 gopkg.in/AlecAivazis/survey.v1 v1.6.3 h1:5ULq/dOAZJZxz8kPV3sI8HHjluXi3k62fUtkTbBzPy8=

--- a/plugin/client.go
+++ b/plugin/client.go
@@ -26,6 +26,7 @@ import (
 // NewClient returns a properly configured plugin client for a given plugin path
 func NewClient(pluginPath string) *gplugin.Client {
 
+	// Filtering logs coming from plugin according to Yorc parent process log level
 	var logLevel hclog.Level
 	if log.IsDebug() {
 		logLevel = hclog.Debug

--- a/plugin/client.go
+++ b/plugin/client.go
@@ -15,20 +15,33 @@
 package plugin
 
 import (
-	"io/ioutil"
-	stdlog "log"
+	"os"
 	"os/exec"
 
+	hclog "github.com/hashicorp/go-hclog"
 	gplugin "github.com/hashicorp/go-plugin"
-
 	"github.com/ystia/yorc/v3/log"
 )
 
 // NewClient returns a properly configured plugin client for a given plugin path
 func NewClient(pluginPath string) *gplugin.Client {
-	if !log.IsDebug() {
-		stdlog.SetOutput(ioutil.Discard)
+
+	var logLevel hclog.Level
+	if log.IsDebug() {
+		logLevel = hclog.Debug
+	} else {
+		logLevel = hclog.Info
 	}
+
+	// Create an hclog.Logger to be able to infer plugin logs level
+	logger := hclog.New(&hclog.LoggerOptions{
+		Output: os.Stdout,
+		Level:  logLevel,
+		// Using the same time format as standard logs, instead of hclog default
+		// format which is a version of RFC3339
+		TimeFormat: "2006/01/02 15:04:05",
+	})
+
 	// Setup RPC communication
 	SetupPluginCommunication()
 
@@ -36,5 +49,6 @@ func NewClient(pluginPath string) *gplugin.Client {
 		HandshakeConfig: HandshakeConfig,
 		Plugins:         getPlugins(nil),
 		Cmd:             exec.Command(pluginPath),
+		Logger:          logger,
 	})
 }

--- a/plugin/config.go
+++ b/plugin/config.go
@@ -37,6 +37,12 @@ type defaultConfigManager struct {
 }
 
 func (cm *defaultConfigManager) SetupConfig(cfg config.Configuration) error {
+
+	// Configuring standard log to use Hashicorp hclog within the plugin so that
+	// these standard logs can be parsed and filtered in the Yorc server according
+	// to their log level
+	initPluginStdLog()
+
 	// Currently we only use this plugin part to initialize the Consul publisher
 	cClient, err := cfg.GetNewConsulClient()
 	if err != nil {

--- a/plugin/config_test.go
+++ b/plugin/config_test.go
@@ -40,7 +40,9 @@ func (m *mockConfigManager) SetupConfig(cfg config.Configuration) error {
 	return nil
 }
 
-func TestConfigManagerSetupConfig(t *testing.T) {
+func setupConfigManagerTestEnv(t *testing.T) (*mockConfigManager, *plugin.RPCClient,
+	ConfigManager) {
+
 	t.Parallel()
 	mock := new(mockConfigManager)
 	client, _ := plugin.TestPluginRPCConn(
@@ -49,14 +51,19 @@ func TestConfigManagerSetupConfig(t *testing.T) {
 			ConfigManagerPluginName: &ConfigManagerPlugin{mock},
 		},
 		nil)
-	defer client.Close()
 
 	raw, err := client.Dispense(ConfigManagerPluginName)
 	require.Nil(t, err)
 
 	cm := raw.(ConfigManager)
 
-	err = cm.SetupConfig(config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}})
+	return mock, client, cm
+
+}
+func TestConfigManagerSetupConfig(t *testing.T) {
+	mock, client, cm := setupConfigManagerTestEnv(t)
+	defer client.Close()
+	err := cm.SetupConfig(config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}})
 	require.Nil(t, err)
 	require.True(t, mock.setupConfigCalled)
 	require.Equal(t, "test", mock.conf.Consul.Address)
@@ -64,21 +71,8 @@ func TestConfigManagerSetupConfig(t *testing.T) {
 }
 
 func TestConfigManagerSetupConfigWithFailure(t *testing.T) {
-	t.Parallel()
-	mock := new(mockConfigManager)
-	client, _ := plugin.TestPluginRPCConn(
-		t,
-		map[string]plugin.Plugin{
-			ConfigManagerPluginName: &ConfigManagerPlugin{mock},
-		},
-		nil)
+	_, client, cm := setupConfigManagerTestEnv(t)
 	defer client.Close()
-
-	raw, err := client.Dispense(ConfigManagerPluginName)
-	require.Nil(t, err)
-
-	cm := raw.(ConfigManager)
-
-	err = cm.SetupConfig(config.Configuration{Consul: config.Consul{Address: "testFailure", Datacenter: "testdc"}})
+	err := cm.SetupConfig(config.Configuration{Consul: config.Consul{Address: "testFailure", Datacenter: "testdc"}})
 	require.Error(t, err, "An error was expected during executing plugin operation")
 }

--- a/plugin/config_test.go
+++ b/plugin/config_test.go
@@ -43,9 +43,12 @@ func (m *mockConfigManager) SetupConfig(cfg config.Configuration) error {
 func TestConfigManagerSetupConfig(t *testing.T) {
 	t.Parallel()
 	mock := new(mockConfigManager)
-	client, _ := plugin.TestPluginRPCConn(t, map[string]plugin.Plugin{
-		ConfigManagerPluginName: &ConfigManagerPlugin{mock},
-	})
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			ConfigManagerPluginName: &ConfigManagerPlugin{mock},
+		},
+		nil)
 	defer client.Close()
 
 	raw, err := client.Dispense(ConfigManagerPluginName)
@@ -63,9 +66,12 @@ func TestConfigManagerSetupConfig(t *testing.T) {
 func TestConfigManagerSetupConfigWithFailure(t *testing.T) {
 	t.Parallel()
 	mock := new(mockConfigManager)
-	client, _ := plugin.TestPluginRPCConn(t, map[string]plugin.Plugin{
-		ConfigManagerPluginName: &ConfigManagerPlugin{mock},
-	})
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			ConfigManagerPluginName: &ConfigManagerPlugin{mock},
+		},
+		nil)
 	defer client.Close()
 
 	raw, err := client.Dispense(ConfigManagerPluginName)

--- a/plugin/config_test.go
+++ b/plugin/config_test.go
@@ -43,7 +43,6 @@ func (m *mockConfigManager) SetupConfig(cfg config.Configuration) error {
 func setupConfigManagerTestEnv(t *testing.T) (*mockConfigManager, *plugin.RPCClient,
 	ConfigManager) {
 
-	t.Parallel()
 	mock := new(mockConfigManager)
 	client, _ := plugin.TestPluginRPCConn(
 		t,
@@ -61,6 +60,7 @@ func setupConfigManagerTestEnv(t *testing.T) (*mockConfigManager, *plugin.RPCCli
 
 }
 func TestConfigManagerSetupConfig(t *testing.T) {
+	t.Parallel()
 	mock, client, cm := setupConfigManagerTestEnv(t)
 	defer client.Close()
 	err := cm.SetupConfig(config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}})
@@ -71,6 +71,7 @@ func TestConfigManagerSetupConfig(t *testing.T) {
 }
 
 func TestConfigManagerSetupConfigWithFailure(t *testing.T) {
+	t.Parallel()
 	_, client, cm := setupConfigManagerTestEnv(t)
 	defer client.Close()
 	err := cm.SetupConfig(config.Configuration{Consul: config.Consul{Address: "testFailure", Datacenter: "testdc"}})

--- a/plugin/definitions_test.go
+++ b/plugin/definitions_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func createClientServer(t *testing.T, opts *ServeOpts) (*plugin.RPCClient, *plugin.RPCServer) {
-	return plugin.TestPluginRPCConn(t, getPlugins(opts))
+	return plugin.TestPluginRPCConn(t, getPlugins(opts), nil)
 }
 
 func TestDefinitionsClient_GetDefinitions(t *testing.T) {

--- a/plugin/delegate_test.go
+++ b/plugin/delegate_test.go
@@ -65,11 +65,14 @@ func (m *mockDelegateExecutor) ExecDelegate(ctx context.Context, conf config.Con
 func TestDelegateExecutorExecDelegate(t *testing.T) {
 	t.Parallel()
 	mock := new(mockDelegateExecutor)
-	client, _ := plugin.TestPluginRPCConn(t, map[string]plugin.Plugin{
-		DelegatePluginName: &DelegatePlugin{F: func() prov.DelegateExecutor {
-			return mock
-		}},
-	})
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			DelegatePluginName: &DelegatePlugin{F: func() prov.DelegateExecutor {
+				return mock
+			}},
+		},
+		nil)
 	defer client.Close()
 
 	raw, err := client.Dispense(DelegatePluginName)
@@ -101,11 +104,14 @@ func TestDelegateExecutorExecDelegate(t *testing.T) {
 func TestDelegateExecutorExecDelegateWithFailure(t *testing.T) {
 	t.Parallel()
 	mock := new(mockDelegateExecutor)
-	client, _ := plugin.TestPluginRPCConn(t, map[string]plugin.Plugin{
-		DelegatePluginName: &DelegatePlugin{F: func() prov.DelegateExecutor {
-			return mock
-		}},
-	})
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			DelegatePluginName: &DelegatePlugin{F: func() prov.DelegateExecutor {
+				return mock
+			}},
+		},
+		nil)
 	defer client.Close()
 
 	raw, err := client.Dispense(DelegatePluginName)
@@ -130,11 +136,14 @@ func TestDelegateExecutorExecDelegateWithFailure(t *testing.T) {
 func TestDelegateExecutorExecDelegateWithCancel(t *testing.T) {
 	t.Parallel()
 	mock := new(mockDelegateExecutor)
-	client, _ := plugin.TestPluginRPCConn(t, map[string]plugin.Plugin{
-		DelegatePluginName: &DelegatePlugin{F: func() prov.DelegateExecutor {
-			return mock
-		}},
-	})
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			DelegatePluginName: &DelegatePlugin{F: func() prov.DelegateExecutor {
+				return mock
+			}},
+		},
+		nil)
 	defer client.Close()
 
 	raw, err := client.Dispense(DelegatePluginName)
@@ -164,13 +173,16 @@ func TestDelegateExecutorExecDelegateWithCancel(t *testing.T) {
 
 func TestDelegateGetSupportedTypes(t *testing.T) {
 	mock := new(mockDelegateExecutor)
-	client, _ := plugin.TestPluginRPCConn(t, map[string]plugin.Plugin{
-		DelegatePluginName: &DelegatePlugin{
-			F: func() prov.DelegateExecutor {
-				return mock
-			},
-			SupportedTypes: []string{"tosca.my.types", "test"}},
-	})
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			DelegatePluginName: &DelegatePlugin{
+				F: func() prov.DelegateExecutor {
+					return mock
+				},
+				SupportedTypes: []string{"tosca.my.types", "test"}},
+		},
+		nil)
 	defer client.Close()
 	raw, err := client.Dispense(DelegatePluginName)
 	require.Nil(t, err)

--- a/plugin/infra_usage_collector_test.go
+++ b/plugin/infra_usage_collector_test.go
@@ -64,7 +64,9 @@ func (m *mockInfraUsageCollector) GetUsageInfo(ctx context.Context, conf config.
 	return res, nil
 }
 
-func TestInfraUsageCollectorGetUsageInfo(t *testing.T) {
+func setupInfraUsageCollectorTestEnv(t *testing.T) (*mockInfraUsageCollector, *plugin.RPCClient,
+	prov.InfraUsageCollector, events.LogOptionalFields, context.Context) {
+
 	t.Parallel()
 	mock := new(mockInfraUsageCollector)
 	client, _ := plugin.TestPluginRPCConn(
@@ -75,7 +77,6 @@ func TestInfraUsageCollectorGetUsageInfo(t *testing.T) {
 			}},
 		},
 		nil)
-	defer client.Close()
 
 	raw, err := client.Dispense(InfraUsageCollectorPluginName)
 	require.Nil(t, err)
@@ -88,6 +89,13 @@ func TestInfraUsageCollectorGetUsageInfo(t *testing.T) {
 		events.OperationName: "myTest",
 	}
 	ctx := events.NewContext(context.Background(), lof)
+
+	return mock, client, plugin, lof, ctx
+
+}
+func TestInfraUsageCollectorGetUsageInfo(t *testing.T) {
+	mock, client, plugin, lof, ctx := setupInfraUsageCollectorTestEnv(t)
+	defer client.Close()
 	info, err := plugin.GetUsageInfo(
 		ctx,
 		config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
@@ -115,30 +123,9 @@ func TestInfraUsageCollectorGetUsageInfo(t *testing.T) {
 }
 
 func TestInfraUsageCollectorGetUsageInfoWithFailure(t *testing.T) {
-	t.Parallel()
-	mock := new(mockInfraUsageCollector)
-	client, _ := plugin.TestPluginRPCConn(
-		t,
-		map[string]plugin.Plugin{
-			InfraUsageCollectorPluginName: &InfraUsageCollectorPlugin{F: func() prov.InfraUsageCollector {
-				return mock
-			}},
-		},
-		nil)
+	_, client, plugin, _, ctx := setupInfraUsageCollectorTestEnv(t)
 	defer client.Close()
-
-	raw, err := client.Dispense(InfraUsageCollectorPluginName)
-	require.Nil(t, err)
-
-	plugin := raw.(prov.InfraUsageCollector)
-
-	lof := events.LogOptionalFields{
-		events.WorkFlowID:    "testWF",
-		events.InterfaceName: "delegate",
-		events.OperationName: "myTest",
-	}
-	ctx := events.NewContext(context.Background(), lof)
-	_, err = plugin.GetUsageInfo(
+	_, err := plugin.GetUsageInfo(
 		ctx,
 		config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
 		"TestFailure", "myInfra")
@@ -147,32 +134,11 @@ func TestInfraUsageCollectorGetUsageInfoWithFailure(t *testing.T) {
 }
 
 func TestInfraUsageCollectorGetUsageInfoWithCancel(t *testing.T) {
-	t.Parallel()
-	mock := new(mockInfraUsageCollector)
-	client, _ := plugin.TestPluginRPCConn(
-		t,
-		map[string]plugin.Plugin{
-			InfraUsageCollectorPluginName: &InfraUsageCollectorPlugin{F: func() prov.InfraUsageCollector {
-				return mock
-			}},
-		},
-		nil)
+	mock, client, plugin, _, ctx := setupInfraUsageCollectorTestEnv(t)
 	defer client.Close()
-
-	raw, err := client.Dispense(InfraUsageCollectorPluginName)
-	require.Nil(t, err)
-
-	plugin := raw.(prov.InfraUsageCollector)
-
-	lof := events.LogOptionalFields{
-		events.WorkFlowID:    "testWF",
-		events.InterfaceName: "delegate",
-		events.OperationName: "myTest",
-	}
-	ctx := events.NewContext(context.Background(), lof)
 	ctx, cancelF := context.WithCancel(ctx)
 	go func() {
-		_, err = plugin.GetUsageInfo(
+		_, err := plugin.GetUsageInfo(
 			ctx,
 			config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
 			"TestCancel", "myInfra")

--- a/plugin/infra_usage_collector_test.go
+++ b/plugin/infra_usage_collector_test.go
@@ -67,11 +67,14 @@ func (m *mockInfraUsageCollector) GetUsageInfo(ctx context.Context, conf config.
 func TestInfraUsageCollectorGetUsageInfo(t *testing.T) {
 	t.Parallel()
 	mock := new(mockInfraUsageCollector)
-	client, _ := plugin.TestPluginRPCConn(t, map[string]plugin.Plugin{
-		InfraUsageCollectorPluginName: &InfraUsageCollectorPlugin{F: func() prov.InfraUsageCollector {
-			return mock
-		}},
-	})
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			InfraUsageCollectorPluginName: &InfraUsageCollectorPlugin{F: func() prov.InfraUsageCollector {
+				return mock
+			}},
+		},
+		nil)
 	defer client.Close()
 
 	raw, err := client.Dispense(InfraUsageCollectorPluginName)
@@ -114,11 +117,14 @@ func TestInfraUsageCollectorGetUsageInfo(t *testing.T) {
 func TestInfraUsageCollectorGetUsageInfoWithFailure(t *testing.T) {
 	t.Parallel()
 	mock := new(mockInfraUsageCollector)
-	client, _ := plugin.TestPluginRPCConn(t, map[string]plugin.Plugin{
-		InfraUsageCollectorPluginName: &InfraUsageCollectorPlugin{F: func() prov.InfraUsageCollector {
-			return mock
-		}},
-	})
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			InfraUsageCollectorPluginName: &InfraUsageCollectorPlugin{F: func() prov.InfraUsageCollector {
+				return mock
+			}},
+		},
+		nil)
 	defer client.Close()
 
 	raw, err := client.Dispense(InfraUsageCollectorPluginName)
@@ -143,11 +149,14 @@ func TestInfraUsageCollectorGetUsageInfoWithFailure(t *testing.T) {
 func TestInfraUsageCollectorGetUsageInfoWithCancel(t *testing.T) {
 	t.Parallel()
 	mock := new(mockInfraUsageCollector)
-	client, _ := plugin.TestPluginRPCConn(t, map[string]plugin.Plugin{
-		InfraUsageCollectorPluginName: &InfraUsageCollectorPlugin{F: func() prov.InfraUsageCollector {
-			return mock
-		}},
-	})
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			InfraUsageCollectorPluginName: &InfraUsageCollectorPlugin{F: func() prov.InfraUsageCollector {
+				return mock
+			}},
+		},
+		nil)
 	defer client.Close()
 
 	raw, err := client.Dispense(InfraUsageCollectorPluginName)
@@ -178,14 +187,17 @@ func TestInfraUsageCollectorGetUsageInfoWithCancel(t *testing.T) {
 func TestGetSupportedInfra(t *testing.T) {
 	t.Parallel()
 	mock := new(mockInfraUsageCollector)
-	client, _ := plugin.TestPluginRPCConn(t, map[string]plugin.Plugin{
-		InfraUsageCollectorPluginName: &InfraUsageCollectorPlugin{
-			F: func() prov.InfraUsageCollector {
-				return mock
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			InfraUsageCollectorPluginName: &InfraUsageCollectorPlugin{
+				F: func() prov.InfraUsageCollector {
+					return mock
+				},
+				SupportedInfras: []string{"myInfra"},
 			},
-			SupportedInfras: []string{"myInfra"},
 		},
-	})
+		nil)
 	defer client.Close()
 
 	raw, err := client.Dispense(InfraUsageCollectorPluginName)

--- a/plugin/log.go
+++ b/plugin/log.go
@@ -1,0 +1,52 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	stdlog "log"
+	"os"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/ystia/yorc/v3/log"
+)
+
+// Creating a hclog logger so that Hashicorp go plugin logs can be correctly
+// parsed by Yorc Server parent process, and filtered appropriately,
+// according to the parent process log level.
+var hclogger = hclog.New(&hclog.LoggerOptions{
+	// Plugin logs have to go to stderr in order to be shown in the parent process
+	Output: os.Stderr,
+	Level:  hclog.Debug,
+	// Parent process expect child log in JSON format to be able to parse them
+	JSONFormat: true,
+})
+
+// Writer parsing log messages to infer the log level from message prefix
+// [DEBUG], [INFO], [WARN], [ERROR]
+var stdWriter = hclogger.StandardWriter(&hclog.StandardLoggerOptions{InferLevels: true})
+
+// initPluginStdLog configures standard logs to use hclog in the plugin
+func initPluginStdLog() {
+	stdlog.SetOutput(stdWriter)
+	stdlog.SetPrefix("")
+	stdlog.SetFlags(0)
+}
+
+// initPluginYorcLog configures Yorc log to use hclog in the plugin
+func initPluginYorcLog() {
+	log.SetOutput(stdWriter)
+	log.SetPrefix("")
+	log.SetFlags(0)
+}

--- a/plugin/operation_test.go
+++ b/plugin/operation_test.go
@@ -69,11 +69,14 @@ func (m *mockOperationExecutor) ExecOperation(ctx context.Context, conf config.C
 func TestOperationExecutorExecOperation(t *testing.T) {
 	t.Parallel()
 	mock := new(mockOperationExecutor)
-	client, _ := plugin.TestPluginRPCConn(t, map[string]plugin.Plugin{
-		OperationPluginName: &OperationPlugin{F: func() prov.OperationExecutor {
-			return mock
-		}},
-	})
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			OperationPluginName: &OperationPlugin{F: func() prov.OperationExecutor {
+				return mock
+			}},
+		},
+		nil)
 	defer client.Close()
 
 	raw, err := client.Dispense(OperationPluginName)
@@ -113,11 +116,14 @@ func TestOperationExecutorExecOperation(t *testing.T) {
 func TestOperationExecutorExecOperationWithFailure(t *testing.T) {
 	t.Parallel()
 	mock := new(mockOperationExecutor)
-	client, _ := plugin.TestPluginRPCConn(t, map[string]plugin.Plugin{
-		OperationPluginName: &OperationPlugin{F: func() prov.OperationExecutor {
-			return mock
-		}},
-	})
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			OperationPluginName: &OperationPlugin{F: func() prov.OperationExecutor {
+				return mock
+			}},
+		},
+		nil)
 	defer client.Close()
 
 	raw, err := client.Dispense(OperationPluginName)
@@ -150,11 +156,14 @@ func TestOperationExecutorExecOperationWithFailure(t *testing.T) {
 func TestOperationExecutorExecOperationWithCancel(t *testing.T) {
 	t.Parallel()
 	mock := new(mockOperationExecutor)
-	client, _ := plugin.TestPluginRPCConn(t, map[string]plugin.Plugin{
-		OperationPluginName: &OperationPlugin{F: func() prov.OperationExecutor {
-			return mock
-		}},
-	})
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			OperationPluginName: &OperationPlugin{F: func() prov.OperationExecutor {
+				return mock
+			}},
+		},
+		nil)
 	defer client.Close()
 
 	raw, err := client.Dispense(OperationPluginName)
@@ -183,13 +192,16 @@ func TestOperationExecutorExecOperationWithCancel(t *testing.T) {
 
 func TestOperationGetSupportedArtifactTypes(t *testing.T) {
 	mock := new(mockOperationExecutor)
-	client, _ := plugin.TestPluginRPCConn(t, map[string]plugin.Plugin{
-		OperationPluginName: &OperationPlugin{
-			F: func() prov.OperationExecutor {
-				return mock
-			},
-			SupportedTypes: []string{"tosca.my.types", "test"}},
-	})
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			OperationPluginName: &OperationPlugin{
+				F: func() prov.OperationExecutor {
+					return mock
+				},
+				SupportedTypes: []string{"tosca.my.types", "test"}},
+		},
+		nil)
 	defer client.Close()
 	raw, err := client.Dispense(OperationPluginName)
 	require.Nil(t, err)

--- a/plugin/serve.go
+++ b/plugin/serve.go
@@ -16,15 +16,12 @@ package plugin
 
 import (
 	"encoding/gob"
-	"os"
 	"text/template"
 
-	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 
 	"github.com/ystia/yorc/v3/config"
 	"github.com/ystia/yorc/v3/events"
-	"github.com/ystia/yorc/v3/log"
 	"github.com/ystia/yorc/v3/prov"
 	"github.com/ystia/yorc/v3/vault"
 )
@@ -77,27 +74,19 @@ type ServeOpts struct {
 func Serve(opts *ServeOpts) {
 	SetupPluginCommunication()
 
-	// Creating a hclog logger so that Hashicorp go plugin logs can be correctly
-	// parsed by Yorc Server parent process, and filtered appropriately,
-	// according to the parent process log level.
-	logger := hclog.New(&hclog.LoggerOptions{
-		// Plugin logs have to go to stderr in order to be shown in the parent process
-		Output: os.Stderr,
-		Level:  hclog.Debug,
-		// Parent process expect child log in JSON format to be able to parse them
-		JSONFormat: true,
-	})
+	// Configuring Yorc logs to use Hashicorp hclog in the plugin so that
+	// these logs can be parsed and filtered in the Yorc server  according to their
+	// log level
+	initPluginYorcLog()
 
-	// Configuring Yorc logs to use hclog in the plugin
-	stdWriter := logger.StandardWriter(&hclog.StandardLoggerOptions{InferLevels: true})
-	log.SetOutput(stdWriter)
-	log.SetPrefix("")
-	log.SetFlags(0)
+	// Cannot configure here standard log to use Hashicorp hclog, as next call
+	// plugin.Serve() is setting standard log output to os.Stderr.
+	// This will be done in config.go by the defaultConfigManager
 
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: HandshakeConfig,
 		Plugins:         getPlugins(opts),
-		Logger:          logger,
+		Logger:          hclogger,
 	})
 }
 

--- a/plugin/serve.go
+++ b/plugin/serve.go
@@ -84,7 +84,6 @@ func Serve(opts *ServeOpts) {
 		// Plugin logs have to go to stderr in order to be shown in the parent process
 		Output: os.Stderr,
 		Level:  hclog.Debug,
-		// TimeFormat: "2006/01/02 15:04:05",
 		// Parent process expect child log in JSON format to be able to parse them
 		JSONFormat: true,
 	})

--- a/plugin/serve_test.go
+++ b/plugin/serve_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestServeDefaultOpts(t *testing.T) {
 	t.Parallel()
-	client, _ := plugin.TestPluginRPCConn(t, getPlugins(nil))
+	client, _ := plugin.TestPluginRPCConn(t, getPlugins(nil), nil)
 	defer client.Close()
 
 	raw, err := client.Dispense(OperationPluginName)

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-yorc_version: 3.2.0-RC1
+yorc_version: 3.2.0-SNAPSHOT
 # Alien4Cloud version used by the bootstrap as the default version to download/install
 alien4cloud_version: 2.1.1
 consul_version: 1.2.3


### PR DESCRIPTION
# Pull Request description

## Description of the change

Previously, to see any plugin log, even error logs, Yorc Server had to be configured with debug logging enabled.
This is not necessary anymore. When debug logging is disabled on Yorc Server, only the plugin debug logs will be filtered, other logs will be displayed by the Yorc server.
So Yorc Server debug logging (which is verbose) doesn't have to be enabled to see plugin errors.


### What I did

When a plugin is using yorc `github.com/ystia/yorc/v3/log` package,
or when this plugin is using the standard `log` library and prefixes these standard log messages with a level : `[DEBUG]`, `[INFO]` , `[WARN]`, `[ERROR]`, (no prefix means INFO)
Yorc server will automatically receive each log message from the plugin, parse its log level and display it except if the message log level is DEBUG and debug logging is disabled. 

### How I did it


Using `github.com/hashicorp/go-hclog` to have plugin logs automatically parsed and filtered according to their level.
Code configuring the plugin takes care of creating a go-hclog instance and use this instance for standard log and yorc log in the plugin.
Code configuring a plugin client in Yorc server creates go-hclog instance with a log level set to `DEBUG` if debug logging is enabled on Yorc, else with a log level of `INFO`.

Summary of changes:

`doc/plugins.rst`:
Added a Logging section in documentation.

`go.mod`:
Upgraded the version of `github.com/hashicorp/go-plugin` used to benefit from enhancements on log management.
Using now `github.com/hashicorp/go-hclog` internally to rely on the automatic parsing/filtering of plugin logs in parent process

`plugin/client.go`: 
Creating a `github.com/hashicorp/go-hclog` instance that will allow Yorc Server to automatically parse, filter and display log messages coming from the plugin.

`plugin/config.go`:
This code called on the plugin after this plugin has been created, takes care of setting standard log appropriately, so that any standard log written on the plugin can be correctly parsed and filtered by Yorc Server.

`plugin/*test.go`:
Update needed to an API change in the new version of `github.com/hashicorp/go-plugin` (one additional argument in `TestPluginRPCConn()` function.
Code refactoring to avoid duplicate code issues reported by CodeFactor.

`plugin/log.go`:
New file creating a `github.com/hashicorp/go-hclog` instance and providing functions `initPluginStdLog()` and `initPluginYorcLog()` doing the necessary settings so that a plugin developper
can use the standard log library or Yorc logs to log messages in his code, and have the Yorc Server parent process parse and filter these messages automatically,
thanks to the underlying use of a `github.com/hashicorp/go-hclog` instance.

`plugin/serve.go`:
This code called on the plugin, takes care of setting yorc log appropriately, so that any yorc log written on the plugin can be correctly parsed and filtered by Yorc Server.
We cannot do the same thing for standard logs here as the last call `plugin.Serve()` is overriding standard log to `os.Stderr`. This work is done later in `plugin/config.go`


### How to verify it

Install a Yorc Server from this pull request.
Download my-plugin.zip provided in attachment:
[my-plugin.zip](https://github.com/ystia/yorc/files/3186726/my-plugin.zip)
(plugin source code available at  https://github.com/ystia/yorc-plugin-example/tree/feature/GH-329-plugin-logs/src),
unzip it and copy my-plugin binary in Yorc user directory `plugins`

Using the deployment topology topology.zip in attachment:
[topology.zip](https://github.com/ystia/yorc/files/3186747/topology.zip)
(containing source file available at https://github.com/ystia/yorc-plugin-example/blob/feature/GH-329-plugin-logs/tosca/topology.yaml),

Unzip it, then deploy an application running :
```bash
$ yorc d deploy --id my-test-app  topology.yaml
```

Check Yorc Server logs, you should see INFO and WARN logs from the plugin like this one :
```
May 15 17:27:01 yorccompute-0 yorc[27011]: 2019/05/15 17:27:01 [INFO]  my-plugin: Executing operation "standard.create": timestamp=2019-05-15T17:27:01.859Z
May 15 17:27:01 yorccompute-0 yorc[27011]: 2019/05/15 17:27:01 [WARN]  my-plugin: This is a plugin warning log on standard log example: timestamp=2019-05-15T17:27:01.859Z
May 15 17:27:01 yorccompute-0 yorc[27011]: 2019/05/15 17:27:01 [INFO]  my-plugin: This is a plugin log on standard log example: timestamp=2019-05-15T17:27:01.859Z
```
and no debug log.

Undeploy the application, running :
```bash
$ yorc d undeploy -p my-test-app
```

Once done, restart Yorc in debug mode, by exporting `YORC_LOG=1` in the Yorc Server environment.
For example if you run yorc as a service, you can add this line in `/etc/systemd/system/yorc.service` in `[service]` section:
```
Environment="YORC_LOG=1"
```
Then run:
```bash
$ systemctl daemon-reload
$ systemctl stop yorc
$ systemctl start yorc
```

Deploy the application :
```bash
$ yorc d deploy --id my-test-app  topology.yaml
```

Check Yorc Server logs, you should see the same INFO and WARN logs from the plugin as seen in the previous deployment, but your should see as well debug logs like :
```
May 15 17:27:00 yorccompute-0 yorc[27011]: 2019/05/15 17:27:00 [DEBUG] my-plugin: Entering plugin ExecDelegate: timestamp=2019-05-15T17:27:00.768Z
```
and also debug messages corresponding to events that are logged when debug logging is enabled:
```
May 15 17:27:00 yorccompute-0 yorc[27011]: 2019/05/15 17:27:00 [DEBUG] my-plugin: consul http Transport config: &{idleMu:{state:0 sema:0} wantIdle:false idleConn:map[] idleConnCh:map[] idleLRU:{ll:<nil> m:map[]} reqMu:{state:0 sema:0} reqCanceler:map[] altMu:{state:0 sema:0} altProto:{v:<nil>} connCountMu:{state:0 sema:0} connPerHostCount:map[] connPerHostAvailable:map[] Proxy:0x6d6900 DialContext:0x6eb1f0 Dial:<nil> DialTLS:<nil> TLSClientConfig:<nil> TLSHandshakeTimeout:50s DisableKeepAlives:false DisableCompression:false MaxIdleConns:500 MaxIdleConnsPerHost:500 MaxConnsPerHost:500 IdleConnTimeout:10s ResponseHeaderTimeout:0s ExpectContinueTimeout:1s TLSNextProto:map[] ProxyConnectHeader:map[] MaxResponseHeaderBytes:0 nextProtoOnce:{m:{state:0 sema:0} done:0} h2transport:<nil>}: timestamp=2019-05-15T17:27:00.768Z
May 15 17:27:00 yorccompute-0 yorc[27011]: 2019/05/15 17:27:00 [DEBUG] my-plugin: Found node instances [0] for my-test-app Compute: timestamp=2019-05-15T17:27:00.813Z
May 15 17:27:00 yorccompute-0 yorc[27011]: 2019/05/15 17:27:00 [DEBUG] my-plugin: [2019-05-15T17:27:00.858982612Z][INFO][my-test-app][install][fa5bb36b-465a-4f59-8d14-027021050196][f66b8e9d-8794-4a34-996c-7bfd81004b92-0][Compute][0][delegate][install][]Status for node "Compute", instance "0" changed to "creating": timestamp=2019-05-15T17:27:00.863Z
May 15 17:27:00 yorccompute-0 yorc[27011]: 2019/05/15 17:27:00 [DEBUG] my-plugin: [2019-05-15T17:27:00.867278819Z][INFO][my-test-app][][][][Compute][0][][][]Attribute value for node "Compute", instance "0" changed to "creating": timestamp=2019-05-15T17:27:00.870Z
May 15 17:27:00 yorccompute-0 yorc[27011]: 2019/05/15 17:27:00 [DEBUG] my-plugin: Received instance attribute value change notification for [deploymentID:"my-test-app", nodeName:"Compute", instanceName:"0", capabilityName:"", attributeName:"state": timestamp=2019-05-15T17:27:00.870Z
May 15 17:27:00 yorccompute-0 yorc[27011]: 2019/05/15 17:27:00 [DEBUG] my-plugin: [2019-05-15T17:27:00.872115819Z][INFO][my-test-app][install][fa5bb36b-465a-4f59-8d14-027021050196][f66b8e9d-8794-4a34-996c-7bfd81004b92][Compute][][delegate][install][]**********Provisioning node "Compute" of type "mytosca.types.Compute": timestamp=2019-05-15T17:27:00.875Z
May 15 17:27:00 yorccompute-0 yorc[27011]: 2019/05/15 17:27:00 [DEBUG] my-plugin: [2019-05-15T17:27:00.920109658Z][INFO][my-test-app][install][fa5bb36b-465a-4f59-8d14-027021050196][f66b8e9d-8794-4a34-996c-7bfd81004b92-0][Compute][0][delegate][install][]Status for node "Compute", instance "0" changed to "started": timestamp=2019-05-15T17:27:00.923Z
May 15 17:27:00 yorccompute-0 yorc[27011]: 2019/05/15 17:27:00 [DEBUG] my-plugin: [2019-05-15T17:27:00.926308995Z][INFO][my-test-app][][][][Compute][0][][][]Attribute value for node "Compute", instance "0" changed to "started": timestamp=2019-05-15T17:27:00.929Z
May 15 17:27:00 yorccompute-0 yorc[27011]: 2019/05/15 17:27:00 [DEBUG] my-plugin: Received instance attribute value change notification for [deploymentID:"my-test-app", nodeName:"Compute", instanceName:"0", capabilityName:"", attributeName:"state": timestamp=2019-05-15T17:27:00.929Z
May 15 17:27:01 yorccompute-0 yorc[27011]: 2019/05/15 17:27:01 [DEBUG] my-plugin: Entering ExecOperation: timestamp=2019-05-15T17:27:01.859Z
May 15 17:27:01 yorccompute-0 yorc[27011]: 2019/05/15 17:27:01 [INFO]  my-plugin: Executing operation "standard.create": timestamp=2019-05-15T17:27:01.859Z
May 15 17:27:01 yorccompute-0 yorc[27011]: 2019/05/15 17:27:01 [WARN]  my-plugin: This is a plugin warning log on standard log example: timestamp=2019-05-15T17:27:01.859Z
May 15 17:27:01 yorccompute-0 yorc[27011]: 2019/05/15 17:27:01 [INFO]  my-plugin: This is a plugin log on standard log example: timestamp=2019-05-15T17:27:01.859Z
May 15 17:27:01 yorccompute-0 yorc[27011]: 2019/05/15 17:27:01 [DEBUG] my-plugin: [2019-05-15T17:27:01.859959426Z][INFO][my-test-app][install][fa5bb36b-465a-4f59-8d14-027021050196][daa99cb1-f5a6-4b96-b258-9eb38d56754e][Soft][][standard][create][]******Executing operation "standard.create" on node "Soft": timestamp=201
```


### Description for the changelog

Print plugin logs in higher level than DEBUG ([GH-329](https://github.com/ystia/yorc/issues/329))

## Applicable Issues

Fixes #329 
