### PR TITLE
Set job node state in error for Ansible job when failure occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix attributes notifications for services (substitutions) ([GH-423](https://github.com/ystia/yorc/issues/423))
 * Monitoring can be stopped before the job termination ([GH-438](https://github.com/ystia/yorc/issues/438))
 * mem_per_node slurm option parameter is limited to integer number of GB ([GH-446](https://github.com/ystia/yorc/issues/446))
+* Job node state remains to "executing" when Ansible job fails ([GH-455](https://github.com/ystia/yorc/issues/455))
 
 ### ENHANCEMENTS
 

--- a/prov/ansible/monitoring_job.go
+++ b/prov/ansible/monitoring_job.go
@@ -75,6 +75,7 @@ func (o *actionOperator) ExecAction(ctx context.Context, cfg config.Configuratio
 		case "RUNNING", "QUEUED":
 			return false, opErr
 		case "COMPLETED":
+			deployments.SetInstanceStateStringWithContextualLogs(ctx, consulutil.GetKV(), deploymentID, action.Data["nodeName"], "0", tosca.NodeStateStarted.String())
 			return true, opErr
 		case "FAILED":
 			if opErr == nil {

--- a/prov/ansible/monitoring_job.go
+++ b/prov/ansible/monitoring_job.go
@@ -17,6 +17,8 @@ package ansible
 import (
 	"context"
 	"encoding/json"
+	"github.com/ystia/yorc/v4/deployments"
+	"github.com/ystia/yorc/v4/helper/consulutil"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -78,6 +80,7 @@ func (o *actionOperator) ExecAction(ctx context.Context, cfg config.Configuratio
 			if opErr == nil {
 				opErr = errors.Errorf("job implementation of node %q was detected as failed", nodeName)
 			}
+			deployments.SetInstanceStateStringWithContextualLogs(ctx, consulutil.GetKV(), deploymentID, action.Data["nodeName"], "0", tosca.NodeStateError.String())
 			return true, opErr
 		}
 


### PR DESCRIPTION
# Pull Request description

### How to verify it
See issue description
### Description for the changelog
job node state remains to "executing" when Ansible job fails ([GH-455](https://github.com/ystia/yorc/issues/455))
## Applicable Issues
#455 