### PR TITLE
Bugfix/gh 413 concurrent map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### BUG FIXES
 
+* Yorc server crashes on error: fatal error: concurrent map write ([GH-413](https://github.com/ystia/yorc/issues/413))
 * Yorc bootstrap on HostPool in interactive mode should ask for hosts private IP addresses also ([GH-411](https://github.com/ystia/yorc/issues/411))
 * Secure bootstrap on Hosts Pool fails configuring infra, error "playbooks must be a list of plays" ([GH-396](https://github.com/ystia/yorc/issues/396))
 * Kubernetes infrastructure configuration support in Yorc is not able to detect erroneous config file path ([GH-378](https://github.com/ystia/yorc/issues/378))

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -68,7 +68,7 @@ const ansibleInventoryHostedHeader = "hosted_operations"
 const ansibleInventoryHostsVarsHeader = ansibleInventoryHostsHeader + ":vars"
 const ansibleInventoryHostedVarsHeader = ansibleInventoryHostedHeader + ":vars"
 
-var ansibleConfig = map[string]map[string]string{
+var ansibleDefaultConfig = map[string]map[string]string{
 	ansibleConfigDefaultsHeader: map[string]string{
 		"host_key_checking": "False",
 		"timeout":           "30",
@@ -1346,6 +1346,8 @@ func (e *executionCommon) vaultEncodeString(s, ansibleRecipePath string) (string
 func (e *executionCommon) generateAnsibleConfigurationFile(
 	ansiblePath, ansibleRecipePath string) error {
 
+	ansibleConfig := getAnsibleConfigFromDefault()
+
 	// Adding settings whose values are known at runtime, related to the deployment
 	// directory path
 	ansibleConfig[ansibleConfigDefaultsHeader]["retry_files_save_path"] = ansibleRecipePath
@@ -1385,4 +1387,16 @@ func (e *executionCommon) generateAnsibleConfigurationFile(
 	}
 
 	return err
+}
+
+func getAnsibleConfigFromDefault() map[string]map[string]string {
+	ansibleConfig := make(map[string]map[string]string, len(ansibleDefaultConfig))
+	for k, mapVal := range ansibleDefaultConfig {
+		newVal := make(map[string]string, len(mapVal))
+		for internalK, internalV := range mapVal {
+			newVal[internalK] = internalV
+		}
+		ansibleConfig[k] = newVal
+	}
+	return ansibleConfig
 }


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fixed an issue where a global variable map storing default values for ansible configuration was modified concurrently by different routines.

### What I did

The routine creating ansible configuration is using now a local variable map, initialized by copying default values from the global variable map which is not modified anymore.

Added a unit tests running concurrently routines, that was reproducing the concurrency issue before the fix, and that is now passing after the fix.

### How to verify it

Run unit tests.

### Description for the changelog

 Yorc server crashes on error: fatal error: concurrent map write ([GH-413](https://github.com/ystia/yorc/issues/413))

## Applicable Issues

Fixes #413
