### PR TITLE
Fix Erroneous Warning message on purged deployments timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Kubernetes infrastructure configuration support in Yorc is not able to detect erroneous config file path ([GH-378](https://github.com/ystia/yorc/issues/378))
 * Emit a persistent event on deployment purge ([GH-402](https://github.com/ystia/yorc/issues/402))
 * Invalid memory address panic appends on a workflow with non-existent on success step reference ([GH-417](https://github.com/ystia/yorc/issues/417))
+* Erroneous Warning message on purged deployments timestamp ([GH-421](https://github.com/ystia/yorc/issues/421))
 
 ## 3.2.0-RC1 (May 10, 2019)
 


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fixed warn msg fmt + ignore lock key on purged deps

### Description for the changelog

*  Erroneous Warning message on purged deployments timestamp ([GH-421](https://github.com/ystia/yorc/issues/421))

## Applicable Issues

Fixes #421 
