### PR TITLE
Convert scalar-unit mem size to KiB for Slurm option

### DIFF
--- a/prov/slurm/helper.go
+++ b/prov/slurm/helper.go
@@ -407,13 +407,13 @@ func quoteArgs(t []string) string {
 	return args
 }
 
-// Slurm mem units are K|M|G|T ie KiB MiB GiB TiB
+// Convert scalar-unit size to Kib as K for Slurm
 func toSlurmMemFormat(memStr string) (string, error) {
 	mem, err := humanize.ParseBytes(memStr)
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to convert to slurm memory format value:%q", memStr)
 	}
 
-	humanB := strings.ReplaceAll(humanize.IBytes(mem), " ", "")
-	return humanB[0 : len(humanB)-2], nil
+	// Pass to KiB as K for Slurm
+	return strconv.Itoa(int(mem)/1024) + "K", nil
 }

--- a/prov/slurm/helper_test.go
+++ b/prov/slurm/helper_test.go
@@ -424,10 +424,11 @@ func TestToSlurmMemFormat(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{"TestMemInGB", args{"250 GB"}, "233G", false},
-		{"TestMemInMiB", args{"800 MiB"}, "800M", false},
-		{"TestMemInGiBWithDecimal", args{"0.5 GiB"}, "512M", false},
-		{"TestMemInGBWithDecimal", args{"0.5GB"}, "477M", false},
+		{"TestMemInGB", args{"250 GB"}, "244140625K", false},
+		{"TestMemInMiB", args{"2010 MiB"}, "2058240K", false},
+		{"TestMemInMiB", args{"800 MiB"}, "819200K", false},
+		{"TestMemInGiBWithDecimal", args{"0.5 GiB"}, "524288K", false},
+		{"TestMemInGBWithDecimal", args{"0.5GB"}, "488281K", false},
 		{"TestBadFormat", args{"0.5 Bad"}, "", true},
 	}
 


### PR DESCRIPTION
# Pull Request description

## Description of the change
Convert scalar-unit mem size to KiB for Slurm option
## Applicable Issues
#446 