### PR TITLE
Support operation long naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Yorc should support long standard operation names as well as short ones ([GH-300](https://github.com/ystia/yorc/issues/300))
+
 ### ENHANCEMENTS
 
 * Bootstrap support of Ubuntu 1904 ([GH-419](https://github.com/ystia/yorc/issues/419))

--- a/deployments/operations.go
+++ b/deployments/operations.go
@@ -175,6 +175,8 @@ func getOperationAndInterfacePath(kv *api.KV, deploymentID, nodeTemplateImpl, no
 	interfaceName := stringutil.GetAllExceptLastElement(operationName, ".")
 	if strings.HasPrefix(interfaceName, tosca.StandardInterfaceName) {
 		interfaceName = strings.Replace(interfaceName, tosca.StandardInterfaceName, tosca.StandardInterfaceShortName, 1)
+	} else if strings.HasPrefix(interfaceName, tosca.ConfigureInterfaceName) {
+		interfaceName = strings.Replace(interfaceName, tosca.ConfigureInterfaceName, tosca.ConfigureInterfaceShortName, 1)
 	}
 	if nodeTemplateImpl != "" {
 		operationPath = path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/nodes", nodeTemplateImpl, "interfaces", interfaceName, opShortName)

--- a/deployments/operations.go
+++ b/deployments/operations.go
@@ -174,7 +174,7 @@ func getOperationAndInterfacePath(kv *api.KV, deploymentID, nodeTemplateImpl, no
 
 	interfaceName := stringutil.GetAllExceptLastElement(operationName, ".")
 	if strings.HasPrefix(interfaceName, tosca.StandardInterfaceName) {
-		interfaceName = strings.Replace(interfaceName, tosca.StandardInterfaceName, "standard", 1)
+		interfaceName = strings.Replace(interfaceName, tosca.StandardInterfaceName, tosca.StandardInterfaceShortName, 1)
 	}
 	if nodeTemplateImpl != "" {
 		operationPath = path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/nodes", nodeTemplateImpl, "interfaces", interfaceName, opShortName)

--- a/deployments/operations.go
+++ b/deployments/operations.go
@@ -171,7 +171,11 @@ func getOperationPath(kv *api.KV, deploymentID, nodeTemplate, nodeType, operatio
 func getOperationAndInterfacePath(kv *api.KV, deploymentID, nodeTemplateImpl, nodeTypeImpl, operationName string) (string, string, error) {
 	var operationPath, interfacePath string
 	opShortName := stringutil.GetLastElement(operationName, ".")
+
 	interfaceName := stringutil.GetAllExceptLastElement(operationName, ".")
+	if strings.HasPrefix(interfaceName, tosca.StandardInterfaceName) {
+		interfaceName = strings.Replace(interfaceName, tosca.StandardInterfaceName, "standard", 1)
+	}
 	if nodeTemplateImpl != "" {
 		operationPath = path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/nodes", nodeTemplateImpl, "interfaces", interfaceName, opShortName)
 		interfacePath = path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/nodes", nodeTemplateImpl, "interfaces", interfaceName)

--- a/deployments/operations_test.go
+++ b/deployments/operations_test.go
@@ -55,6 +55,7 @@ func testOperationImplementationArtifactPrimary(t *testing.T, kv *api.KV, deploy
 		want checks
 	}{
 		{"TestBashOnNodeType", args{"yorc.tests.nodes.OpImplementationArtifact", "standard.create"}, checks{"tosca.artifacts.Implementation.Bash", "scripts/create.sh"}},
+		{"TestBashOnNodeType", args{"yorc.tests.nodes.OpImplementationArtifact", "tosca.interfaces.node.lifecycle.standard.create"}, checks{"tosca.artifacts.Implementation.Bash", "scripts/create.sh"}},
 		{"TestBashOnRelType", args{"yorc.tests.relationships.OpImplementationArtifact", "configure.pre_configure_source"}, checks{"tosca.artifacts.Implementation.Bash", "something"}},
 		{"TestBashOnImportedRelType", args{"yorc.tests.relationships.imports.OpImplementationArtifact", "configure.pre_configure_source"}, checks{"tosca.artifacts.Implementation.Bash", "imports/something"}},
 		{"TestBashOnImportedNodeType", args{"yorc.tests.nodes.imports.OpImplementationArtifact", "standard.create"}, checks{"tosca.artifacts.Implementation.Bash", "imports/scripts/create.sh"}},
@@ -88,6 +89,7 @@ func testGetOperationImplementationFile(t *testing.T, kv *api.KV, deploymentID s
 		want want
 	}{
 		{"TestOpImplemFileOnImplemArtifactNodeType", args{"yorc.tests.nodes.OpImplementationArtifact", "standard.create"}, want{"scripts/create.sh", "scripts/create.sh"}},
+		{"TestOpImplemFileOnImplemArtifactNodeType", args{"yorc.tests.nodes.OpImplementationArtifact", "tosca.interfaces.node.lifecycle.standard.create"}, want{"scripts/create.sh", "scripts/create.sh"}},
 		{"TestOpImplemFileOnImplemArtifactRelType", args{"yorc.tests.relationships.OpImplementationArtifact", "configure.pre_configure_source"}, want{"something", "something"}},
 		{"TestOpImplemFileOnImplemArtifactImportedNodeType", args{"yorc.tests.nodes.imports.OpImplementationArtifact", "standard.create"}, want{"scripts/create.sh", "imports/scripts/create.sh"}},
 		{"TestOpImplemFileOnImplemArtifactImportedRelType", args{"yorc.tests.relationships.imports.OpImplementationArtifact", "configure.pre_configure_source"}, want{"something", "imports/something"}},
@@ -125,6 +127,7 @@ func testOperationHost(t *testing.T, kv *api.KV) {
 		wantErr bool
 	}{
 		{"TestOperationHostOnNodeType", args{"yorc.tests.OperationHosts.nodes.OHNode", "standard", "create"}, "ORCHESTRATOR", false},
+		{"TestOperationHostOnNodeType", args{"yorc.tests.OperationHosts.nodes.OHNode", "tosca.interfaces.node.lifecycle.standard", "create"}, "ORCHESTRATOR", false},
 		{"TestOperationHostDefault1OnNodeType", args{"yorc.tests.OperationHosts.nodes.OHNode", "standard", "configure"}, "", false},
 		{"TestOperationHostDefault2OnNodeType", args{"yorc.tests.OperationHosts.nodes.OHNode", "standard", "start"}, "", false},
 		{"TestOperationHostDefault3OnNodeType", args{"yorc.tests.OperationHosts.nodes.OHNode", "standard", "stop"}, "", false},

--- a/deployments/operations_test.go
+++ b/deployments/operations_test.go
@@ -55,9 +55,11 @@ func testOperationImplementationArtifactPrimary(t *testing.T, kv *api.KV, deploy
 		want checks
 	}{
 		{"TestBashOnNodeType", args{"yorc.tests.nodes.OpImplementationArtifact", "standard.create"}, checks{"tosca.artifacts.Implementation.Bash", "scripts/create.sh"}},
-		{"TestBashOnNodeType", args{"yorc.tests.nodes.OpImplementationArtifact", "tosca.interfaces.node.lifecycle.standard.create"}, checks{"tosca.artifacts.Implementation.Bash", "scripts/create.sh"}},
+		{"TestBashOnNodeTypeFQInterfaceName", args{"yorc.tests.nodes.OpImplementationArtifact", "tosca.interfaces.node.lifecycle.standard.create"}, checks{"tosca.artifacts.Implementation.Bash", "scripts/create.sh"}},
 		{"TestBashOnRelType", args{"yorc.tests.relationships.OpImplementationArtifact", "configure.pre_configure_source"}, checks{"tosca.artifacts.Implementation.Bash", "something"}},
 		{"TestBashOnImportedRelType", args{"yorc.tests.relationships.imports.OpImplementationArtifact", "configure.pre_configure_source"}, checks{"tosca.artifacts.Implementation.Bash", "imports/something"}},
+		{"TestBashOnRelTypeWithFQInterfaceName", args{"yorc.tests.relationships.OpImplementationArtifact", "tosca.interfaces.relationships.configure.pre_configure_source"}, checks{"tosca.artifacts.Implementation.Bash", "something"}},
+		{"TestBashOnImportedRelTypeFQInterfaceName", args{"yorc.tests.relationships.imports.OpImplementationArtifact", "tosca.interfaces.relationships.configure.pre_configure_source"}, checks{"tosca.artifacts.Implementation.Bash", "imports/something"}},
 		{"TestBashOnImportedNodeType", args{"yorc.tests.nodes.imports.OpImplementationArtifact", "standard.create"}, checks{"tosca.artifacts.Implementation.Bash", "imports/scripts/create.sh"}},
 	}
 
@@ -89,10 +91,11 @@ func testGetOperationImplementationFile(t *testing.T, kv *api.KV, deploymentID s
 		want want
 	}{
 		{"TestOpImplemFileOnImplemArtifactNodeType", args{"yorc.tests.nodes.OpImplementationArtifact", "standard.create"}, want{"scripts/create.sh", "scripts/create.sh"}},
-		{"TestOpImplemFileOnImplemArtifactNodeType", args{"yorc.tests.nodes.OpImplementationArtifact", "tosca.interfaces.node.lifecycle.standard.create"}, want{"scripts/create.sh", "scripts/create.sh"}},
+		{"TestOpImplemFileOnImplemArtifactNodeTypeFQInterfaceName", args{"yorc.tests.nodes.OpImplementationArtifact", "tosca.interfaces.node.lifecycle.standard.create"}, want{"scripts/create.sh", "scripts/create.sh"}},
 		{"TestOpImplemFileOnImplemArtifactRelType", args{"yorc.tests.relationships.OpImplementationArtifact", "configure.pre_configure_source"}, want{"something", "something"}},
 		{"TestOpImplemFileOnImplemArtifactImportedNodeType", args{"yorc.tests.nodes.imports.OpImplementationArtifact", "standard.create"}, want{"scripts/create.sh", "imports/scripts/create.sh"}},
 		{"TestOpImplemFileOnImplemArtifactImportedRelType", args{"yorc.tests.relationships.imports.OpImplementationArtifact", "configure.pre_configure_source"}, want{"something", "imports/something"}},
+		{"TestOpImplemFileOnImplemArtifactImportedRelTypeFQInterfaceName", args{"yorc.tests.relationships.imports.OpImplementationArtifact", "tosca.interfaces.relationships.configure.pre_configure_source"}, want{"something", "imports/something"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -127,7 +130,7 @@ func testOperationHost(t *testing.T, kv *api.KV) {
 		wantErr bool
 	}{
 		{"TestOperationHostOnNodeType", args{"yorc.tests.OperationHosts.nodes.OHNode", "standard", "create"}, "ORCHESTRATOR", false},
-		{"TestOperationHostOnNodeType", args{"yorc.tests.OperationHosts.nodes.OHNode", "tosca.interfaces.node.lifecycle.standard", "create"}, "ORCHESTRATOR", false},
+		{"TestOperationHostOnNodeTypeFQInterfaceName", args{"yorc.tests.OperationHosts.nodes.OHNode", "tosca.interfaces.node.lifecycle.standard", "create"}, "ORCHESTRATOR", false},
 		{"TestOperationHostDefault1OnNodeType", args{"yorc.tests.OperationHosts.nodes.OHNode", "standard", "configure"}, "", false},
 		{"TestOperationHostDefault2OnNodeType", args{"yorc.tests.OperationHosts.nodes.OHNode", "standard", "start"}, "", false},
 		{"TestOperationHostDefault3OnNodeType", args{"yorc.tests.OperationHosts.nodes.OHNode", "standard", "stop"}, "", false},
@@ -135,6 +138,10 @@ func testOperationHost(t *testing.T, kv *api.KV) {
 		{"TestOperationHostDefault1OnNodeType", args{"yorc.tests.OperationHosts.relationships.OHRel", "configure", "post_configure_target"}, "", false},
 		{"TestOperationHostDefault2OnNodeType", args{"yorc.tests.OperationHosts.relationships.OHRel", "configure", "add_source"}, "", false},
 		{"TestOperationHostDefault3OnNodeType", args{"yorc.tests.OperationHosts.relationships.OHRel", "configure", "remove_target"}, "", false},
+		{"TestOperationHostOnNodeType", args{"yorc.tests.OperationHosts.relationships.OHRel", "tosca.interfaces.relationships.configure", "pre_configure_source"}, "ORCHESTRATOR", false},
+		{"TestOperationHostDefault1OnNodeTypeFQInterfaceName", args{"yorc.tests.OperationHosts.relationships.OHRel", "tosca.interfaces.relationships.configure", "post_configure_target"}, "", false},
+		{"TestOperationHostDefault2OnNodeTypeFQInterfaceName", args{"yorc.tests.OperationHosts.relationships.OHRel", "tosca.interfaces.relationships.configure", "add_source"}, "", false},
+		{"TestOperationHostDefault3OnNodeTypeFQInterfaceName", args{"yorc.tests.OperationHosts.relationships.OHRel", "tosca.interfaces.relationships.configure", "remove_target"}, "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tosca/constants.go
+++ b/tosca/constants.go
@@ -25,3 +25,6 @@ const RunnableRunOperationName = RunnableInterfaceName + ".run"
 
 // RunnableCancelOperationName is the fully qualified name of the Cancel operation
 const RunnableCancelOperationName = RunnableInterfaceName + ".cancel"
+
+// StandardInterfaceName is the fully qualified name of the Standard interface
+const StandardInterfaceName = "tosca.interfaces.node.lifecycle.standard"

--- a/tosca/constants.go
+++ b/tosca/constants.go
@@ -28,3 +28,6 @@ const RunnableCancelOperationName = RunnableInterfaceName + ".cancel"
 
 // StandardInterfaceName is the fully qualified name of the Standard interface
 const StandardInterfaceName = "tosca.interfaces.node.lifecycle.standard"
+
+// StandardInterfaceShortName is the short name of the Standard interface
+const StandardInterfaceShortName = "standard"

--- a/tosca/constants.go
+++ b/tosca/constants.go
@@ -31,3 +31,9 @@ const StandardInterfaceName = "tosca.interfaces.node.lifecycle.standard"
 
 // StandardInterfaceShortName is the short name of the Standard interface
 const StandardInterfaceShortName = "standard"
+
+// ConfigureInterfaceName is the fully qualified name of the Configure interface
+const ConfigureInterfaceName = "tosca.interfaces.relationships.configure"
+
+// ConfigureInterfaceShortName is the short name of the Configure interface
+const ConfigureInterfaceShortName = "configure"


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

### How I did it
 if operation name contains tosca.interfaces.node.lifecycle.standard:
-> use the short name "standard" to find related interface path in Consul KV
### How to verify it
- Pass U-Tests
- Create a Worflow with Alien4Cloud which contains a call-operation from standard interface
### Description for the changelog
* Yorc should support long standard operation names as well as short ones ([GH-300](https://github.com/ystia/yorc/issues/300))

## Applicable Issues
#300 