### PR TITLE
Check task exists when retrieving status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Deleting one host in Pool deletes other hosts having as prefix the deleted hostname ([GH-430](https://github.com/ystia/yorc/issues/430))
 * Yorc should support long standard operation names as well as short ones ([GH-300](https://github.com/ystia/yorc/issues/300))
 * Fix attributes notifications for services (substitutions) ([GH-423](https://github.com/ystia/yorc/issues/423))
+* Monitoring can be stopped before the job termination ([GH-438](https://github.com/ystia/yorc/issues/438))
 
 ## 3.2.0 (May 31, 2019)
 

--- a/prov/scheduling/scheduler/consul_test.go
+++ b/prov/scheduling/scheduler/consul_test.go
@@ -43,14 +43,14 @@ func TestRunConsulSchedulingPackageTests(t *testing.T) {
 	}()
 
 	t.Run("groupScheduling", func(t *testing.T) {
-		t.Run("testRegisterAction", func(t *testing.T) {
-			testRegisterAction(t, client)
-		})
+		//t.Run("testRegisterAction", func(t *testing.T) {
+		//	testRegisterAction(t, client)
+		//})
 		t.Run("testProceedScheduledAction", func(t *testing.T) {
 			testProceedScheduledAction(t, client)
 		})
-		t.Run("testUnregisterAction", func(t *testing.T) {
-			testUnregisterAction(t, client)
-		})
+		//t.Run("testUnregisterAction", func(t *testing.T) {
+		//	testUnregisterAction(t, client)
+		//})
 	})
 }

--- a/prov/scheduling/scheduler/consul_test.go
+++ b/prov/scheduling/scheduler/consul_test.go
@@ -49,6 +49,9 @@ func TestRunConsulSchedulingPackageTests(t *testing.T) {
 		t.Run("testProceedScheduledAction", func(t *testing.T) {
 			testProceedScheduledAction(t, client)
 		})
+		t.Run("testProceedScheduledActionWithFirstActionStillRunning", func(t *testing.T) {
+			testProceedScheduledActionWithFirstActionStillRunning(t, client)
+		})
 		t.Run("testUnregisterAction", func(t *testing.T) {
 			testUnregisterAction(t, client)
 		})

--- a/prov/scheduling/scheduler/consul_test.go
+++ b/prov/scheduling/scheduler/consul_test.go
@@ -43,14 +43,14 @@ func TestRunConsulSchedulingPackageTests(t *testing.T) {
 	}()
 
 	t.Run("groupScheduling", func(t *testing.T) {
-		//t.Run("testRegisterAction", func(t *testing.T) {
-		//	testRegisterAction(t, client)
-		//})
+		t.Run("testRegisterAction", func(t *testing.T) {
+			testRegisterAction(t, client)
+		})
 		t.Run("testProceedScheduledAction", func(t *testing.T) {
 			testProceedScheduledAction(t, client)
 		})
-		//t.Run("testUnregisterAction", func(t *testing.T) {
-		//	testUnregisterAction(t, client)
-		//})
+		t.Run("testUnregisterAction", func(t *testing.T) {
+			testUnregisterAction(t, client)
+		})
 	})
 }

--- a/prov/scheduling/scheduler/consul_test.go
+++ b/prov/scheduling/scheduler/consul_test.go
@@ -52,6 +52,9 @@ func TestRunConsulSchedulingPackageTests(t *testing.T) {
 		t.Run("testProceedScheduledActionWithFirstActionStillRunning", func(t *testing.T) {
 			testProceedScheduledActionWithFirstActionStillRunning(t, client)
 		})
+		t.Run("testProceedScheduledActionWithBadStatusError", func(t *testing.T) {
+			testProceedScheduledActionWithBadStatusError(t, client)
+		})
 		t.Run("testUnregisterAction", func(t *testing.T) {
 			testUnregisterAction(t, client)
 		})

--- a/prov/scheduling/scheduler/scheduled_action.go
+++ b/prov/scheduling/scheduler/scheduled_action.go
@@ -106,7 +106,8 @@ func (sca *scheduledAction) proceed() error {
 		}
 		if ok {
 			status, err := tasks.GetTaskStatus(sca.kv, sca.latestTaskID)
-			if err != nil {
+			// As action task is deleted after being executed asynchronously, we handle again if task still exists
+			if !tasks.IsTaskNotFoundError(err) {
 				return err
 			}
 			if status == tasks.TaskStatusINITIAL || status == tasks.TaskStatusRUNNING {

--- a/prov/scheduling/scheduler/scheduler_test.go
+++ b/prov/scheduling/scheduler/scheduler_test.go
@@ -155,7 +155,7 @@ func testProceedScheduledActionWithFirstActionStillRunning(t *testing.T, client 
 	taskID := "orig-taskID"
 	wfName := "my-wf"
 	action := &prov.Action{ActionType: actionType, Data: map[string]string{"key1": "val1", "key2": "val2", "key3": "val3"},
-		AsyncOperation: prov.AsyncOperation{DeploymentID: deploymentID, NodeName: nodeName, Operation: prov.Operation{Name: interfaceName + "." + opeName}, TaskID: taskID, WorkflowName: wfName, }}
+		AsyncOperation: prov.AsyncOperation{DeploymentID: deploymentID, NodeName: nodeName, Operation: prov.Operation{Name: interfaceName + "." + opeName}, TaskID: taskID, WorkflowName: wfName}}
 	id, err := scheduling.RegisterAction(client, deploymentID, ti, action)
 
 	require.Nil(t, err, "Unexpected error while registering action")

--- a/prov/scheduling/scheduler/scheduler_test.go
+++ b/prov/scheduling/scheduler/scheduler_test.go
@@ -172,7 +172,7 @@ func testProceedScheduledActionWithFirstActionStillRunning(t *testing.T, client 
 				continue
 			}
 
-			// Delete the related task to reschedule another one
+			// Set the task status to RUNNING in order to not reschedule another task
 			if kvp != nil && len(kvp.Value) > 0 {
 				taskID := string(kvp.Value)
 				p := &api.KVPair{Key: path.Join(consulutil.TasksPrefix, taskID, "status"), Value: []byte(strconv.Itoa(int(tasks.TaskStatusRUNNING)))}
@@ -225,6 +225,99 @@ func testProceedScheduledActionWithFirstActionStillRunning(t *testing.T, client 
 		case <-ticker.C:
 			ind++
 			// as the task is still running, no other task is created
+			check(1, checkCpt)
+			if ind == 3 {
+				ticker.Stop()
+				return
+			}
+		}
+	}
+
+	require.Equal(t, checkCpt, 5, "unexpected number of checks done")
+}
+
+func testProceedScheduledActionWithBadStatusError(t *testing.T, client *api.Client) {
+	t.Parallel()
+	deploymentID := "dep-" + t.Name()
+	ti := 1 * time.Second
+	actionType := "test-action"
+	action := &prov.Action{ActionType: actionType, Data: map[string]string{"key1": "val1", "key2": "val2", "key3": "val3"}}
+	id, err := scheduling.RegisterAction(client, deploymentID, ti, action)
+	require.Nil(t, err, "Unexpected error while registering action")
+	require.NotEmpty(t, id, "id is not expected to be empty")
+
+	closeCh := make(chan struct{})
+	defer close(closeCh)
+	go func() {
+		var latestIndex uint64
+		for {
+			select {
+			case <-closeCh:
+				return
+			default:
+			}
+			kvp, meta, err := client.KV().Get(path.Join(consulutil.SchedulingKVPrefix, "actions", id, "latestTaskID"), &api.QueryOptions{WaitIndex: latestIndex})
+			if err != nil {
+				t.Logf("%v", err)
+				continue
+			}
+			if latestIndex == meta.LastIndex {
+				continue
+			}
+
+			// Set the task status to RUNNING in order to not reschedule another task
+			if kvp != nil && len(kvp.Value) > 0 {
+				taskID := string(kvp.Value)
+				p := &api.KVPair{Key: path.Join(consulutil.TasksPrefix, taskID, "status"), Value: []byte("BAD")}
+				client.KV().Put(p, nil)
+			}
+
+		}
+	}()
+
+	var check = func(index, cpt int) {
+		cpt++
+		// Check related tasks have been created
+		keys, _, err := client.KV().Keys(consulutil.TasksPrefix+"/", "/", nil)
+		require.Nil(t, err, "Unexpected error while checking actions tasks")
+		depTask := 0
+		for _, key := range keys {
+			kvp, _, err := client.KV().Get(key+"targetId", nil)
+			if kvp != nil && string(kvp.Value) == deploymentID {
+				depTask++
+				kvp, _, err = client.KV().Get(key+"data/actionType", nil)
+				require.Nil(t, err, "Unexpected error while getting action type")
+				require.NotNil(t, kvp, "kvp is nil for action type")
+				require.Equal(t, string(kvp.Value), actionType)
+
+				kvp, _, err = client.KV().Get(key+"data/key1", nil)
+				require.Nil(t, err, "Unexpected error while getting key1")
+				require.NotNil(t, kvp, "kvp is nil for key1")
+				require.Equal(t, string(kvp.Value), "val1")
+
+				kvp, _, err = client.KV().Get(key+"data/key2", nil)
+				require.Nil(t, err, "Unexpected error while getting key3")
+				require.NotNil(t, kvp, "kvp is nil for key2")
+				require.Equal(t, string(kvp.Value), "val2")
+
+				kvp, _, err = client.KV().Get(key+"data/key3", nil)
+				require.Nil(t, err, "Unexpected error while getting key3")
+				require.NotNil(t, kvp, "kvp is nil for key3")
+				require.Equal(t, string(kvp.Value), "val3")
+			}
+		}
+		require.Equal(t, index, depTask, "Unexpected nb of tasks")
+	}
+
+	ind := 0
+	checkCpt := 0
+	ticker := time.NewTicker(ti)
+	time.Sleep(2 * time.Second)
+	for i := 0; i <= 2; i++ {
+		select {
+		case <-ticker.C:
+			ind++
+			// as the proceed returns an error, the scheduler will stop and only one task will be created
 			check(1, checkCpt)
 			if ind == 3 {
 				ticker.Stop()

--- a/prov/scheduling/scheduler/scheduler_test.go
+++ b/prov/scheduling/scheduler/scheduler_test.go
@@ -117,7 +117,7 @@ func testProceedScheduledAction(t *testing.T, client *api.Client) {
 				require.Equal(t, string(kvp.Value), "val3")
 			}
 		}
-		//require.Equal(t, index, depTask, "Unexpected nb of tasks")
+		require.Equal(t, index, depTask, "Unexpected nb of tasks")
 	}
 
 	ind := 0

--- a/prov/scheduling/scheduler/scheduler_test.go
+++ b/prov/scheduling/scheduler/scheduler_test.go
@@ -117,7 +117,7 @@ func testProceedScheduledAction(t *testing.T, client *api.Client) {
 				require.Equal(t, string(kvp.Value), "val3")
 			}
 		}
-		require.Equal(t, index, depTask, "Unexpected nb of tasks")
+		//require.Equal(t, index, depTask, "Unexpected nb of tasks")
 	}
 
 	ind := 0

--- a/prov/scheduling/scheduler/scheduler_test.go
+++ b/prov/scheduling/scheduler/scheduler_test.go
@@ -15,6 +15,7 @@
 package scheduler
 
 import (
+	"github.com/ystia/yorc/v3/tasks"
 	"path"
 	"strconv"
 	"testing"
@@ -26,7 +27,6 @@ import (
 	"github.com/ystia/yorc/v3/helper/consulutil"
 	"github.com/ystia/yorc/v3/prov"
 	"github.com/ystia/yorc/v3/prov/scheduling"
-	"github.com/ystia/yorc/v3/tasks"
 )
 
 func testRegisterAction(t *testing.T, client *api.Client) {
@@ -71,7 +71,7 @@ func testProceedScheduledAction(t *testing.T, client *api.Client) {
 				return
 			default:
 			}
-			keys, meta, err := client.KV().Keys(consulutil.TasksPrefix+"/", "/", &api.QueryOptions{WaitIndex: latestIndex})
+			kvp, meta, err := client.KV().Get(path.Join(consulutil.SchedulingKVPrefix, "actions", id, "latestTaskID"), &api.QueryOptions{WaitIndex: latestIndex})
 			if err != nil {
 				t.Logf("%v", err)
 				continue
@@ -79,10 +79,14 @@ func testProceedScheduledAction(t *testing.T, client *api.Client) {
 			if latestIndex == meta.LastIndex {
 				continue
 			}
-			for _, key := range keys {
-				// set all tasks to done asap to reschedule them
-				client.KV().Put(&api.KVPair{Key: path.Join(key, "status"), Value: []byte(strconv.Itoa(int(tasks.TaskStatusDONE)))}, nil)
+
+			// set the related task to done asap to reschedule them
+			if kvp != nil && len(kvp.Value) > 0 {
+				taskID := string(kvp.Value)
+				p := &api.KVPair{Key: path.Join(consulutil.TasksPrefix, taskID, "status"), Value: []byte(strconv.Itoa(int(tasks.TaskStatusDONE)))}
+				client.KV().Put(p, nil)
 			}
+
 		}
 	}()
 
@@ -129,6 +133,99 @@ func testProceedScheduledAction(t *testing.T, client *api.Client) {
 		case <-ticker.C:
 			ind++
 			check(ind, checkCpt)
+			if ind == 3 {
+				ticker.Stop()
+				return
+			}
+		}
+	}
+
+	require.Equal(t, checkCpt, 5, "unexpected number of checks done")
+}
+
+func testProceedScheduledActionWithFirstActionStillRunning(t *testing.T, client *api.Client) {
+	t.Parallel()
+	deploymentID := "dep-" + t.Name()
+	ti := 1 * time.Second
+	actionType := "test-action"
+	action := &prov.Action{ActionType: actionType, Data: map[string]string{"key1": "val1", "key2": "val2", "key3": "val3"}}
+	id, err := scheduling.RegisterAction(client, deploymentID, ti, action)
+	require.Nil(t, err, "Unexpected error while registering action")
+	require.NotEmpty(t, id, "id is not expected to be empty")
+
+	closeCh := make(chan struct{})
+	defer close(closeCh)
+	go func() {
+		var latestIndex uint64
+		for {
+			select {
+			case <-closeCh:
+				return
+			default:
+			}
+			kvp, meta, err := client.KV().Get(path.Join(consulutil.SchedulingKVPrefix, "actions", id, "latestTaskID"), &api.QueryOptions{WaitIndex: latestIndex})
+			if err != nil {
+				t.Logf("%v", err)
+				continue
+			}
+			if latestIndex == meta.LastIndex {
+				continue
+			}
+
+			// Delete the related task to reschedule another one
+			if kvp != nil && len(kvp.Value) > 0 {
+				taskID := string(kvp.Value)
+				p := &api.KVPair{Key: path.Join(consulutil.TasksPrefix, taskID, "status"), Value: []byte(strconv.Itoa(int(tasks.TaskStatusRUNNING)))}
+				client.KV().Put(p, nil)
+			}
+
+		}
+	}()
+
+	var check = func(index, cpt int) {
+		cpt++
+		// Check related tasks have been created
+		keys, _, err := client.KV().Keys(consulutil.TasksPrefix+"/", "/", nil)
+		require.Nil(t, err, "Unexpected error while checking actions tasks")
+		depTask := 0
+		for _, key := range keys {
+			kvp, _, err := client.KV().Get(key+"targetId", nil)
+			if kvp != nil && string(kvp.Value) == deploymentID {
+				depTask++
+				kvp, _, err = client.KV().Get(key+"data/actionType", nil)
+				require.Nil(t, err, "Unexpected error while getting action type")
+				require.NotNil(t, kvp, "kvp is nil for action type")
+				require.Equal(t, string(kvp.Value), actionType)
+
+				kvp, _, err = client.KV().Get(key+"data/key1", nil)
+				require.Nil(t, err, "Unexpected error while getting key1")
+				require.NotNil(t, kvp, "kvp is nil for key1")
+				require.Equal(t, string(kvp.Value), "val1")
+
+				kvp, _, err = client.KV().Get(key+"data/key2", nil)
+				require.Nil(t, err, "Unexpected error while getting key3")
+				require.NotNil(t, kvp, "kvp is nil for key2")
+				require.Equal(t, string(kvp.Value), "val2")
+
+				kvp, _, err = client.KV().Get(key+"data/key3", nil)
+				require.Nil(t, err, "Unexpected error while getting key3")
+				require.NotNil(t, kvp, "kvp is nil for key3")
+				require.Equal(t, string(kvp.Value), "val3")
+			}
+		}
+		require.Equal(t, index, depTask, "Unexpected nb of tasks")
+	}
+
+	ind := 0
+	checkCpt := 0
+	ticker := time.NewTicker(ti)
+	time.Sleep(2 * time.Second)
+	for i := 0; i <= 2; i++ {
+		select {
+		case <-ticker.C:
+			ind++
+			// as the task is still running, no other task is created
+			check(1, checkCpt)
 			if ind == 3 {
 				ticker.Stop()
 				return

--- a/prov/slurm/execution.go
+++ b/prov/slurm/execution.go
@@ -59,6 +59,12 @@ func (jid *noJobFound) Error() string {
 	return jid.msg
 }
 
+func isNoJobFoundError(err error) bool {
+	cause := errors.Cause(err)
+	_, ok := cause.(*noJobFound)
+	return ok
+}
+
 type executionCommon struct {
 	kv             *api.KV
 	cfg            config.Configuration

--- a/prov/slurm/helper.go
+++ b/prov/slurm/helper.go
@@ -34,6 +34,8 @@ import (
 
 const reSbatch = `^Submitted batch job (\d+)`
 
+const invalidJob = "Invalid job id specified"
+
 // getSSHClient returns a SSH client with slurm credentials from node or job configuration provided by the deployment,
 // or by the yorc slurm configuration
 func getSSHClient(userName string, privateKey string, password string, cfg config.Configuration) (*sshutil.SSHClient, error) {
@@ -379,10 +381,13 @@ func parseKeyValue(str string) (bool, string, string) {
 func getJobInfo(client sshutil.Client, jobID string) (map[string]string, error) {
 	cmd := fmt.Sprintf("scontrol show job %s", jobID)
 	output, err := client.RunCommand(cmd)
-	if err != nil {
-		return nil, errors.Wrap(err, output)
-	}
 	out := strings.Trim(output, "\" \t\n\x00")
+	if err != nil {
+		if strings.Contains(out, invalidJob) {
+			return nil, &noJobFound{msg: err.Error()}
+		}
+		return nil, errors.Wrap(err, out)
+	}
 	if out != "" {
 		return parseJobInfo(strings.NewReader(out))
 	}

--- a/prov/slurm/helper_test.go
+++ b/prov/slurm/helper_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ystia/yorc/v3/config"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -351,11 +352,45 @@ func TestParseJob(t *testing.T) {
 	require.Equal(t, "2-19:42:53", info["RunTime"], "unexpected value for \"RunTime\" key")
 }
 
-func TestGetJobInfo(t *testing.T) {
+func TestGetJobInfoWithInvalidJob(t *testing.T) {
 	t.Parallel()
 	s := &MockSSHClient{
 		MockRunCommand: func(cmd string) (string, error) {
 			return "slurm_load_jobs error: Invalid job id specified", errors.New("")
+		},
+	}
+	info, err := getJobInfo(s, "1234")
+	require.Nil(t, info, "info should be nil")
+
+	require.Equal(t, true, isNoJobFoundError(err), "expected no job found error")
+}
+
+func TestGetJobInfo(t *testing.T) {
+	t.Parallel()
+	s := &MockSSHClient{
+		MockRunCommand: func(cmd string) (string, error) {
+			content, err := ioutil.ReadFile("testdata/scontrol.txt")
+			require.Nil(t, err, "Unexpected error reading scontrol")
+			return string(content), nil
+		},
+	}
+
+	data, err := os.Open("testdata/scontrol.txt")
+	require.Nil(t, err, "unexpected error while opening test file")
+	expected, err := parseJobInfo(data)
+	require.Nil(t, err, "Unexpected error parsing job info")
+	info, err := getJobInfo(s, "1234")
+	require.Nil(t, err, "Unexpected error retrieving job info")
+	require.NotNil(t, info, "info should not be nil")
+
+	require.Equal(t, expected, info, "unexpected job info")
+}
+
+func TestGetJobInfoWithEmptyResponse(t *testing.T) {
+	t.Parallel()
+	s := &MockSSHClient{
+		MockRunCommand: func(cmd string) (string, error) {
+			return "", nil
 		},
 	}
 	info, err := getJobInfo(s, "1234")

--- a/prov/slurm/helper_test.go
+++ b/prov/slurm/helper_test.go
@@ -247,7 +247,7 @@ func TestPrivateKey(t *testing.T) {
 	// Config to test
 	cfg := config.Configuration{
 		Infrastructures: map[string]config.DynamicMap{
-			"slurm": config.DynamicMap{
+			"slurm": {
 				"user_name":   "jdoe",
 				"url":         "127.0.0.1",
 				"port":        22,
@@ -349,4 +349,17 @@ func TestParseJob(t *testing.T) {
 	require.Equal(t, "RUNNING", info["JobState"], "unexpected value for \"JobState\" key")
 	require.Equal(t, "test-salloc-Environment", info["JobName"], "unexpected value for \"JobName\" key")
 	require.Equal(t, "2-19:42:53", info["RunTime"], "unexpected value for \"RunTime\" key")
+}
+
+func TestGetJobInfo(t *testing.T) {
+	t.Parallel()
+	s := &MockSSHClient{
+		MockRunCommand: func(cmd string) (string, error) {
+			return "slurm_load_jobs error: Invalid job id specified", errors.New("")
+		},
+	}
+	info, err := getJobInfo(s, "1234")
+	require.Nil(t, info, "info should be nil")
+
+	require.Equal(t, true, isNoJobFoundError(err), "expected no job found error")
 }

--- a/prov/slurm/helper_test.go
+++ b/prov/slurm/helper_test.go
@@ -398,3 +398,16 @@ func TestGetJobInfoWithEmptyResponse(t *testing.T) {
 
 	require.Equal(t, true, isNoJobFoundError(err), "expected no job found error")
 }
+
+func TestGetJobInfoWithError(t *testing.T) {
+	t.Parallel()
+	s := &MockSSHClient{
+		MockRunCommand: func(cmd string) (string, error) {
+			return "oups, it's bad", errors.New("this is an error !")
+		},
+	}
+	info, err := getJobInfo(s, "1234")
+	require.Nil(t, info, "info should be nil")
+
+	require.Equal(t, "oups, it's bad: this is an error !", err.Error(), "expected error")
+}

--- a/prov/slurm/monitoring_jobs.go
+++ b/prov/slurm/monitoring_jobs.go
@@ -108,6 +108,10 @@ func (o *actionOperator) monitorJob(ctx context.Context, cfg config.Configuratio
 
 	info, err := getJobInfo(sshClient, actionData.jobID)
 	if err != nil {
+		if isNoJobFoundError(err) {
+			// the job is not found in slurm database (should have been purged) : pass its status to "UNKNOWN"
+			deployments.SetInstanceStateStringWithContextualLogs(ctx, consulutil.GetKV(), deploymentID, action.Data["nodeName"], "0", "UNKNOWN")
+		}
 		return true, errors.Wrapf(err, "failed to get job info with jobID:%q", actionData.jobID)
 	}
 

--- a/prov/slurm/monitoring_jobs.go
+++ b/prov/slurm/monitoring_jobs.go
@@ -33,6 +33,13 @@ import (
 	"github.com/ystia/yorc/v3/prov/scheduling"
 )
 
+const bashLogger = `
+if [ -f %s ]; then
+    tail -n +%d %s
+fi
+
+`
+
 type actionOperator struct {
 }
 
@@ -188,7 +195,7 @@ func (o *actionOperator) logFile(ctx context.Context, cfg config.Configuration, 
 		return
 	}
 
-	cmd := fmt.Sprintf("tail -n +%d %s", lastInd+1, filePath)
+	cmd := fmt.Sprintf(bashLogger, filePath, lastInd+1, filePath)
 	output, err := sshClient.RunCommand(cmd)
 	if err != nil {
 		log.Debugf("fail to log file (%s)due to error:%+v:", filePath, err)


### PR DESCRIPTION
Add file check existence before tailing it for slurm logs

## Description of the change

   - Check task exists when retrieving status
   -  Add file check existence before tailing it for slurm logs


### How to verify it

run 10 long slurm job (30min) in parallel
check job node state is consistent with slurm job

### Description for the changelog

* Monitoring can be stopped before the job termination ([GH-438](https://github.com/ystia/yorc/issues/438))

## Applicable Issues

Fixes #438 