### PR TITLE
Feature/gh 419 ubuntu 1904 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### ENHANCEMENTS
 
+* Bootstrap support of Ubuntu 1904 ([GH-419](https://github.com/ystia/yorc/issues/419))
 * Print plugin logs in higher level than DEBUG ([GH-329](https://github.com/ystia/yorc/issues/329))
 * Slurm job logs are displayed many time ([GH-397](https://github.com/ystia/yorc/issues/397))
 * Allow to configure resources prefix for bootstrapped Yorc ([GH-399](https://github.com/ystia/yorc/issues/399))

--- a/doc/bootstrap.rst
+++ b/doc/bootstrap.rst
@@ -36,7 +36,7 @@ The bootstrap was validated on:
 
   * CentOS 7,
   * Red Hat Enterprise Linux 7.5,
-  * Ubuntu 18.10 (which is installing python3 by default, see 
+  * Ubuntu 19.04 (which is installing python3 by default, see 
     :ref:`bootstrap configuration file <yorc_google_example_ubuntu_section>`
     example below for specific Ansible configuration settings needed for remote 
     hosts using python3).
@@ -343,10 +343,10 @@ Example of a Google Cloud deployment configuration file
 
 .. _yorc_google_example_ubuntu_section:
 
-Example of a Google Cloud deployment configuration with Ubuntu 18.10 on-demand compute
+Example of a Google Cloud deployment configuration with Ubuntu 19.04 on-demand compute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In this example, on-demand compute instances run Ubuntu 18.10 on which python3
+In this example, on-demand compute instances run Ubuntu 19.04 on which python3
 is installed by default (and not python).
 In this case, a specific Ansible behavioral inventory parameter 
 ``ansible_python_interpreter`` must be defined so that Ansible is able to find 
@@ -373,7 +373,7 @@ this python interpreter on the remote hosts.
       project: myproject
   ansible:
     inventory:
-      # Remote host run Ubuntu 18.10, using python3.
+      # Remote host run Ubuntu 19.04, using python3.
       # Defining here the Ansible behavioral inventory parameter ansible_python_interpreter
       # pointing to python3.
       # This is required or Ansible will attempt to use python on the remote host
@@ -384,7 +384,7 @@ this python interpreter on the remote hosts.
     region: europe-west1
   compute:
     image_project: ubuntu-os-cloud
-    image_family: ubuntu-1810
+    image_family: ubuntu-1904
     machine_type: n1-standard-2
     zone: europe-west1-b
     # User and public key to define on created compute instance


### PR DESCRIPTION
# Pull Request description


## Description of the change

As Ubuntu 1810 will be soon EOL, and the bootstrap has been validated already on Ubuntu 1904, updated the bootstrap documentation to mention it supports this version.
Updated the example bootstrapping Yorc on this OS in GCP.

### Description for the changelog

Bootstrap support of Ubuntu 1904 ([GH-419](https://github.com/ystia/yorc/issues/419))

## Applicable Issues

Fixes #419
