### PR TITLE
Allow to provide units for mem_per_node job slurm option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Deleting one host in Pool deletes other hosts having as prefix the deleted hostname ([GH-430](https://github.com/ystia/yorc/issues/430))
 * Yorc should support long standard operation names as well as short ones ([GH-300](https://github.com/ystia/yorc/issues/300))
 * Fix attributes notifications for services (substitutions) ([GH-423](https://github.com/ystia/yorc/issues/423))
+* mem_per_node slurm option parameter is limited to integer number of GB ([GH-446](https://github.com/ystia/yorc/issues/446))
 
 ### ENHANCEMENTS
 

--- a/data/tosca/yorc-slurm-types.yml
+++ b/data/tosca/yorc-slurm-types.yml
@@ -42,9 +42,11 @@ data_types:
         type: integer
         required: false
       mem_per_node:
-        type: string
-        description: The memory per node required to the job. Different units can be specified using the suffix [K|M|G|T].
+        type: scalar-unit.size
+        description: The memory per node required to the job.
         required: false
+        constraints:
+          - greater_or_equal: 0 KB
       time:
         type: string
         description: >

--- a/data/tosca/yorc-slurm-types.yml
+++ b/data/tosca/yorc-slurm-types.yml
@@ -42,8 +42,8 @@ data_types:
         type: integer
         required: false
       mem_per_node:
-        type: integer
-        description: The memory per node in GB required to the job.
+        type: string
+        description: The memory per node required to the job. Different units can be specified using the suffix [K|M|G|T].
         required: false
       time:
         type: string

--- a/prov/slurm/execution.go
+++ b/prov/slurm/execution.go
@@ -282,9 +282,7 @@ func (e *executionCommon) buildJobInfo(ctx context.Context) error {
 	if m, err := deployments.GetNodePropertyValue(e.kv, e.deploymentID, e.NodeName, "slurm_options", "mem_per_node"); err != nil {
 		return err
 	} else if m != nil && m.RawString() != "" {
-		if e.jobInfo.Mem, err = strconv.Atoi(m.RawString()); err != nil {
-			return err
-		}
+		e.jobInfo.Mem = strings.ReplaceAll(m.RawString(), " ", "")
 	}
 
 	if c, err := deployments.GetNodePropertyValue(e.kv, e.deploymentID, e.NodeName, "slurm_options", "cpus_per_task"); err != nil {
@@ -404,8 +402,8 @@ func (e *executionCommon) buildJobOpts() string {
 		opts += fmt.Sprintf(" --ntasks=%d", e.jobInfo.Tasks)
 	}
 	opts += fmt.Sprintf(" --nodes=%d", e.jobInfo.Nodes)
-	if e.jobInfo.Mem != 0 {
-		opts += fmt.Sprintf(" --mem=%dG", e.jobInfo.Mem)
+	if e.jobInfo.Mem != "" {
+		opts += fmt.Sprintf(" --mem=%s", e.jobInfo.Mem)
 	}
 	if e.jobInfo.Cpus != 0 {
 		opts += fmt.Sprintf(" --cpus-per-task=%d", e.jobInfo.Cpus)

--- a/prov/slurm/execution.go
+++ b/prov/slurm/execution.go
@@ -282,7 +282,9 @@ func (e *executionCommon) buildJobInfo(ctx context.Context) error {
 	if m, err := deployments.GetNodePropertyValue(e.kv, e.deploymentID, e.NodeName, "slurm_options", "mem_per_node"); err != nil {
 		return err
 	} else if m != nil && m.RawString() != "" {
-		e.jobInfo.Mem = strings.ReplaceAll(m.RawString(), " ", "")
+		if e.jobInfo.Mem, err = toSlurmMemFormat(m.RawString()); err != nil {
+			return err
+		}
 	}
 
 	if c, err := deployments.GetNodePropertyValue(e.kv, e.deploymentID, e.NodeName, "slurm_options", "cpus_per_task"); err != nil {

--- a/prov/slurm/helper.go
+++ b/prov/slurm/helper.go
@@ -17,6 +17,7 @@ package slurm
 import (
 	"bufio"
 	"fmt"
+	"github.com/dustin/go-humanize"
 	"io"
 	"regexp"
 	"strconv"
@@ -399,4 +400,15 @@ func quoteArgs(t []string) string {
 		args += v + " "
 	}
 	return args
+}
+
+// Slurm mem units are K|M|G|T ie KiB MiB GiB TiB
+func toSlurmMemFormat(memStr string) (string, error) {
+	mem, err := humanize.ParseBytes(memStr)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to convert to slurm memory format value:%q", memStr)
+	}
+
+	humanB := strings.ReplaceAll(humanize.IBytes(mem), " ", "")
+	return humanB[0 : len(humanB)-2], nil
 }

--- a/prov/slurm/helper_test.go
+++ b/prov/slurm/helper_test.go
@@ -350,3 +350,35 @@ func TestParseJob(t *testing.T) {
 	require.Equal(t, "test-salloc-Environment", info["JobName"], "unexpected value for \"JobName\" key")
 	require.Equal(t, "2-19:42:53", info["RunTime"], "unexpected value for \"RunTime\" key")
 }
+
+func TestToSlurmMemFormat(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		memStr string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{"TestMemInGB", args{"250 GB"}, "233G", false},
+		{"TestMemInMiB", args{"800 MiB"}, "800M", false},
+		{"TestMemInGiBWithDecimal", args{"0.5 GiB"}, "512M", false},
+		{"TestMemInGBWithDecimal", args{"0.5GB"}, "477M", false},
+		{"TestBadFormat", args{"0.5 Bad"}, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			memSlurm, err := toSlurmMemFormat(tt.args.memStr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("toSlurmMemFormat() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			require.Equal(t, tt.want, memSlurm, "unexpected slurm mem format")
+		})
+	}
+
+}

--- a/prov/slurm/structs.go
+++ b/prov/slurm/structs.go
@@ -46,7 +46,7 @@ type jobInfo struct {
 	Tasks                  int               `json:"tasks,omitempty"`
 	Cpus                   int               `json:"cpus,omitempty"`
 	Nodes                  int               `json:"nodes,omitempty"`
-	Mem                    int               `json:"mem,omitempty"`
+	Mem                    string            `json:"mem,omitempty"`
 	MaxTime                string            `json:"max_time,omitempty"`
 	Opts                   []string          `json:"opts,omitempty"`
 	Args                   []string          `json:"args,omitempty"`


### PR DESCRIPTION
# Pull Request description

## Description of the change
Change the mem_per_node slurm option param from integer to string in order to provide slurm memory unit

### How to verify it
run a job with mem_per_node slurm job option to 300 M by instance
### Description for the changelog
 mem_per_node slurm option parameter is limited to integer number of GB ([GH-446](https://github.com/ystia/yorc/issues/446))
## Applicable Issues
#446 