### PR TITLE
Bugfix/bootstrap hp private ip input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### BUG FIXES
 
+* Yorc bootstrap on HostPool in interactive mode should ask for hosts private IP addresses also ([GH-411](https://github.com/ystia/yorc/issues/411))
 * Secure bootstrap on Hosts Pool fails configuring infra, error "playbooks must be a list of plays" ([GH-396](https://github.com/ystia/yorc/issues/396))
 * Kubernetes infrastructure configuration support in Yorc is not able to detect erroneous config file path ([GH-378](https://github.com/ystia/yorc/issues/378))
 

--- a/commands/bootstrap/inputs.go
+++ b/commands/bootstrap/inputs.go
@@ -188,6 +188,8 @@ var (
 			value:       "",
 		},
 	}
+
+	mandatoryHostPoolLabels = []string{"public_address", "private_address"}
 )
 
 // Infrastructure inputs, which when missing, will have to be provided interactively
@@ -605,10 +607,24 @@ func initializeInputs(inputFilePath, resourcesPath string, configuration config.
 				return err
 			}
 		} else {
+
 			// The private SSH key used to connect to each host is the Yorc private key
+			// Initializing this private key and checking as well mandatory
+			// labels are defined
 			privateKeyPath := filepath.Join(inputValues.Yorc.DataDir, ".ssh", "yorc.pem")
-			for i := range inputValues.Hosts {
-				inputValues.Hosts[i].Connection.PrivateKey = privateKeyPath
+			for _, host := range inputValues.Hosts {
+				host.Connection.PrivateKey = privateKeyPath
+				// Checking labels
+				if host.Labels == nil {
+					return fmt.Errorf("Missing mandatory labels %s for host %s",
+						strings.Join(mandatoryHostPoolLabels, ", "), host.Name)
+				}
+				for _, label := range mandatoryHostPoolLabels {
+					if _, found := host.Labels[label]; !found {
+						return fmt.Errorf("Missing mandatory label %s for host %s",
+							label, host.Name)
+					}
+				}
 			}
 		}
 	}
@@ -1107,23 +1123,27 @@ func getHostsInputs(resourcesPath string) ([]rest.HostConfig, error) {
 			hostConfig.Connection.Port = 22
 		}
 
-		//asking public address first
-		fmt.Println("Defining key/value labels for this host. Defining public_address value is mandatory")
+		//asking public/private address first
+		fmt.Println("Defining key/value labels for this host")
+		fmt.Printf("Inputs for labels %s are mandatory\n",
+			strings.Join(mandatoryHostPoolLabels, ", "))
 		hostConfig.Labels = make(map[string]string)
 
-		prompt = &survey.Input{
-			Message: "public_address value:"}
+		for _, label := range mandatoryHostPoolLabels {
+			prompt = &survey.Input{
+				Message: label + " value:"}
 
-		question = &survey.Question{
-			Name:     "value",
-			Prompt:   prompt,
-			Validate: survey.Required,
-		}
-		if err := survey.Ask([]*survey.Question{question}, &answer); err != nil {
-			return nil, err
-		}
+			question = &survey.Question{
+				Name:     "value",
+				Prompt:   prompt,
+				Validate: survey.Required,
+			}
+			if err := survey.Ask([]*survey.Question{question}, &answer); err != nil {
+				return nil, err
+			}
 
-		hostConfig.Labels["public_address"] = answer.Value
+			hostConfig.Labels[label] = answer.Value
+		}
 
 		//asking for additional key values labels
 		for {


### PR DESCRIPTION
# Pull Request description

## Description of the change

Previous code was only asking for a mandatory label `public_address` when adding a host in a Hosts Pool.
The code is now asking as well to define a label `private_adress`.
This is needed as some scripts installing components from the stack are referencing the host private address.

### What I did

Making input mandatory in interactive sessions.
Checking the label is defined in non-interactive sessions (using config files).


### How to verify it

Either, do a bootstrap in interactive mode on Hosts Pool, and check providing a public and private IP address is mandatory,
or use a bootstrap config file with for example this settings for a host in the Pool:
```yaml
hosts:
- name: host1
  connection:
    user: centos
    private_key: /path/to/privatekey
    host: 10.1.2.3
    port: 22
  labels:
    os.type: linux
    public_address: 10.1.2.3
```
and check an error appears describing a label private_address is missing.

### Description for the changelog

Yorc bootstrap on HostPool in interactive mode should ask for hosts private IP addresses also ([GH-411](https://github.com/ystia/yorc/issues/411))

## Applicable Issues

Fixes #411