### PR TITLE
Update Alien version to 2.2.0-SM6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### ENHANCEMENTS
 
 * Expose bypass error parameter on workflow ([GH-425](https://github.com/ystia/yorc/issues/425))
+* Support Alien4Cloud 2.2 ([GH-441](https://github.com/ystia/yorc/issues/441))
 
 ## 3.2.0 (May 31, 2019)
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 yorc_version: 3.3.0-SNAPSHOT
 # Alien4Cloud version used by the bootstrap as the default version to download/install
-alien4cloud_version: 2.1.1
+alien4cloud_version: 2.2.0-SM6
 consul_version: 1.2.3
 terraform_version: 0.11.8
 ansible_version: 2.7.9


### PR DESCRIPTION
## Description of the change
Update Alien4Cloud version
### What I did
Update versions.yaml necessary for bootstrap. 

### How to verify it

Bootstrap yorc using updated urls for :

- alien4Cloud (can use pulp repository, http://10.197.135.244/starlings/alien4cloud/alien4cloud-premium-dist-2.2.0-SM6-dist.tar.gz)
- alien4cloud-yorc-plugin (can use plulp or download from JFrog plugin build of
feature/GH-124-Upgrade-to-Alien-2.2/alien4cloud-yorc-plugin-3.3.0-SNAPSHOT.zip)
- yorc : (can use pulp, dir yorc-deploy/test_alien_2.2/yorc-alien_2.2.tgz or build from jFrog)


Moreover, you can upload CSARs from Forge (branch feature/GH-124-Upgrade-to-Alien-2.2) to test some application samples deployment such as Welcome

### Description for the changelog

## Applicable Issues
