### PR TITLE
Bugfix/sshd scp issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Monitoring can be stopped before the job termination ([GH-438](https://github.com/ystia/yorc/issues/438))
 * mem_per_node slurm option parameter is limited to integer number of GB ([GH-446](https://github.com/ystia/yorc/issues/446))
 * Job node state remains to "executing" when Ansible job fails ([GH-455](https://github.com/ystia/yorc/issues/455))
+* Panic occurs uploading job slurm artifacts during load test ([GH-465](https://github.com/ystia/yorc/issues/465))
 
 ### ENHANCEMENTS
 

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible // indirect
-	github.com/bramvdbogaerde/go-scp v0.0.0-20170919175937-e1fc87afa32536b6f2a58fc9cf937432aeff91e7
 	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
 	github.com/containerd/continuity v0.0.0-20181203112020-004b46473808 // indirect
 	github.com/denisenkom/go-mssqldb v0.0.0-20190204142019-df6d76eb9289 // indirect

--- a/helper/sshutil/sshutil.go
+++ b/helper/sshutil/sshutil.go
@@ -267,6 +267,7 @@ func (client *SSHClient) CopyFile(source io.Reader, remotePath string, permissio
 		}
 	}()
 
+	wg.Wait()
 	close(errCh)
 	for err := range errCh {
 		if err != nil {

--- a/helper/sshutil/sshutil.go
+++ b/helper/sshutil/sshutil.go
@@ -26,8 +26,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 
-	"github.com/bramvdbogaerde/go-scp"
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
@@ -199,29 +199,80 @@ func ToPrivateKeyContent(pk string) ([]byte, error) {
 }
 
 // CopyFile allows to copy a reader over SSH with defined remote path and specific permissions
-func (client *SSHClient) CopyFile(source io.Reader, remotePath, permissions string) error {
-	// Create a new SCP client
-	scpHostPort := fmt.Sprintf("%s:%d", client.Host, client.Port)
-	scpClient := scp.NewClient(scpHostPort, client.Config)
-
-	// Connect to the remote server
-	err := scpClient.Connect()
-	if err != nil {
-		return errors.Wrapf(err, "Couldn't establish a connection to the remote host:%q", scpHostPort)
-	}
-	defer scpClient.Session.Close()
-
+// CopyFile allows to copy a reader over SSH with defined remote path and specific permissions
+func (client *SSHClient) CopyFile(source io.Reader, remotePath string, permissions string) error {
 	// Create the remote directory
 	remoteDir := path.Dir(remotePath)
 	mkdirCmd := fmt.Sprintf("mkdir -p %s", remoteDir)
-	_, err = client.RunCommand(mkdirCmd)
+	_, err := client.RunCommand(mkdirCmd)
 	if err != nil {
 		return errors.Wrapf(err, "Couldn't create the remote directory:%q", remoteDir)
 	}
 
-	// Finally, copy the reader over SSH
-	log.Debugf("Copy source over SSH to remote path:%s", remotePath)
-	scpClient.CopyFile(source, remotePath, permissions)
+	// determine the length by reading the reader
+	content, err := ioutil.ReadAll(source)
+	if err != nil {
+		return err
+	}
+	size := int64(len(content))
+
+	// Copy the file with scp
+	filename := path.Base(remotePath)
+	directory := path.Dir(remotePath)
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	errCh := make(chan error, 2)
+
+	session, err := client.newSession()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		defer wg.Done()
+		w, err := session.StdinPipe()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer w.Close()
+
+		_, err = fmt.Fprintln(w, "C"+permissions, size, filename)
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		_, err = io.Copy(w, bytes.NewReader(content))
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		_, err = fmt.Fprint(w, "\x00")
+		if err != nil {
+			errCh <- err
+			return
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		err := session.Run(fmt.Sprintf("scp -qt %s", directory))
+		if err != nil {
+			errCh <- err
+			return
+		}
+	}()
+
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/helper/sshutil/sshutil.go
+++ b/helper/sshutil/sshutil.go
@@ -230,15 +230,17 @@ func (client *SSHClient) CopyFile(source io.Reader, remotePath string, permissio
 		return err
 	}
 
+	// need to get StdinPipe before starting ssh process
+	w, err := session.StdinPipe()
+	if err != nil {
+		return err
+	}
+
 	go func() {
 		defer wg.Done()
-		w, err := session.StdinPipe()
-		if err != nil {
-			errCh <- err
-			return
-		}
-		defer w.Close()
 
+		// close writer once file data have been written or if error occurs
+		defer w.Close()
 		_, err = fmt.Fprintln(w, "C"+permissions, size, filename)
 		if err != nil {
 			errCh <- err

--- a/prov/ansible/monitoring_job.go
+++ b/prov/ansible/monitoring_job.go
@@ -17,8 +17,8 @@ package ansible
 import (
 	"context"
 	"encoding/json"
-	"github.com/ystia/yorc/v4/deployments"
-	"github.com/ystia/yorc/v4/helper/consulutil"
+	"github.com/ystia/yorc/v3/deployments"
+	"github.com/ystia/yorc/v3/helper/consulutil"
 	"strings"
 
 	"github.com/pkg/errors"


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did
-  Remove go-scp lib usage in order to benefit from our own ssh pool sessions to handle scp command
- Add  sync.WaitGroup Wait to original function

### How to verify it
Load tests
### Description for the changelog
* Panic occurs uploading job slurm artifacts during load test ([GH-465](https://github.com/ystia/yorc/issues/465))
## Applicable Issues
#465 