### PR TITLE
Bugfix/gh 409 compute resources filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### BUG FIXES
 
+* Failure to deploy an application with Compute resources constraints on Hosts Pool ([GH-409](https://github.com/ystia/yorc/issues/409))
 * Secure bootstrap on Hosts Pool fails configuring infra, error "playbooks must be a list of plays" ([GH-396](https://github.com/ystia/yorc/issues/396))
 * Kubernetes infrastructure configuration support in Yorc is not able to detect erroneous config file path ([GH-378](https://github.com/ystia/yorc/issues/378))
 

--- a/deployments/testdata/capabilities.yaml
+++ b/deployments/testdata/capabilities.yaml
@@ -45,6 +45,10 @@ capability_types:
         type: string
         default: "bind1"
   yorc.test.capabilities.Endpoint:
+    properties:
+      prop1:
+        type: string
+        default: "defaultValue"
     attributes:
       attr2:
         type: string

--- a/prov/hostspool/consul_test.go
+++ b/prov/hostspool/consul_test.go
@@ -15,8 +15,13 @@
 package hostspool
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/ystia/yorc/v3/deployments"
 	"github.com/ystia/yorc/v3/log"
 	"github.com/ystia/yorc/v3/testutil"
 )
@@ -25,7 +30,13 @@ import (
 func TestRunConsulHostsPoolPackageTests(t *testing.T) {
 	srv, client := testutil.NewTestConsulInstance(t)
 	defer srv.Stop()
+	kv := client.KV()
 	log.SetDebug(true)
+
+	deploymentID := strings.Replace(t.Name(), "/", "_", -1)
+	err := deployments.StoreDeploymentDefinition(context.Background(), kv, deploymentID, "testdata/topology_hp_compute.yaml")
+	require.NoError(t, err)
+
 	t.Run("TestConsulManagerAdd", func(t *testing.T) {
 		testConsulManagerAdd(t, client)
 	})
@@ -79,5 +90,8 @@ func TestRunConsulHostsPoolPackageTests(t *testing.T) {
 	})
 	t.Run("testConsulManagerAddLabelsWithAllocation", func(t *testing.T) {
 		testConsulManagerAddLabelsWithAllocation(t, client)
+	})
+	t.Run("testCreateFiltersFromComputeCapabilities", func(t *testing.T) {
+		testCreateFiltersFromComputeCapabilities(t, kv, deploymentID)
 	})
 }

--- a/prov/hostspool/executor.go
+++ b/prov/hostspool/executor.go
@@ -247,6 +247,13 @@ func appendCapabilityFilter(kv *api.KV, deploymentID, nodeName, capName, propNam
 	if err != nil {
 		return filters, err
 	}
+
+	hasProp, propDataType, err := deployments.GetCapabilityPropertyType(kv, deploymentID,
+		nodeName, capName, propName)
+	if err != nil {
+		return filters, err
+	}
+
 	if p != nil && p.RawString() != "" {
 		var sb strings.Builder
 		sb.WriteString(capName)
@@ -255,15 +262,16 @@ func appendCapabilityFilter(kv *api.KV, deploymentID, nodeName, capName, propNam
 		sb.WriteString(" ")
 		sb.WriteString(op)
 		sb.WriteString(" ")
-		switch t := p.Value.(type) {
-		case string:
+		if hasProp && propDataType == "string" {
 			// Strings need to be quoted in filters
 			sb.WriteString("'")
-			sb.WriteString(t)
+			sb.WriteString(p.RawString())
 			sb.WriteString("'")
-		default:
+
+		} else {
 			sb.WriteString(p.RawString())
 		}
+
 		f, err := labelsutil.CreateFilter(sb.String())
 		if err != nil {
 			return filters, err

--- a/prov/hostspool/testdata/topology_hp_compute.yaml
+++ b/prov/hostspool/testdata/topology_hp_compute.yaml
@@ -1,0 +1,68 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: Testfilter
+  template_version: 0.1.0-SNAPSHOT
+  template_author: yorctester
+
+description: ""
+
+imports:
+  - <yorc-types.yml>
+  - <yorc-hostspool-types.yml>
+  - <normative-types.yml>
+
+topology_template:
+  node_templates:
+    Compute:
+      type: yorc.nodes.hostspool.Compute
+      properties:
+        shareable: true
+      capabilities:
+        endpoint:
+          properties:
+            credentials:
+              user: "not significant, set by Yorc itself"
+            secure: true
+            protocol: tcp
+            network_name: PRIVATE
+            initiator: source
+        host:
+          properties:
+            num_cpus: 1
+            disk_size: "20 GB"
+        os:
+          properties:
+            type: linux
+        scalable:
+          properties:
+            min_instances: 1
+            max_instances: 1
+            default_instances: 1
+  workflows:
+    install:
+      steps:
+        Compute_install:
+          target: Compute
+          activities:
+            - delegate: install
+    uninstall:
+      steps:
+        Compute_uninstall:
+          target: Compute
+          activities:
+            - delegate: uninstall
+    start:
+      steps:
+        Compute_start:
+          target: Compute
+          activities:
+            - delegate: start
+    stop:
+      steps:
+        Compute_stop:
+          target: Compute
+          activities:
+            - delegate: stop
+    run:
+    cancel:


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fixed an issue attempting to deploy an application with Compute resources constraints on number of CPUs (or any other non-string constraint).

### What I did

Relying on a capability property type to know if the property value is a string or not.
Previous code was relying on a ToscaValue type which is always a string, even for non-string properties, so this was not the right way to determine a property value type.
Detailed changes per file:

`deployments/capabilities.go`:
Added function `GetCapabilityPropertyType` returning the type of a capability property

`deployments/capabilities_test.go`:
Added a unit test for new function `GetCapabilityPropertyType`

`deployments/testdata/capabilities.yaml`:
Added a string property to a capability, used in unit tests

`prov/hostspool/consul_test.go`:
Populating consul with deployment data from testdata/topology_hp_compute.yaml
Calling new test `testCreateFiltersFromComputeCapabilities`

`prov/hostspool/executor.go`:
Getting the type of a capability property. If this is a string, surrounding the property value by quotes in the property value, as required now for strings (while non-string values must not be quoted)

`prov/hostspool/executor.go`:
Changed previous code relying on the ToscaValue type of a property value, as this type is always a string (see `deployments/commons.go`, function `getValueAssignmentWithoutResolve()`)
and using new function `deployments.GetCapabilityPropertyType()` to get a property type, and quoting the value if and only if the type is as string, ans expected by the filter implementation.

`prov/hostspool/executor_test.go`:
Added a unit test checking the creation fo filters from compute capabilities

`prov/hostspool/testdata/topology_hp_compute.yaml`:
New test deployment topology with compute capabilities to test

### How to verify it

Define a Hosts Pool in Yorc, specifying labels to describe hosts resources, like :
```yaml
hosts:
- name: host1
  connection:
    user: myuser
    host: 1.2.3.4
    port: 22
  labels:
    host.cpu_frequency: 3 GHz
    host.disk_size: 40 GB
    host.mem_size: 4GB
    host.num_cpus: 2
    os.architecture: x86_64
    os.distribution: centos
    os.type: linux
    os.version: "7.3.1611"
    private_address: "10.0.0.123"
    public_address: "1.2.3.4"
```

From Alien4Cloud, create an application made of a Compute instance with these constraints on Compute Resources :

![compute](https://user-images.githubusercontent.com/33217305/58263947-4dbb1100-7d7d-11e9-9496-f9405c8f9627.PNG)


Attempt to deploy the application On the Hosts Pool location defined with a shareable compute resource, check the deployment is successful

### Description for the changelog

Failure to deploy an application with Compute resources constraints on Hosts Pool ([GH-409](https://github.com/ystia/yorc/issues/409))

## Applicable Issues

Fixes #409 
