### PR TITLE
Backport32/bugfix/gh 451 common types storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Yorc should support long standard operation names as well as short ones ([GH-300](https://github.com/ystia/yorc/issues/300))
 * Fix attributes notifications for services (substitutions) ([GH-423](https://github.com/ystia/yorc/issues/423))
 * Monitoring can be stopped before the job termination ([GH-438](https://github.com/ystia/yorc/issues/438))
+* Problem with getting the path of common types stored in Consul ([GH-451](https://github.com/ystia/yorc/issues/451))
 
 ## 3.2.0 (May 31, 2019)
 

--- a/deployments/definition_store_test.go
+++ b/deployments/definition_store_test.go
@@ -1073,7 +1073,7 @@ func BenchmarkDefinitionStore(b *testing.B) {
 		c.Stderr = ioutil.Discard
 	}
 
-	srv, client := testutil.NewTestConsulInstanceWithConfig(b, cb)
+	srv, client := testutil.NewTestConsulInstanceWithConfigAndStore(b, cb)
 	kv := client.KV()
 	defer srv.Stop()
 	deploymentID := testutil.BuildDeploymentID(b)

--- a/deployments/store/definition_store.go
+++ b/deployments/store/definition_store.go
@@ -23,11 +23,11 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
-	"github.com/ystia/yorc/v3/deployments/internal"
-	"github.com/ystia/yorc/v3/helper/collections"
-	"github.com/ystia/yorc/v3/helper/consulutil"
-	"github.com/ystia/yorc/v3/log"
-	"github.com/ystia/yorc/v3/tosca"
+	"github.com/ystia/yorc/v4/deployments/internal"
+	"github.com/ystia/yorc/v4/helper/collections"
+	"github.com/ystia/yorc/v4/helper/consulutil"
+	"github.com/ystia/yorc/v4/log"
+	"github.com/ystia/yorc/v4/tosca"
 )
 
 // BuiltinOrigin is the origin for Yorc builtin
@@ -55,17 +55,14 @@ func getLatestCommonsTypesPaths() ([]string, error) {
 		if len(versions) == 0 {
 			continue
 		}
-		typePath := path.Join(versions[0], "types")
-		if len(versions) >= 1 {
-			var maxVersion semver.Version
-			for _, v := range versions {
-				version, err := semver.Make(path.Base(v))
-				if err == nil && version.GTE(maxVersion) {
-					maxVersion = version
-				}
+		var maxVersion semver.Version
+		for _, v := range versions {
+			version, err := semver.Make(path.Base(v))
+			if err == nil && version.GTE(maxVersion) {
+				maxVersion = version
 			}
-			typePath = path.Join(builtinTypesPath, maxVersion.String(), "types")
 		}
+		typePath := path.Join(builtinTypesPath, maxVersion.String())
 
 		paths = append(paths, typePath)
 	}

--- a/deployments/store/definition_store.go
+++ b/deployments/store/definition_store.go
@@ -23,11 +23,11 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
-	"github.com/ystia/yorc/v4/deployments/internal"
-	"github.com/ystia/yorc/v4/helper/collections"
-	"github.com/ystia/yorc/v4/helper/consulutil"
-	"github.com/ystia/yorc/v4/log"
-	"github.com/ystia/yorc/v4/tosca"
+	"github.com/ystia/yorc/v3/deployments/internal"
+	"github.com/ystia/yorc/v3/helper/collections"
+	"github.com/ystia/yorc/v3/helper/consulutil"
+	"github.com/ystia/yorc/v3/log"
+	"github.com/ystia/yorc/v3/tosca"
 )
 
 // BuiltinOrigin is the origin for Yorc builtin

--- a/deployments/store/definition_store.go
+++ b/deployments/store/definition_store.go
@@ -39,6 +39,10 @@ var lock sync.Mutex
 
 var builtinTypes = make([]string, 0)
 
+// getLatestCommonsTypesPaths() returns all the path keys corresponding to the last version of a type
+// that is stored under the consulutil.CommonsTypesKVPrefix.
+// For example, one path key could be _yorc/commons_types/some_type/2.0.0 if the last version
+// of the some_type type is 2.0.0
 func getLatestCommonsTypesPaths() ([]string, error) {
 	kv := consulutil.GetKV()
 	// keys, _, err := kv.List("", nil)

--- a/deployments/store/definition_store.go
+++ b/deployments/store/definition_store.go
@@ -41,13 +41,14 @@ var builtinTypes = make([]string, 0)
 
 func getLatestCommonsTypesPaths() ([]string, error) {
 	kv := consulutil.GetKV()
-	keys, _, err := kv.Keys(consulutil.CommonsTypesKVPrefix+"/", "/", nil)
+	keys, _, err := kv.List("", nil)
+	//keys, _, err := kv.Keys(consulutil.CommonsTypesKVPrefix+"/", "/", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 	}
 	paths := make([]string, 0, len(keys))
 	for _, builtinTypesPath := range keys {
-		versions, _, err := kv.Keys(builtinTypesPath, "/", nil)
+		versions, _, err := kv.Keys(builtinTypesPath.Key, "/", nil)
 		if err != nil {
 			return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 		}
@@ -62,7 +63,7 @@ func getLatestCommonsTypesPaths() ([]string, error) {
 				maxVersion = version
 			}
 		}
-		typePath := path.Join(builtinTypesPath, maxVersion.String())
+		typePath := path.Join(builtinTypesPath.Key, maxVersion.String())
 
 		paths = append(paths, typePath)
 	}

--- a/deployments/store/definition_store.go
+++ b/deployments/store/definition_store.go
@@ -41,14 +41,14 @@ var builtinTypes = make([]string, 0)
 
 func getLatestCommonsTypesPaths() ([]string, error) {
 	kv := consulutil.GetKV()
-	keys, _, err := kv.List("", nil)
-	//keys, _, err := kv.Keys(consulutil.CommonsTypesKVPrefix+"/", "/", nil)
+	// keys, _, err := kv.List("", nil)
+	keys, _, err := kv.Keys(consulutil.CommonsTypesKVPrefix+"/", "/", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 	}
 	paths := make([]string, 0, len(keys))
 	for _, builtinTypesPath := range keys {
-		versions, _, err := kv.Keys(builtinTypesPath.Key, "/", nil)
+		versions, _, err := kv.Keys(builtinTypesPath, "/", nil)
 		if err != nil {
 			return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 		}
@@ -63,7 +63,7 @@ func getLatestCommonsTypesPaths() ([]string, error) {
 				maxVersion = version
 			}
 		}
-		typePath := path.Join(builtinTypesPath.Key, maxVersion.String())
+		typePath := path.Join(builtinTypesPath, maxVersion.String())
 
 		paths = append(paths, typePath)
 	}

--- a/deployments/store/definition_store_test.go
+++ b/deployments/store/definition_store_test.go
@@ -82,7 +82,7 @@ func storeCommonTypePath(ctx context.Context, t *testing.T, paths []string) {
 	// Where "some_type/some_value" is one of the existingPath slice element provided in the tests structure,
 	// for example "toto/1.0.0",
 	// and "some_name" (here ".exist") represents some element (like a property) name of the some_type type
-	var someValue string = "1"
+	someValue := "1"
 	for _, p := range paths {
 		// Store value "1" with key _yorc/commons_types/toto/1.0.0/.exist
 		consulStore.StoreConsulKeyAsString(path.Join(consulutil.CommonsTypesKVPrefix, p, ".exist"), someValue)

--- a/deployments/store/definition_store_test.go
+++ b/deployments/store/definition_store_test.go
@@ -43,8 +43,9 @@ func TestRunDefinitionStoreTests(t *testing.T) {
 	})
 }
 
-// newTestConsulInstance creates and configures Consul instance for tests
-// can't use util functions from testutil package in order to avoid import cycles
+// newTestConsulInstance creates and configures Consul instance
+// for testing functions in the store package
+// Remarque: can't use util functions from testutil package in order to avoid import cycles
 func newTestConsulInstance(t *testing.T) (*testutil.TestServer, *api.Client) {
 	logLevel := "debug"
 	if isCI, ok := os.LookupEnv("CI"); ok && isCI == "true" {
@@ -77,15 +78,16 @@ func newTestConsulInstance(t *testing.T) (*testutil.TestServer, *api.Client) {
 func storeCommonTypePath(ctx context.Context, t *testing.T, paths []string) {
 	_, errGrp, consulStore := consulutil.WithContext(ctx)
 
-	// Store some_value (here "1") with key "_yorc/commons_types/some_type/some_version/some_name"
+	// Store someValue (here "1") with key "_yorc/commons_types/some_type/some_version/some_name"
 	// Where "some_type/some_value" is one of the existingPath slice element provided in the tests structure,
 	// for example "toto/1.0.0",
 	// and "some_name" (here ".exist") represents some element (like a property) name of the some_type type
-	var some_value string = "1"
+	var someValue string = "1"
 	for _, p := range paths {
 		// Store value "1" with key _yorc/commons_types/toto/1.0.0/.exist
-		consulStore.StoreConsulKeyAsString(path.Join(consulutil.CommonsTypesKVPrefix, p, ".exist"), some_value)
+		consulStore.StoreConsulKeyAsString(path.Join(consulutil.CommonsTypesKVPrefix, p, ".exist"), someValue)
 	}
+	//
 	require.NoError(t, errGrp.Wait())
 }
 
@@ -94,7 +96,6 @@ func storeCommonTypePath(ctx context.Context, t *testing.T, paths []string) {
 // - some_type/some_value
 // - some_name
 func testTypesPath(t *testing.T, kv *api.KV) {
-	log.Printf("Try to execute testTypesPath")
 	log.SetDebug(true)
 
 	tests := []struct {

--- a/deployments/store/definition_store_test.go
+++ b/deployments/store/definition_store_test.go
@@ -1,0 +1,125 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	"os"
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/ystia/yorc/v3/config"
+	"github.com/ystia/yorc/v3/helper/consulutil"
+	"github.com/ystia/yorc/v3/log"
+)
+
+// TestRunDefinitionStoreTests aims to run a max of tests on store functions
+func TestRunDefinitionStoreTests(t *testing.T) {
+	log.Printf("TestRunDefinitionStoreTests")
+	srv, _ := newTestConsulInstance(t)
+	defer srv.Stop()
+
+	t.Run("StoreTests", func(t *testing.T) {
+		t.Run("TestTypesPath", func(t *testing.T) {
+			storeSomething()
+			testTypesPath(t)
+		})
+	})
+}
+
+// newTestConsulInstance creates and configures Conul instance for tests
+// can't use util functions from testutil package in order to avoid import cycles
+func newTestConsulInstance(t *testing.T) (*testutil.TestServer, *api.Client) {
+	log.Printf("Try to create consul instance")
+	logLevel := "debug"
+	if isCI, ok := os.LookupEnv("CI"); ok && isCI == "true" {
+		logLevel = "warn"
+	}
+	log.Printf("Log level ok")
+	cb := func(c *testutil.TestServerConfig) {
+		c.Args = []string{"-ui"}
+		c.LogLevel = logLevel
+	}
+	srv1, err := testutil.NewTestServerConfig(cb)
+	if err != nil {
+		t.Fatalf("Failed to create consul server: %v", err)
+	}
+	log.Printf("TestServerConfig ok")
+
+	cfg := config.Configuration{
+		Consul: config.Consul{
+			Address:        srv1.HTTPAddr,
+			PubMaxRoutines: config.DefaultConsulPubMaxRoutines,
+		},
+	}
+
+	client, err := cfg.GetNewConsulClient()
+	assert.Nil(t, err)
+
+	kv := client.KV()
+	consulutil.InitConsulPublisher(cfg.Consul.PubMaxRoutines, kv)
+	return srv1, client
+}
+
+// storeSomething allows to store some type definitions to consul under consulutil.CommonsTypesKVPrefix
+func storeSomething() {
+	prefix := consulutil.CommonsTypesKVPrefix + "/"
+	resources := getSomeResourcesToStore(2)
+	ctx := context.Background()
+	storeDefinition(ctx, prefix, resources)
+}
+
+// storeDefinition uses the consulStore from the context
+func storeDefinition(ctx context.Context, origin string, resDefinitions map[string]string) {
+	ctx, _, consulStore := consulutil.WithContext(ctx)
+	for name, value := range resDefinitions {
+		consulStore.StoreConsulKeyAsString(path.Join(origin, name), value)
+	}
+}
+
+// getSomeResourcesToStore creates a map for resource definitiaons to store
+// for each of the nbres respurces, construct 2 resource names corresponding to 2 versions of the resource
+func getSomeResourcesToStore(nbres int) map[string]string {
+	res := make(map[string]string, nbres)
+	value1 := "abc"
+	value2 := "xyz"
+	for i := 0; i < nbres; i++ {
+		resName := "test_types" + strconv.Itoa(i)
+		resName1 := resName + "/" + "1.1.1"
+		res[resName1] = value1
+		resName2 := resName + "/" + "2.1.1"
+		res[resName2] = value2
+	}
+	return res
+}
+
+// restTypePath ais to test getLatestCommonsTypesPaths
+// WIP
+func testTypesPath(t *testing.T) {
+	log.Printf("Try to execute testTypesPath")
+	log.SetDebug(true)
+
+	paths, err := getLatestCommonsTypesPaths()
+
+	log.Printf("Length of paths is " + string(len(paths)))
+
+	require.Nil(t, err)
+	require.Len(t, paths, 0)
+}

--- a/testutil/helper.go
+++ b/testutil/helper.go
@@ -30,6 +30,7 @@ import (
 // NewTestConsulInstance allows to :
 //  - creates and returns a new Consul server and client
 //  - starts a Consul Publisher
+//  - stores common-types to Consul
 // Warning: You need to defer the server stop command in the caller
 func NewTestConsulInstance(t testing.TB) (*testutil.TestServer, *api.Client) {
 	logLevel := "debug"
@@ -41,15 +42,21 @@ func NewTestConsulInstance(t testing.TB) (*testutil.TestServer, *api.Client) {
 		c.Args = []string{"-ui"}
 		c.LogLevel = logLevel
 	}
-	return NewTestConsulInstanceWithConfig(t, cb)
+	return NewTestConsulInstanceWithConfigAndStore(t, cb)
 }
 
-// NewTestConsulInstanceWithConfig sets up a consul instance for testing
-//
+// NewTestConsulInstanceWithConfigAndStore sets up a consul instance for testing
+func NewTestConsulInstanceWithConfigAndStore(t testing.TB, cb testutil.ServerConfigCallback) (*testutil.TestServer, *api.Client) {
+
+	return NewTestConsulInstanceWithConfig(t, cb, true)
+}
+
+// NewTestConsulInstanceWithConfig sets up a consul instance for testing :
 //  - creates and returns a new Consul server and client
 //  - starts a Consul Publisher
+//  - stores common-types to Consul only if storeCommons bool parameter is true
 // Warning: You need to defer the server stop command in the caller
-func NewTestConsulInstanceWithConfig(t testing.TB, cb testutil.ServerConfigCallback) (*testutil.TestServer, *api.Client) {
+func NewTestConsulInstanceWithConfig(t testing.TB, cb testutil.ServerConfigCallback, storeCommons bool) (*testutil.TestServer, *api.Client) {
 	srv1, err := testutil.NewTestServerConfig(cb)
 	if err != nil {
 		t.Fatalf("Failed to create consul server: %v", err)
@@ -68,7 +75,9 @@ func NewTestConsulInstanceWithConfig(t testing.TB, cb testutil.ServerConfigCallb
 	kv := client.KV()
 	consulutil.InitConsulPublisher(cfg.Consul.PubMaxRoutines, kv)
 
-	storeCommonDefinitions()
+	if storeCommons {
+		storeCommonDefinitions()
+	}
 
 	return srv1, client
 }


### PR DESCRIPTION
## Description of the change

### What I did
Fixed getLatestCommonTypesPath() method
Added test functions to the deployments/store package

### How I did it

### How to verify it
Run tests 

### Description for the changelog

## Applicable Issues
