### PR TITLE
Bugfix/gh 430 hp delete host prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### BUG FIXES
 
+* Deleting one host in Pool deletes other hosts having as prefix the deleted hostname ([GH-430](https://github.com/ystia/yorc/issues/430))
 * Yorc should support long standard operation names as well as short ones ([GH-300](https://github.com/ystia/yorc/issues/300))
+
+## 3.2.0 (May 31, 2019)
 
 ### ENHANCEMENTS
 

--- a/prov/hostspool/consul_test.go
+++ b/prov/hostspool/consul_test.go
@@ -43,6 +43,9 @@ func TestRunConsulHostsPoolPackageTests(t *testing.T) {
 	t.Run("TestConsulManagerRemove", func(t *testing.T) {
 		testConsulManagerRemove(t, client)
 	})
+	t.Run("TestConsulManagerRemoveHostWithSamePrefix", func(t *testing.T) {
+		testConsulManagerRemoveHostWithSamePrefix(t, client)
+	})
 	t.Run("TestConsulManagerAddLabels", func(t *testing.T) {
 		testConsulManagerAddLabels(t, client)
 	})

--- a/prov/hostspool/hostspool_mgr.go
+++ b/prov/hostspool/hostspool_mgr.go
@@ -264,7 +264,10 @@ func (cm *consulManager) getRemoveOperations(hostname string, checkStatus bool) 
 		return nil, errors.WithStack(badRequestError{`"hostname" missing`})
 	}
 
-	hostKVPrefix := path.Join(consulutil.HostsPoolPrefix, hostname)
+	hostKey := path.Join(consulutil.HostsPoolPrefix, hostname)
+	// Need to remove the host key subtree, but not the tree of hosts having a
+	// hostname containg as a prefix the name of the host to delete
+	hostKeyTreePrexix := hostKey + "/"
 
 	if checkStatus {
 		status, err := cm.GetHostStatus(hostname)
@@ -282,7 +285,11 @@ func (cm *consulManager) getRemoveOperations(hostname string, checkStatus bool) 
 	rmOps := api.KVTxnOps{
 		&api.KVTxnOp{
 			Verb: api.KVDeleteTree,
-			Key:  hostKVPrefix,
+			Key:  hostKeyTreePrexix,
+		},
+		&api.KVTxnOp{
+			Verb: api.KVDelete,
+			Key:  hostKey,
 		},
 	}
 

--- a/prov/hostspool/hostspool_mgr.go
+++ b/prov/hostspool/hostspool_mgr.go
@@ -266,7 +266,7 @@ func (cm *consulManager) getRemoveOperations(hostname string, checkStatus bool) 
 
 	hostKey := path.Join(consulutil.HostsPoolPrefix, hostname)
 	// Need to remove the host key subtree, but not the tree of hosts having a
-	// hostname containg as a prefix the name of the host to delete
+	// hostname containing as a prefix the name of the host to delete
 	hostKeyTreePrexix := hostKey + "/"
 
 	if checkStatus {

--- a/prov/hostspool/hostspool_mgr_test.go
+++ b/prov/hostspool/hostspool_mgr_test.go
@@ -427,6 +427,24 @@ func testConsulManagerRemove(t *testing.T, cc *api.Client) {
 	}
 }
 
+// testConsulManagerRemoveHostWithSamePrefix checks removing a given host in
+// the Pool won't remove other hosts having as hostname a name which has as prefix
+// the hostname of the delete host
+func testConsulManagerRemoveHostWithSamePrefix(t *testing.T, cc *api.Client) {
+	cleanupHostsPool(t, cc)
+	cm := NewManagerWithSSHFactory(cc, mockSSHClientFactory)
+	cm.Add("myHost", Connection{PrivateKey: dummySSHkey}, nil)
+	cm.Add("myHost2", Connection{PrivateKey: dummySSHkey}, nil)
+
+	err := cm.Remove("myHost")
+	require.NoError(t, err, "Unexpected error removing host from Hosts Pool")
+
+	// Check the second host is still there
+	host, err := cm.GetHost("myHost2")
+	require.NoError(t, err, "Found no host myHost2 in Pool")
+	assert.Equal(t, "myHost2", host.Name)
+}
+
 func testConsulManagerList(t *testing.T, cc *api.Client) {
 	cleanupHostsPool(t, cc)
 	cm := &consulManager{cc, mockSSHClientFactory}


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fixed an issue where deleting a given host in a Pool was actually deleting all hosts in the Pool having in their hostname as a prefix the name of the host to delete.

### What I did

Added a unit test reproducing the issue.
Fixed the code asking consul to delete a subtree, given that deleting a subtree `a/b` will actually delete `a/b*`

### How to verify it

Create a Hosts Pool containing hosts with the following hostnames: `myhost`, `myhost1`, `myhost2`.
Then delete host `myhost` in the Hosts Pool running :
```bash
$ yorc hp delete myhost
```

Check `myhost` is delete as expected.
Check `myhost1` and `myhost2` are still in the Hosts Pool.

### Description for the changelog

Deleting one host in Pool deletes other hosts having as prefix the deleted hostname ([GH-430](https://github.com/ystia/yorc/issues/430))

## Applicable Issues

Fixes #430
