### PR TITLE
Feature/gh 425 expose bypass error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### ENHANCEMENTS
 
+* Expose bypass error parameter on workflow ([GH-425](https://github.com/ystia/yorc/issues/425))
+
+## 3.2.0 (May 31, 2019)
+
+### ENHANCEMENTS
+
 * Bootstrap support of Ubuntu 1904 ([GH-419](https://github.com/ystia/yorc/issues/419))
 * Print plugin logs in higher level than DEBUG ([GH-329](https://github.com/ystia/yorc/issues/329))
 * Slurm job logs are displayed many time ([GH-397](https://github.com/ystia/yorc/issues/397))

--- a/commands/deployments/dep_undeploy.go
+++ b/commands/deployments/dep_undeploy.go
@@ -81,7 +81,7 @@ func init() {
 
 	DeploymentsCmd.AddCommand(undeployCmd)
 	undeployCmd.PersistentFlags().BoolVarP(&purge, "purge", "p", false, "To use if you want to purge instead of undeploy")
-	undeployCmd.PersistentFlags().BoolVarP(&stopOnError, "stop-on-error", "", false, "By default if an error occurs during the undeployment, the error is bypassed and the un-deployment continues. This flag allows to stop if an error occurs.")
+	undeployCmd.PersistentFlags().BoolVarP(&stopOnError, "stop-on-error", "", false, "By default if an error occurs during the undeployment, the error is bypassed and the undeployment continues. This flag allows to stop if an error occurs.")
 	undeployCmd.PersistentFlags().BoolVarP(&shouldStreamLogs, "stream-logs", "l", false, "Stream logs after undeploying the application. In this mode logs can't be filtered, to use this feature see the \"log\" command.")
 	undeployCmd.PersistentFlags().BoolVarP(&shouldStreamEvents, "stream-events", "e", false, "Stream events after undeploying the CSAR.")
 

--- a/commands/deployments/dep_undeploy.go
+++ b/commands/deployments/dep_undeploy.go
@@ -17,6 +17,7 @@ package deployments
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -28,6 +29,7 @@ func init() {
 	var purge bool
 	var shouldStreamLogs bool
 	var shouldStreamEvents bool
+	var stopOnError bool
 	var undeployCmd = &cobra.Command{
 		Use:   "undeploy <DeploymentId>",
 		Short: "Undeploy an application",
@@ -41,16 +43,21 @@ func init() {
 				httputil.ErrExit(err)
 			}
 
-			url := "/deployments/" + args[0]
-			if purge {
-				url = url + "?purge=true"
-			}
+			urlStr := "/deployments/" + args[0]
 
-			request, err := client.NewRequest("DELETE", url, nil)
+			q := url.Values{}
+			if purge {
+				q.Add("purge", "true")
+			}
+			if stopOnError {
+				q.Add("stopOnError", "true")
+			}
+			request, err := client.NewRequest("DELETE", urlStr, nil)
 			if err != nil {
 				httputil.ErrExit(err)
 			}
 
+			request.URL.RawQuery = q.Encode()
 			request.Header.Add("Accept", "application/json")
 			response, err := client.Do(request)
 			if err != nil {
@@ -74,6 +81,7 @@ func init() {
 
 	DeploymentsCmd.AddCommand(undeployCmd)
 	undeployCmd.PersistentFlags().BoolVarP(&purge, "purge", "p", false, "To use if you want to purge instead of undeploy")
+	undeployCmd.PersistentFlags().BoolVarP(&stopOnError, "stop-on-error", "", false, "By default if an error occurs during the undeployment, the error is bypassed and the un-deployment continues. This flag allows to stop if an error occurs.")
 	undeployCmd.PersistentFlags().BoolVarP(&shouldStreamLogs, "stream-logs", "l", false, "Stream logs after undeploying the application. In this mode logs can't be filtered, to use this feature see the \"log\" command.")
 	undeployCmd.PersistentFlags().BoolVarP(&shouldStreamEvents, "stream-events", "e", false, "Stream events after undeploying the CSAR.")
 

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -76,6 +76,7 @@ Flags:
   * ``-p``, ``--purge``: To use if you want to purge instead of undeploy.
   * ``-e``, ``--stream-events``: Stream events after deploying the CSAR.
   * ``-l``, ``--stream-logs``: Stream logs after deploying the CSAR. In this mode logs can't be filtered, to use this feature see the "log" command.
+  * ``--stop-on-error``: By default if an error occurs during the undeployment, the error is bypassed and the undeployment continues. This flag allows to stop if an error occurs.
 
 
 List deployments

--- a/rest/consul_test.go
+++ b/rest/consul_test.go
@@ -73,5 +73,8 @@ func TestRunConsulRestPackageTests(t *testing.T) {
 		t.Run("testSSLRest", func(t *testing.T) {
 			testSSLREST(t, client, srv)
 		})
+		t.Run("testDeploymentHandlers", func(t *testing.T) {
+			testDeploymentHandlers(t, client, srv)
+		})
 	})
 }

--- a/rest/deployments.go
+++ b/rest/deployments.go
@@ -236,8 +236,20 @@ func (s *Server) deleteDeploymentHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	purge := false
+	if purgeKeys, ok := r.URL.Query()["purge"]; ok {
+		if len(purgeKeys) > 0 && len(purgeKeys[0]) > 0 {
+			purge, err = strconv.ParseBool(purgeKeys[0])
+			if err != nil {
+				writeError(w, r, newBadRequestMessage("purge query parameter must be a boolean value"))
+				return
+			}
+		} else {
+			purge = true
+		}
+	}
 	var taskType tasks.TaskType
-	if _, ok := r.URL.Query()["purge"]; ok {
+	if purge {
 		log.Debugf("A purge task on deployment:%s has been requested", id)
 		taskType = tasks.TaskTypePurge
 	} else {
@@ -263,7 +275,7 @@ func (s *Server) deleteDeploymentHandler(w http.ResponseWriter, r *http.Request)
 		if len(stopKeys) > 0 && len(stopKeys[0]) > 0 {
 			stopOnError, err = strconv.ParseBool(stopKeys[0])
 			if err != nil {
-				writeError(w, r, newBadRequestMessage("stopOnError URL parameter must be a boolean value"))
+				writeError(w, r, newBadRequestMessage("stopOnError query parameter must be a boolean value"))
 				return
 			}
 		} else {

--- a/rest/deployments.go
+++ b/rest/deployments.go
@@ -236,17 +236,10 @@ func (s *Server) deleteDeploymentHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	purge := false
-	if purgeKeys, ok := r.URL.Query()["purge"]; ok {
-		if len(purgeKeys) > 0 && len(purgeKeys[0]) > 0 {
-			purge, err = strconv.ParseBool(purgeKeys[0])
-			if err != nil {
-				writeError(w, r, newBadRequestMessage("purge query parameter must be a boolean value"))
-				return
-			}
-		} else {
-			purge = true
-		}
+	purge, err := getBoolQueryParam(r, "purge")
+	if err != nil {
+		writeError(w, r, newBadRequestMessage("purge query parameter must be a boolean value"))
+		return
 	}
 	var taskType tasks.TaskType
 	if purge {
@@ -270,17 +263,10 @@ func (s *Server) deleteDeploymentHandler(w http.ResponseWriter, r *http.Request)
 		"workflowName": "uninstall",
 	}
 	// Default is not to stop on error for undeployment
-	stopOnError := false
-	if stopKeys, ok := r.URL.Query()["stopOnError"]; ok {
-		if len(stopKeys) > 0 && len(stopKeys[0]) > 0 {
-			stopOnError, err = strconv.ParseBool(stopKeys[0])
-			if err != nil {
-				writeError(w, r, newBadRequestMessage("stopOnError query parameter must be a boolean value"))
-				return
-			}
-		} else {
-			stopOnError = true
-		}
+	stopOnError, err := getBoolQueryParam(r, "stopOnError")
+	if err != nil {
+		writeError(w, r, newBadRequestMessage("stopOnError query parameter must be a boolean value"))
+		return
 	}
 	data["continueOnError"] = strconv.FormatBool(!stopOnError)
 	if taskID, err := s.tasksCollector.RegisterTaskWithData(id, taskType, data); err != nil {

--- a/rest/deployments_test.go
+++ b/rest/deployments_test.go
@@ -1,0 +1,102 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ystia/yorc/v3/helper/consulutil"
+	ytu "github.com/ystia/yorc/v3/testutil"
+)
+
+func testDeploymentHandlers(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	t.Run("testDeleteDeploymentHandlerWithParamValues", func(t *testing.T) {
+		testDeleteDeploymentHandlerWithParamValues(t, client, srv)
+	})
+}
+
+func testDeleteDeploymentHandlerWithParamValues(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	type ErrorStruct struct {
+		Id     string `json:"id,omitempty"`
+		Status int    `json:"status,omitempty"`
+		Title  string `json:"title,omitempty"`
+		Detail string `json:"detail,omitempty"`
+	}
+
+	type BodyStruct struct {
+		Errors []ErrorStruct `json:"errors,omitempty"`
+	}
+
+	type result struct {
+		statusCode int
+		body       *BodyStruct
+	}
+
+	deploymentID := ytu.BuildDeploymentID(t)
+	t.Parallel()
+	srv.PopulateKV(t, map[string][]byte{
+		consulutil.DeploymentKVPrefix + "/" + deploymentID + "/status": []byte("DEPLOYED"),
+	})
+
+	req := httptest.NewRequest("DELETE", "/deployments/"+deploymentID, nil)
+
+	tests := []struct {
+		name        string
+		stopOnError string
+		want        *result
+	}{
+		{"stopOnErrorWithBadValue", "badValue", &result{statusCode: http.StatusBadRequest, body: &BodyStruct{[]ErrorStruct{ErrorStruct{Id: "bad_request", Status: 400, Title: "Bad Request", Detail: "stopOnError URL parameter must be a boolean value"}}}}},
+		{"stopOnErrorWithCorrectValue", "true", &result{statusCode: http.StatusAccepted, body: nil}},
+		{"stopOnErrorWithNoValue", "", &result{statusCode: http.StatusAccepted, body: nil}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := url.Values{}
+			params.Add("stopOnError", tt.stopOnError)
+			req.URL.RawQuery = params.Encode()
+			resp := newTestHTTPRouter(client, req)
+			require.NotNil(t, resp, "unexpected nil response")
+			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)
+
+			bodyb, err := ioutil.ReadAll(resp.Body)
+			fmt.Println("body=" + string(bodyb))
+			require.Nil(t, err, "unexpected error reading body response")
+
+			if len(bodyb) > 0 {
+				var body *BodyStruct
+				err = json.Unmarshal(bodyb, &body)
+				require.Nil(t, err, "unexpected error unmarshalling json body")
+				fmt.Println(body)
+				if !reflect.DeepEqual(body, tt.want.body) {
+					t.Errorf("body = %v, want %v", body, tt.want)
+				}
+			} else if tt.want.body != nil {
+				t.Errorf("body is empty but want %v", tt.want)
+			}
+
+		})
+	}
+}

--- a/rest/deployments_test.go
+++ b/rest/deployments_test.go
@@ -78,7 +78,7 @@ func testDeleteDeploymentHandlerWithStopOnErrorParam(t *testing.T, client *api.C
 	t.Parallel()
 	type result struct {
 		statusCode      int
-		errors       *Errors
+		errors          *Errors
 		continueOnError bool
 	}
 
@@ -144,7 +144,7 @@ func testDeleteDeploymentHandlerWithPurgeParam(t *testing.T, client *api.Client,
 
 	type result struct {
 		statusCode int
-		errors       *Errors
+		errors     *Errors
 		taskType   tasks.TaskType
 	}
 
@@ -208,25 +208,25 @@ func testGetDeploymentHandler(t *testing.T, client *api.Client, srv *testutil.Te
 
 	type result struct {
 		statusCode int
-		errors       *Errors
+		errors     *Errors
 		deployment *Deployment
 	}
 
 	tests := []struct {
-		name       string
+		name         string
 		deploymentID string
-		want       *result
+		want         *result
 	}{
-	//	{"getDeploymentWithBadID", "badDeploymentID", &result{statusCode: http.StatusNotFound, errors: &Errors{[]*Error{errNotFound}}}},
-		{"getDeployment","getDeployment", &result{statusCode: http.StatusOK, errors: nil,
-			deployment:&Deployment{ID: "getDeployment", Status:"DEPLOYED",
-				Links:[]AtomLink{{Href:"/deployments/getDeployment", Rel:"self", LinkType:"application/json" },
-					{Href:"/deployments/getDeployment/nodes/Compute", Rel:"node", LinkType:"application/json" }}}}},
+		//	{"getDeploymentWithBadID", "badDeploymentID", &result{statusCode: http.StatusNotFound, errors: &Errors{[]*Error{errNotFound}}}},
+		{"getDeployment", "getDeployment", &result{statusCode: http.StatusOK, errors: nil,
+			deployment: &Deployment{ID: "getDeployment", Status: "DEPLOYED",
+				Links: []AtomLink{{Href: "/deployments/getDeployment", Rel: "self", LinkType: "application/json"},
+					{Href: "/deployments/getDeployment/nodes/Compute", Rel: "node", LinkType: "application/json"}}}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			prepareTest(t, tt.name, client, srv)
-			req := httptest.NewRequest("GET", "/deployments/"+ tt.deploymentID, nil)
+			req := httptest.NewRequest("GET", "/deployments/"+tt.deploymentID, nil)
 			req.Header.Set("Accept", "application/json")
 			resp := newTestHTTPRouter(client, req)
 			require.NotNil(t, resp, "unexpected nil response")
@@ -261,18 +261,18 @@ func testListDeploymentHandler(t *testing.T, client *api.Client, srv *testutil.T
 	//t.Parallel() because conflicts can occurs with other tests
 
 	type result struct {
-		statusCode int
-		errors       *Errors
+		statusCode  int
+		errors      *Errors
 		deployments *DeploymentsCollection
 	}
 
 	tests := []struct {
-		name       string
-		want       *result
+		name string
+		want *result
 	}{
 		{"getDeployment", &result{statusCode: http.StatusOK, errors: nil,
-			deployments:&DeploymentsCollection{[]Deployment{{ID: "getDeployment", Status:"DEPLOYED",
-				Links:[]AtomLink{{Href:"/deployments/getDeployment", Rel:"deployment", LinkType:"application/json" }}}}}}},
+			deployments: &DeploymentsCollection{[]Deployment{{ID: "getDeployment", Status: "DEPLOYED",
+				Links: []AtomLink{{Href: "/deployments/getDeployment", Rel: "deployment", LinkType: "application/json"}}}}}}},
 		{"noDeployment", &result{statusCode: http.StatusNoContent, errors: nil,
 			deployments: nil}},
 	}

--- a/rest/deployments_test.go
+++ b/rest/deployments_test.go
@@ -17,7 +17,6 @@ package rest
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"github.com/ystia/yorc/v3/deployments"
 	"github.com/ystia/yorc/v3/helper/consulutil"
 	"github.com/ystia/yorc/v3/tasks"
@@ -36,17 +35,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type ErrorData struct {
-	ID     string `json:"id,omitempty"`
-	Status int    `json:"status,omitempty"`
-	Title  string `json:"title,omitempty"`
-	Detail string `json:"detail,omitempty"`
-}
-
-type BodyStruct struct {
-	Errors []ErrorData `json:"errors,omitempty"`
-}
-
 func testDeploymentHandlers(t *testing.T, client *api.Client, srv *testutil.TestServer) {
 	t.Run("testDeleteDeploymentHandlerWithStopOnErrorParam", func(t *testing.T) {
 		testDeleteDeploymentHandlerWithStopOnErrorParam(t, client, srv)
@@ -54,33 +42,43 @@ func testDeploymentHandlers(t *testing.T, client *api.Client, srv *testutil.Test
 	t.Run("testDeleteDeploymentHandlerWithPurgeParam", func(t *testing.T) {
 		testDeleteDeploymentHandlerWithPurgeParam(t, client, srv)
 	})
+	t.Run("testGetDeploymentHandler", func(t *testing.T) {
+		testGetDeploymentHandler(t, client, srv)
+	})
+	t.Run("testListDeploymentHandler", func(t *testing.T) {
+		testListDeploymentHandler(t, client, srv)
+	})
 }
 
-func loadTestYaml(t *testing.T, testName string, kv *api.KV) string {
-	deploymentID := testName
+func loadTestYaml(t *testing.T, deploymentID string, kv *api.KV) {
 	yamlName := "testdata/testSimpleTopology.yaml"
 	err := deployments.StoreDeploymentDefinition(context.Background(), kv, deploymentID, yamlName)
 	require.Nil(t, err, "Failed to parse "+yamlName+" definition")
-	return deploymentID
 }
 
-func cleanTest(kv *api.KV, taskID string) {
-	kv.DeleteTree(path.Join(consulutil.TasksPrefix, taskID), nil)
+func cleanTest(kv *api.KV, deploymentID, taskID string) {
+	if taskID != "" {
+		kv.DeleteTree(path.Join(consulutil.TasksPrefix, taskID), nil)
+	}
+	if deploymentID != "" {
+		kv.DeleteTree(path.Join(consulutil.DeploymentKVPrefix, deploymentID), nil)
+	}
 }
 
-func prepareTest(t *testing.T, testName string, client *api.Client, srv *testutil.TestServer) string {
-	deploymentID := loadTestYaml(t, testName, client.KV())
-	srv.PopulateKV(t, map[string][]byte{
-		consulutil.DeploymentKVPrefix + "/" + deploymentID + "/status": []byte("DEPLOYED"),
-	})
-	return deploymentID
+func prepareTest(t *testing.T, deploymentID string, client *api.Client, srv *testutil.TestServer) {
+	if deploymentID != "noDeployment" {
+		loadTestYaml(t, deploymentID, client.KV())
+		srv.PopulateKV(t, map[string][]byte{
+			consulutil.DeploymentKVPrefix + "/" + deploymentID + "/status": []byte("DEPLOYED"),
+		})
+	}
 }
 
 func testDeleteDeploymentHandlerWithStopOnErrorParam(t *testing.T, client *api.Client, srv *testutil.TestServer) {
 	t.Parallel()
 	type result struct {
 		statusCode      int
-		body            *BodyStruct
+		errors       *Errors
 		continueOnError bool
 	}
 
@@ -89,14 +87,15 @@ func testDeleteDeploymentHandlerWithStopOnErrorParam(t *testing.T, client *api.C
 		stopOnErrorParam string
 		want             *result
 	}{
-		{"stopOnErrorWithBadValue", "badValue", &result{statusCode: http.StatusBadRequest, body: &BodyStruct{[]ErrorData{{ID: "bad_request", Status: 400, Title: "Bad Request", Detail: "stopOnError query parameter must be a boolean value"}}}}},
-		{"stopOnErrorWithTrue", "true", &result{continueOnError: false, statusCode: http.StatusAccepted, body: nil}},
-		{"stopOnErrorWithFalse", "false", &result{continueOnError: true, statusCode: http.StatusAccepted, body: nil}},
-		{"stopOnErrorWithNoValue", "", &result{continueOnError: false, statusCode: http.StatusAccepted, body: nil}},
+		{"stopOnErrorWithBadValue", "badValue", &result{statusCode: http.StatusBadRequest, errors: &Errors{[]*Error{{ID: "bad_request", Status: 400, Title: "Bad Request", Detail: "stopOnError query parameter must be a boolean value"}}}}},
+		{"stopOnErrorWithTrue", "true", &result{continueOnError: false, statusCode: http.StatusAccepted, errors: nil}},
+		{"stopOnErrorWithFalse", "false", &result{continueOnError: true, statusCode: http.StatusAccepted, errors: nil}},
+		{"stopOnErrorWithNoValue", "", &result{continueOnError: false, statusCode: http.StatusAccepted, errors: nil}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			deploymentID := prepareTest(t, tt.name, client, srv)
+			deploymentID := tt.name
+			prepareTest(t, deploymentID, client, srv)
 			req := httptest.NewRequest("DELETE", "/deployments/"+deploymentID, nil)
 
 			params := url.Values{}
@@ -106,22 +105,21 @@ func testDeleteDeploymentHandlerWithStopOnErrorParam(t *testing.T, client *api.C
 			require.NotNil(t, resp, "unexpected nil response")
 			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)
 
-			bodyb, err := ioutil.ReadAll(resp.Body)
+			body, err := ioutil.ReadAll(resp.Body)
 			require.Nil(t, err, "unexpected error reading body response")
-			if len(bodyb) > 0 {
-				var body *BodyStruct
-				err = json.Unmarshal(bodyb, &body)
+			if len(body) > 0 {
+				var errorsFound Errors
+				err = json.Unmarshal(body, &errorsFound)
 				require.Nil(t, err, "unexpected error unmarshalling json body")
-				fmt.Println(body)
-				if !reflect.DeepEqual(body, tt.want.body) {
-					t.Errorf("body = %v, want %v", body, tt.want)
+				if !reflect.DeepEqual(errorsFound, *tt.want.errors) {
+					t.Errorf("errors = %v, want %v", errorsFound, tt.want)
 				}
-			} else if tt.want.body != nil {
+			} else if tt.want.errors != nil {
 				t.Errorf("body is empty but want %v", tt.want)
 			}
 
 			// Check task data for correct params tests
-			if tt.want.body == nil {
+			if tt.want.errors == nil {
 				require.NotNil(t, resp.Header.Get("Location"), "unexpected nil location header")
 
 				location := resp.Header.Get("Location")
@@ -135,7 +133,7 @@ func testDeleteDeploymentHandlerWithStopOnErrorParam(t *testing.T, client *api.C
 				require.Nil(t, err, "unexpected error parsing bool continueOnError")
 				require.Equal(t, tt.want.continueOnError, continueOnError, "unexpected continueOnError value")
 
-				cleanTest(client.KV(), taskID)
+				cleanTest(client.KV(), deploymentID, taskID)
 			}
 		})
 	}
@@ -146,7 +144,7 @@ func testDeleteDeploymentHandlerWithPurgeParam(t *testing.T, client *api.Client,
 
 	type result struct {
 		statusCode int
-		body       *BodyStruct
+		errors       *Errors
 		taskType   tasks.TaskType
 	}
 
@@ -155,14 +153,15 @@ func testDeleteDeploymentHandlerWithPurgeParam(t *testing.T, client *api.Client,
 		purgeParam string
 		want       *result
 	}{
-		{"purgeWithBadValue", "badValue", &result{statusCode: http.StatusBadRequest, body: &BodyStruct{[]ErrorData{{ID: "bad_request", Status: 400, Title: "Bad Request", Detail: "purge query parameter must be a boolean value"}}}}},
-		{"purgeWithTrue", "true", &result{taskType: tasks.TaskTypePurge, statusCode: http.StatusAccepted, body: nil}},
-		{"purgeWithFalse", "false", &result{taskType: tasks.TaskTypeUnDeploy, statusCode: http.StatusAccepted, body: nil}},
-		{"purgeWithNoValue", "", &result{taskType: tasks.TaskTypePurge, statusCode: http.StatusAccepted, body: nil}},
+		{"purgeWithBadValue", "badValue", &result{statusCode: http.StatusBadRequest, errors: &Errors{[]*Error{{ID: "bad_request", Status: 400, Title: "Bad Request", Detail: "purge query parameter must be a boolean value"}}}}},
+		{"purgeWithTrue", "true", &result{taskType: tasks.TaskTypePurge, statusCode: http.StatusAccepted, errors: nil}},
+		{"purgeWithFalse", "false", &result{taskType: tasks.TaskTypeUnDeploy, statusCode: http.StatusAccepted, errors: nil}},
+		{"purgeWithNoValue", "", &result{taskType: tasks.TaskTypePurge, statusCode: http.StatusAccepted, errors: nil}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			deploymentID := prepareTest(t, tt.name, client, srv)
+			deploymentID := tt.name
+			prepareTest(t, deploymentID, client, srv)
 			req := httptest.NewRequest("DELETE", "/deployments/"+deploymentID, nil)
 
 			params := url.Values{}
@@ -172,22 +171,21 @@ func testDeleteDeploymentHandlerWithPurgeParam(t *testing.T, client *api.Client,
 			require.NotNil(t, resp, "unexpected nil response")
 			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)
 
-			bodyb, err := ioutil.ReadAll(resp.Body)
+			body, err := ioutil.ReadAll(resp.Body)
 			require.Nil(t, err, "unexpected error reading body response")
-			if len(bodyb) > 0 {
-				var body *BodyStruct
-				err = json.Unmarshal(bodyb, &body)
+			if len(body) > 0 {
+				var errorsFound Errors
+				err = json.Unmarshal(body, &errorsFound)
 				require.Nil(t, err, "unexpected error unmarshalling json body")
-				fmt.Println(body)
-				if !reflect.DeepEqual(body, tt.want.body) {
-					t.Errorf("body = %v, want %v", body, tt.want)
+				if !reflect.DeepEqual(errorsFound, *tt.want.errors) {
+					t.Errorf("errors = %v, want %v", errorsFound, tt.want)
 				}
-			} else if tt.want.body != nil {
-				t.Errorf("body is empty but want %v", tt.want)
+			} else if tt.want.errors != nil {
+				t.Errorf("errors is empty but want %v", tt.want)
 			}
 
 			// Check task data for correct params tests
-			if tt.want.body == nil {
+			if tt.want.errors == nil {
 				require.NotNil(t, resp.Header.Get("Location"), "unexpected nil location header")
 
 				location := resp.Header.Get("Location")
@@ -199,9 +197,115 @@ func testDeleteDeploymentHandlerWithPurgeParam(t *testing.T, client *api.Client,
 				require.Nil(t, err, "unexpected error getting task type")
 				require.Equal(t, tt.want.taskType, taskType, "unexpected task type")
 
-				cleanTest(client.KV(), taskID)
+				cleanTest(client.KV(), deploymentID, taskID)
+			}
+		})
+	}
+}
+
+func testGetDeploymentHandler(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	t.Parallel()
+
+	type result struct {
+		statusCode int
+		errors       *Errors
+		deployment *Deployment
+	}
+
+	tests := []struct {
+		name       string
+		deploymentID string
+		want       *result
+	}{
+	//	{"getDeploymentWithBadID", "badDeploymentID", &result{statusCode: http.StatusNotFound, errors: &Errors{[]*Error{errNotFound}}}},
+		{"getDeployment","getDeployment", &result{statusCode: http.StatusOK, errors: nil,
+			deployment:&Deployment{ID: "getDeployment", Status:"DEPLOYED",
+				Links:[]AtomLink{{Href:"/deployments/getDeployment", Rel:"self", LinkType:"application/json" },
+					{Href:"/deployments/getDeployment/nodes/Compute", Rel:"node", LinkType:"application/json" }}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prepareTest(t, tt.name, client, srv)
+			req := httptest.NewRequest("GET", "/deployments/"+ tt.deploymentID, nil)
+			req.Header.Set("Accept", "application/json")
+			resp := newTestHTTPRouter(client, req)
+			require.NotNil(t, resp, "unexpected nil response")
+			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)
+
+			body, err := ioutil.ReadAll(resp.Body)
+			require.Nil(t, err, "unexpected error reading body response")
+
+			if tt.want.errors != nil {
+				var errorsFound Errors
+				err = json.Unmarshal(body, &errorsFound)
+				require.Nil(t, err, "unexpected error unmarshalling json body")
+				if !reflect.DeepEqual(errorsFound, *tt.want.errors) {
+					t.Errorf("errors = %v, want %v", errorsFound, *tt.want.errors)
+				}
 			}
 
+			if tt.want.deployment != nil {
+				var depFound Deployment
+				err = json.Unmarshal(body, &depFound)
+				require.Nil(t, err, "unexpected error unmarshalling json body")
+				if !reflect.DeepEqual(depFound, *tt.want.deployment) {
+					t.Errorf("deployment = %v, want %v", body, *tt.want.deployment)
+				}
+			}
+			cleanTest(client.KV(), tt.deploymentID, "")
+		})
+	}
+}
+
+func testListDeploymentHandler(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	//t.Parallel() because conflicts can occurs with other tests
+
+	type result struct {
+		statusCode int
+		errors       *Errors
+		deployments *DeploymentsCollection
+	}
+
+	tests := []struct {
+		name       string
+		want       *result
+	}{
+		{"getDeployment", &result{statusCode: http.StatusOK, errors: nil,
+			deployments:&DeploymentsCollection{[]Deployment{{ID: "getDeployment", Status:"DEPLOYED",
+				Links:[]AtomLink{{Href:"/deployments/getDeployment", Rel:"deployment", LinkType:"application/json" }}}}}}},
+		{"noDeployment", &result{statusCode: http.StatusNoContent, errors: nil,
+			deployments: nil}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prepareTest(t, tt.name, client, srv)
+			req := httptest.NewRequest("GET", "/deployments", nil)
+			req.Header.Set("Accept", "application/json")
+			resp := newTestHTTPRouter(client, req)
+			require.NotNil(t, resp, "unexpected nil response")
+			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)
+
+			body, err := ioutil.ReadAll(resp.Body)
+			require.Nil(t, err, "unexpected error reading body response")
+
+			if tt.want.errors != nil {
+				var errorsFound Errors
+				err = json.Unmarshal(body, &errorsFound)
+				require.Nil(t, err, "unexpected error unmarshalling json body")
+				if !reflect.DeepEqual(errorsFound, *tt.want.errors) {
+					t.Errorf("errors = %v, want %v", errorsFound, *tt.want.errors)
+				}
+			}
+
+			if tt.want.deployments != nil {
+				var depFound DeploymentsCollection
+				err = json.Unmarshal(body, &depFound)
+				require.Nil(t, err, "unexpected error unmarshalling json body")
+				if !reflect.DeepEqual(depFound, *tt.want.deployments) {
+					t.Errorf("deployment = %v, want %v", depFound, *tt.want.deployments)
+				}
+			}
+			cleanTest(client.KV(), tt.name, "")
 		})
 	}
 }

--- a/rest/deployments_test.go
+++ b/rest/deployments_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 type ErrorData struct {
-	Id     string `json:"id,omitempty"`
+	ID     string `json:"id,omitempty"`
 	Status int    `json:"status,omitempty"`
 	Title  string `json:"title,omitempty"`
 	Detail string `json:"detail,omitempty"`
@@ -89,7 +89,7 @@ func testDeleteDeploymentHandlerWithStopOnErrorParam(t *testing.T, client *api.C
 		stopOnErrorParam string
 		want             *result
 	}{
-		{"stopOnErrorWithBadValue", "badValue", &result{statusCode: http.StatusBadRequest, body: &BodyStruct{[]ErrorData{{Id: "bad_request", Status: 400, Title: "Bad Request", Detail: "stopOnError query parameter must be a boolean value"}}}}},
+		{"stopOnErrorWithBadValue", "badValue", &result{statusCode: http.StatusBadRequest, body: &BodyStruct{[]ErrorData{{ID: "bad_request", Status: 400, Title: "Bad Request", Detail: "stopOnError query parameter must be a boolean value"}}}}},
 		{"stopOnErrorWithTrue", "true", &result{continueOnError: false, statusCode: http.StatusAccepted, body: nil}},
 		{"stopOnErrorWithFalse", "false", &result{continueOnError: true, statusCode: http.StatusAccepted, body: nil}},
 		{"stopOnErrorWithNoValue", "", &result{continueOnError: false, statusCode: http.StatusAccepted, body: nil}},
@@ -155,7 +155,7 @@ func testDeleteDeploymentHandlerWithPurgeParam(t *testing.T, client *api.Client,
 		purgeParam string
 		want       *result
 	}{
-		{"purgeWithBadValue", "badValue", &result{statusCode: http.StatusBadRequest, body: &BodyStruct{[]ErrorData{{Id: "bad_request", Status: 400, Title: "Bad Request", Detail: "purge query parameter must be a boolean value"}}}}},
+		{"purgeWithBadValue", "badValue", &result{statusCode: http.StatusBadRequest, body: &BodyStruct{[]ErrorData{{ID: "bad_request", Status: 400, Title: "Bad Request", Detail: "purge query parameter must be a boolean value"}}}}},
 		{"purgeWithTrue", "true", &result{taskType: tasks.TaskTypePurge, statusCode: http.StatusAccepted, body: nil}},
 		{"purgeWithFalse", "false", &result{taskType: tasks.TaskTypeUnDeploy, statusCode: http.StatusAccepted, body: nil}},
 		{"purgeWithNoValue", "", &result{taskType: tasks.TaskTypePurge, statusCode: http.StatusAccepted, body: nil}},

--- a/rest/deployments_test.go
+++ b/rest/deployments_test.go
@@ -15,76 +15,99 @@
 package rest
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/ystia/yorc/v3/deployments"
+	"github.com/ystia/yorc/v3/helper/consulutil"
+	"github.com/ystia/yorc/v3/tasks"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path"
 	"reflect"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testutil"
 	"github.com/stretchr/testify/require"
-
-	"github.com/ystia/yorc/v3/helper/consulutil"
-	ytu "github.com/ystia/yorc/v3/testutil"
 )
 
+type ErrorData struct {
+	Id     string `json:"id,omitempty"`
+	Status int    `json:"status,omitempty"`
+	Title  string `json:"title,omitempty"`
+	Detail string `json:"detail,omitempty"`
+}
+
+type BodyStruct struct {
+	Errors []ErrorData `json:"errors,omitempty"`
+}
+
 func testDeploymentHandlers(t *testing.T, client *api.Client, srv *testutil.TestServer) {
-	t.Run("testDeleteDeploymentHandlerWithParamValues", func(t *testing.T) {
-		testDeleteDeploymentHandlerWithParamValues(t, client, srv)
+	t.Run("testDeleteDeploymentHandlerWithStopOnErrorParam", func(t *testing.T) {
+		testDeleteDeploymentHandlerWithStopOnErrorParam(t, client, srv)
+	})
+	t.Run("testDeleteDeploymentHandlerWithPurgeParam", func(t *testing.T) {
+		testDeleteDeploymentHandlerWithPurgeParam(t, client, srv)
 	})
 }
 
-func testDeleteDeploymentHandlerWithParamValues(t *testing.T, client *api.Client, srv *testutil.TestServer) {
-	type ErrorStruct struct {
-		Id     string `json:"id,omitempty"`
-		Status int    `json:"status,omitempty"`
-		Title  string `json:"title,omitempty"`
-		Detail string `json:"detail,omitempty"`
-	}
+func loadTestYaml(t *testing.T, testName string, kv *api.KV) string {
+	deploymentID := testName
+	yamlName := "testdata/testSimpleTopology.yaml"
+	err := deployments.StoreDeploymentDefinition(context.Background(), kv, deploymentID, yamlName)
+	require.Nil(t, err, "Failed to parse "+yamlName+" definition")
+	return deploymentID
+}
 
-	type BodyStruct struct {
-		Errors []ErrorStruct `json:"errors,omitempty"`
-	}
+func cleanTest(kv *api.KV, taskID string) {
+	kv.DeleteTree(path.Join(consulutil.TasksPrefix, taskID), nil)
+}
 
-	type result struct {
-		statusCode int
-		body       *BodyStruct
-	}
-
-	deploymentID := ytu.BuildDeploymentID(t)
-	t.Parallel()
+func prepareTest(t *testing.T, testName string, client *api.Client, srv *testutil.TestServer) string {
+	deploymentID := loadTestYaml(t, testName, client.KV())
 	srv.PopulateKV(t, map[string][]byte{
 		consulutil.DeploymentKVPrefix + "/" + deploymentID + "/status": []byte("DEPLOYED"),
 	})
+	return deploymentID
+}
 
-	req := httptest.NewRequest("DELETE", "/deployments/"+deploymentID, nil)
+func testDeleteDeploymentHandlerWithStopOnErrorParam(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	t.Parallel()
+	type result struct {
+		statusCode      int
+		body            *BodyStruct
+		continueOnError bool
+	}
 
 	tests := []struct {
-		name        string
-		stopOnError string
-		want        *result
+		name             string
+		stopOnErrorParam string
+		want             *result
 	}{
-		{"stopOnErrorWithBadValue", "badValue", &result{statusCode: http.StatusBadRequest, body: &BodyStruct{[]ErrorStruct{ErrorStruct{Id: "bad_request", Status: 400, Title: "Bad Request", Detail: "stopOnError URL parameter must be a boolean value"}}}}},
-		{"stopOnErrorWithCorrectValue", "true", &result{statusCode: http.StatusAccepted, body: nil}},
-		{"stopOnErrorWithNoValue", "", &result{statusCode: http.StatusAccepted, body: nil}},
+		{"stopOnErrorWithBadValue", "badValue", &result{statusCode: http.StatusBadRequest, body: &BodyStruct{[]ErrorData{{Id: "bad_request", Status: 400, Title: "Bad Request", Detail: "stopOnError query parameter must be a boolean value"}}}}},
+		{"stopOnErrorWithTrue", "true", &result{continueOnError: false, statusCode: http.StatusAccepted, body: nil}},
+		{"stopOnErrorWithFalse", "false", &result{continueOnError: true, statusCode: http.StatusAccepted, body: nil}},
+		{"stopOnErrorWithNoValue", "", &result{continueOnError: false, statusCode: http.StatusAccepted, body: nil}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			deploymentID := prepareTest(t, tt.name, client, srv)
+			req := httptest.NewRequest("DELETE", "/deployments/"+deploymentID, nil)
+
 			params := url.Values{}
-			params.Add("stopOnError", tt.stopOnError)
+			params.Add("stopOnError", tt.stopOnErrorParam)
 			req.URL.RawQuery = params.Encode()
 			resp := newTestHTTPRouter(client, req)
 			require.NotNil(t, resp, "unexpected nil response")
 			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)
 
 			bodyb, err := ioutil.ReadAll(resp.Body)
-			fmt.Println("body=" + string(bodyb))
 			require.Nil(t, err, "unexpected error reading body response")
-
 			if len(bodyb) > 0 {
 				var body *BodyStruct
 				err = json.Unmarshal(bodyb, &body)
@@ -95,6 +118,88 @@ func testDeleteDeploymentHandlerWithParamValues(t *testing.T, client *api.Client
 				}
 			} else if tt.want.body != nil {
 				t.Errorf("body is empty but want %v", tt.want)
+			}
+
+			// Check task data for correct params tests
+			if tt.want.body == nil {
+				require.NotNil(t, resp.Header.Get("Location"), "unexpected nil location header")
+
+				location := resp.Header.Get("Location")
+				// /deployments/DEPLOYMENT_ID/tasks/TASK_ID
+				locationSplit := strings.Split(location, "/")
+				require.Equal(t, 5, len(locationSplit), "unexpected location format")
+				taskID := strings.Split(location, "/")[4]
+				continueOnErrorStr, err := tasks.GetTaskData(client.KV(), taskID, "continueOnError")
+				require.Nil(t, err, "unexpected error getting continueOnError task data")
+				continueOnError, err := strconv.ParseBool(continueOnErrorStr)
+				require.Nil(t, err, "unexpected error parsing bool continueOnError")
+				require.Equal(t, tt.want.continueOnError, continueOnError, "unexpected continueOnError value")
+
+				cleanTest(client.KV(), taskID)
+			}
+		})
+	}
+}
+
+func testDeleteDeploymentHandlerWithPurgeParam(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	t.Parallel()
+
+	type result struct {
+		statusCode int
+		body       *BodyStruct
+		taskType   tasks.TaskType
+	}
+
+	tests := []struct {
+		name       string
+		purgeParam string
+		want       *result
+	}{
+		{"purgeWithBadValue", "badValue", &result{statusCode: http.StatusBadRequest, body: &BodyStruct{[]ErrorData{{Id: "bad_request", Status: 400, Title: "Bad Request", Detail: "purge query parameter must be a boolean value"}}}}},
+		{"purgeWithTrue", "true", &result{taskType: tasks.TaskTypePurge, statusCode: http.StatusAccepted, body: nil}},
+		{"purgeWithFalse", "false", &result{taskType: tasks.TaskTypeUnDeploy, statusCode: http.StatusAccepted, body: nil}},
+		{"purgeWithNoValue", "", &result{taskType: tasks.TaskTypePurge, statusCode: http.StatusAccepted, body: nil}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deploymentID := prepareTest(t, tt.name, client, srv)
+			req := httptest.NewRequest("DELETE", "/deployments/"+deploymentID, nil)
+
+			params := url.Values{}
+			params.Add("purge", tt.purgeParam)
+			req.URL.RawQuery = params.Encode()
+			resp := newTestHTTPRouter(client, req)
+			require.NotNil(t, resp, "unexpected nil response")
+			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)
+
+			bodyb, err := ioutil.ReadAll(resp.Body)
+			require.Nil(t, err, "unexpected error reading body response")
+			if len(bodyb) > 0 {
+				var body *BodyStruct
+				err = json.Unmarshal(bodyb, &body)
+				require.Nil(t, err, "unexpected error unmarshalling json body")
+				fmt.Println(body)
+				if !reflect.DeepEqual(body, tt.want.body) {
+					t.Errorf("body = %v, want %v", body, tt.want)
+				}
+			} else if tt.want.body != nil {
+				t.Errorf("body is empty but want %v", tt.want)
+			}
+
+			// Check task data for correct params tests
+			if tt.want.body == nil {
+				require.NotNil(t, resp.Header.Get("Location"), "unexpected nil location header")
+
+				location := resp.Header.Get("Location")
+				// /deployments/DEPLOYMENT_ID/tasks/TASK_ID
+				locationSplit := strings.Split(location, "/")
+				require.Equal(t, 5, len(locationSplit), "unexpected location format")
+				taskID := strings.Split(location, "/")[4]
+				taskType, err := tasks.GetTaskType(client.KV(), taskID)
+				require.Nil(t, err, "unexpected error getting task type")
+				require.Equal(t, tt.want.taskType, taskType, "unexpected task type")
+
+				cleanTest(client.KV(), taskID)
 			}
 
 		})

--- a/rest/http.go
+++ b/rest/http.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
+	"strconv"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/julienschmidt/httprouter"
@@ -204,6 +205,16 @@ func encodeJSONResponse(w http.ResponseWriter, r *http.Request, resp interface{}
 	}
 	w.Header().Set("Content-Type", "application/json")
 	jEnc.Encode(resp)
+}
+
+func getBoolQueryParam(r *http.Request, paramName string) (bool, error) {
+	if values, ok := r.URL.Query()[paramName]; ok {
+		if len(values) > 0 && len(values[0]) > 0 {
+			return strconv.ParseBool(values[0])
+		}
+		return true, nil
+	}
+	return false, nil
 }
 
 func getAddress(configuration config.Configuration) (net.Addr, error) {

--- a/rest/http_api.md
+++ b/rest/http_api.md
@@ -104,8 +104,9 @@ Content-Type: application/json
 ### Undeploy  an active deployment <a name="undeploy"></a>
 
 Undeploy a deployment. By adding the optional 'purge' url parameter to your request you will suppress any reference to this deployment from the yorc database at the end of the undeployment. A successful call to this endpoint results in a HTTP status code 202 with a 'Location' header relative to the base URI indicating the task URI handling the undeployment process.
+By adding the optional 'stopOnError' url parameter to your request, the un-deployment will stop at the first encountered error. Otherwise, it will continue until the end.
 
-`DELETE /deployments/<deployment_id>[?purge]`
+`DELETE /deployments/<deployment_id>[?purge]&[stopOnError]`
 
 **Response**:
 

--- a/rest/testdata/testSimpleTopology.yaml
+++ b/rest/testdata/testSimpleTopology.yaml
@@ -1,0 +1,54 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: SimpleApp
+  template_version: 0.1.0-SNAPSHOT
+  template_author: test
+
+description: ""
+
+imports:
+  - <yorc-types.yml>
+  - <normative-types.yml>
+  - <yorc-google-types.yml>
+
+topology_template:
+  node_templates:
+    Compute:
+      metadata:
+        a4c_edit_x: 3
+        a4c_edit_y: "-27"
+      type: yorc.nodes.google.Compute
+      properties:
+        image_project: "centos-cloud"
+        image_family: "centos-7"
+        machine_type: "n1-standard-1"
+        zone: "europe-west1-b"
+  workflows:
+    install:
+      steps:
+        Compute_install:
+          target: Compute
+          activities:
+            - delegate: install
+    uninstall:
+      steps:
+        Compute_uninstall:
+          target: Compute
+          activities:
+            - delegate: uninstall
+    start:
+      steps:
+        Compute_start:
+          target: Compute
+          activities:
+            - delegate: start
+    stop:
+      steps:
+        Compute_stop:
+          target: Compute
+          activities:
+            - delegate: stop
+    run:
+    cancel:
+


### PR DESCRIPTION
# Pull Request description

As: An integrator
I want to: Have choice to bypass errors or not on workflows
So that: I can stop on errors for an undeploy workflow

AC1: Should be part of the REST API
AC2: Think if it should be limited to undeploy workflow
AC3: Default behavior should remain unchanged
AC4: Check that a4c plugin handle this case for undeployments
AC5: Sounds a good opportunity for increasing our test coverage on rest package

## Description of the change

### What I did
- Already exposed for custom workflows
- Add "stopOnError" query parameter handling to delete handler and store it via task data "continueOnError"
- Allow the worker to handle "continueOnError" on undeploy workflow
- Add option stop-on-error for CLI to use it

### How to verify it
- Deploy the welcome application
- Stop the python web server via custom command (this will make the undeploy firtst step fail)
- Undeploy it with CLI or REST client with stopOnError param
- Check the deployment status is UNDEPLOYMENT_FAILED and the undeployment is stopped

### Description for the changelog
* Expose bypass error parameter on workflow ([GH-425](https://github.com/ystia/yorc/issues/425))
## Applicable Issues
#425 