### PR TITLE
Using now block storage API v3, still able to use v1 for tests purposes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### ENHANCEMENTS
 
+* Support OpenStack Block storage API v3 ([GH-440](https://github.com/ystia/yorc/issues/440))
 * Expose bypass error parameter on workflow ([GH-425](https://github.com/ystia/yorc/issues/425))
 * Support Alien4Cloud 2.2 ([GH-441](https://github.com/ystia/yorc/issues/441))
 * Allow to provide extra env vars to Alien4Cloud during bootstrap ([GH-452](https://github.com/ystia/yorc/issues/452))

--- a/prov/terraform/openstack/consul_test.go
+++ b/prov/terraform/openstack/consul_test.go
@@ -66,5 +66,8 @@ func TestRunConsulOpenstackPackageTests(t *testing.T) {
 		t.Run("OSInstanceWithServerGroup", func(t *testing.T) {
 			testOSInstanceWithServerGroup(t, kv, srv)
 		})
+		t.Run("TestGenerateTerraformInfo", func(t *testing.T) {
+			testGenerateTerraformInfo(t, srv, kv)
+		})
 	})
 }

--- a/prov/terraform/openstack/generator.go
+++ b/prov/terraform/openstack/generator.go
@@ -37,6 +37,7 @@ import (
 
 const (
 	floatingIPEndpointCapAttribute = "/capabilities/endpoint/attributes/floating_ip_address"
+	consulKeysResource             = "consul_keys"
 )
 
 type osGenerator struct {
@@ -247,14 +248,14 @@ func (g *osGenerator) generateBlockStorageInfra(opts generateInfraOptions) error
 			Path:  path.Join(opts.instancesKey, opts.instanceName, "/attributes/volume_id"),
 			Value: fmt.Sprintf("${%s.%s.id}", opts.resourceTypes[blockStorageVolume], bsVolume.Name)}
 		consulKeys := commons.ConsulKeys{Keys: []commons.ConsulKey{consulKey}}
-		commons.AddResource(opts.infrastructure, "consul_keys", bsVolume.Name, &consulKeys)
+		commons.AddResource(opts.infrastructure, consulKeysResource, bsVolume.Name, &consulKeys)
 	} else {
 		name := opts.cfg.ResourcesPrefix + opts.nodeName + "-" + opts.instanceName
 		consulKey := commons.ConsulKey{
 			Path:  path.Join(opts.instancesKey, opts.instanceName, "/properties/volume_id"),
 			Value: strings.TrimSpace(bsIds[opts.instanceIndex])}
 		consulKeys := commons.ConsulKeys{Keys: []commons.ConsulKey{consulKey}}
-		commons.AddResource(opts.infrastructure, "consul_keys", name, &consulKeys)
+		commons.AddResource(opts.infrastructure, consulKeysResource, name, &consulKeys)
 	}
 
 	return err
@@ -311,7 +312,7 @@ func (g *osGenerator) generateFloatingIPInfra(opts generateInfraOptions) error {
 
 	}
 	consulKeys := commons.ConsulKeys{Keys: []commons.ConsulKey{consulKey}}
-	commons.AddResource(opts.infrastructure, "consul_keys", ip.Name, &consulKeys)
+	commons.AddResource(opts.infrastructure, consulKeysResource, ip.Name, &consulKeys)
 	return err
 }
 
@@ -350,7 +351,7 @@ func (g *osGenerator) generateNetworkInfra(opts generateInfraOptions) error {
 	consulKeys := commons.ConsulKeys{Keys: []commons.ConsulKey{consulKey}}
 	consulKeys.DependsOn = []string{fmt.Sprintf("%s.%s_subnet", opts.resourceTypes[networkingSubnet],
 		opts.nodeName)}
-	commons.AddResource(opts.infrastructure, "consul_keys", opts.nodeName, &consulKeys)
+	commons.AddResource(opts.infrastructure, consulKeysResource, opts.nodeName, &consulKeys)
 
 	return err
 }

--- a/prov/terraform/openstack/generator.go
+++ b/prov/terraform/openstack/generator.go
@@ -34,6 +34,10 @@ import (
 	"github.com/ystia/yorc/v4/tosca"
 )
 
+const (
+	floatingIPEndpointCapAttribute = "/capabilities/endpoint/attributes/floating_ip_address"
+)
+
 type osGenerator struct {
 }
 
@@ -176,7 +180,7 @@ func (g *osGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg con
 				floatingIP := FloatingIP{Pool: ip.Pool}
 				commons.AddResource(&infrastructure, resourceTypes[computeFloatingIP], ip.Name, &floatingIP)
 				consulKey = commons.ConsulKey{
-					Path:  path.Join(instancesKey, instanceName, "/capabilities/endpoint/attributes/floating_ip_address"),
+					Path:  path.Join(instancesKey, instanceName, floatingIPEndpointCapAttribute),
 					Value: fmt.Sprintf("${%s.%s.address}", resourceTypes[computeFloatingIP], ip.Name)}
 			} else {
 				ips := strings.Split(ip.Pool, ",")
@@ -197,7 +201,7 @@ func (g *osGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg con
 					floatingIP := FloatingIP{Pool: networkName.RawString()}
 					commons.AddResource(&infrastructure, resourceTypes[computeFloatingIP], ip.Name, &floatingIP)
 					consulKey = commons.ConsulKey{
-						Path:  path.Join(instancesKey, instanceName, "/capabilities/endpoint/attributes/floating_ip_address"),
+						Path:  path.Join(instancesKey, instanceName, floatingIPEndpointCapAttribute),
 						Value: fmt.Sprintf("${%s.%s.address}", resourceTypes[computeFloatingIP], ip.Name)}
 
 				} else {
@@ -206,7 +210,7 @@ func (g *osGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg con
 					if err != nil {
 						return false, nil, nil, nil, err
 					}
-					consulKey = commons.ConsulKey{Path: path.Join(instancesKey, instanceName, "/capabilities/endpoint/attributes/floating_ip_address"), Value: ips[instName]}
+					consulKey = commons.ConsulKey{Path: path.Join(instancesKey, instanceName, floatingIPEndpointCapAttribute), Value: ips[instName]}
 				}
 
 			}

--- a/prov/terraform/openstack/generator.go
+++ b/prov/terraform/openstack/generator.go
@@ -123,14 +123,15 @@ func (g *osGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg con
 		case "yorc.nodes.openstack.Compute":
 			err = g.generateOSInstance(ctx,
 				osInstanceOptions{
-					kv:            kv,
-					cfg:           cfg,
-					deploymentID:  deploymentID,
-					nodeName:      nodeName,
-					instanceName:  instanceName,
-					resourceTypes: resourceTypes,
+					kv:             kv,
+					cfg:            cfg,
+					infrastructure: &infrastructure,
+					deploymentID:   deploymentID,
+					nodeName:       nodeName,
+					instanceName:   instanceName,
+					resourceTypes:  resourceTypes,
 				},
-				&infrastructure, outputs, &cmdEnv)
+				outputs, &cmdEnv)
 			if err != nil {
 				return false, nil, nil, nil, err
 			}

--- a/prov/terraform/openstack/generator.go
+++ b/prov/terraform/openstack/generator.go
@@ -123,7 +123,7 @@ func (g *osGenerator) generateTerraformInfraForNode(ctx context.Context, kv *api
 			instanceIndex:  instIdx,
 			resourceTypes:  resourceTypes,
 		}
-		err := g.generateInstanceInfra(ctx, infraOpts, outputs, cmdEnv)
+		err := g.generateInstanceInfra(ctx, infraOpts, outputs, &cmdEnv)
 		if err != nil {
 			return false, nil, nil, nil, err
 		}
@@ -172,7 +172,7 @@ func getOpenStackProviderEnv(cfg config.Configuration, infraName string) (map[st
 }
 
 func (g *osGenerator) generateInstanceInfra(ctx context.Context, opts generateInfraOptions,
-	outputs map[string]string, cmdEnv []string) error {
+	outputs map[string]string, cmdEnv *[]string) error {
 
 	instanceState, err := deployments.GetInstanceState(opts.kv, opts.deploymentID,
 		opts.nodeName, opts.instanceName)
@@ -196,7 +196,7 @@ func (g *osGenerator) generateInstanceInfra(ctx context.Context, opts generateIn
 				instanceName:   opts.instanceName,
 				resourceTypes:  opts.resourceTypes,
 			},
-			outputs, &cmdEnv)
+			outputs, cmdEnv)
 
 	case "yorc.nodes.openstack.BlockStorage":
 		err = g.generateBlockStorageInfra(opts)
@@ -215,7 +215,7 @@ func (g *osGenerator) generateInstanceInfra(ctx context.Context, opts generateIn
 				nodeName:      opts.nodeName,
 				resourceTypes: opts.resourceTypes,
 			},
-			opts.infrastructure, outputs, &cmdEnv)
+			opts.infrastructure, outputs, cmdEnv)
 	default:
 		err = errors.Errorf("Unsupported node type '%s' for node '%s' in deployment '%s'",
 			opts.nodeType, opts.nodeName, opts.deploymentID)

--- a/prov/terraform/openstack/generator.go
+++ b/prov/terraform/openstack/generator.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/consul/api"
 	"github.com/pkg/errors"
 
 	"github.com/ystia/yorc/v4/config"
@@ -60,6 +61,14 @@ func (g *osGenerator) GenerateTerraformInfraForNode(ctx context.Context, cfg con
 		return false, nil, nil, nil, err
 	}
 	kv := cClient.KV()
+
+	return g.generateTerraformInfraForNode(ctx, kv, cfg, deploymentID, nodeName, infrastructurePath)
+}
+
+func (g *osGenerator) generateTerraformInfraForNode(ctx context.Context, kv *api.KV,
+	cfg config.Configuration, deploymentID,
+	nodeName, infrastructurePath string) (bool, map[string]string, []string, commons.PostApplyCallback, error) {
+
 	instancesKey := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology", "instances", nodeName)
 	terraformStateKey := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "terraform-state", nodeName)
 

--- a/prov/terraform/openstack/generator_test.go
+++ b/prov/terraform/openstack/generator_test.go
@@ -142,7 +142,7 @@ func testGenerateTerraformInfo(t *testing.T, srv1 *testutil.TestServer, kv *api.
 	}
 	outputs := make(map[string]string)
 	cmdEnv := make([]string, 0)
-	err = g.generateInstanceInfra(context.Background(), infraOpts, outputs, cmdEnv)
+	err = g.generateInstanceInfra(context.Background(), infraOpts, outputs, &cmdEnv)
 	require.Error(t, err, "Expected to get an error on wrong node type")
 
 	// Case where the floating IP is available as a property

--- a/prov/terraform/openstack/generator_test.go
+++ b/prov/terraform/openstack/generator_test.go
@@ -73,6 +73,7 @@ func testGenerateTerraformInfo(t *testing.T, srv1 *testutil.TestServer, kv *api.
 		path.Join(instancesPrefix, "BlockStorage/0/attributes/volume_id"): []byte("my_vol_id"),
 		path.Join(instancesPrefix, "/FIPCompute/0/capabilities/endpoint",
 			"attributes/floating_ip_address"): []byte("1.2.3.4"),
+		path.Join(instancesPrefix, "/Network_2/0/attributes/network_id"): []byte("netID"),
 	})
 
 	cfg := config.Configuration{
@@ -96,9 +97,9 @@ func testGenerateTerraformInfo(t *testing.T, srv1 *testutil.TestServer, kv *api.
 		path.Join(instancesPrefix, "Compute/0/attributes/public_ip_address"):                "Compute-0-publicIP",
 		path.Join(instancesPrefix, "Compute/0/capabilities/endpoint/attributes/ip_address"): "Compute-0-IPAddress",
 		path.Join(consulutil.DeploymentKVPrefix, depID, "topology/relationship_instances",
-			"BlockStorage/1/0/attributes/device"): "VolBlockStoragetoCompute-0-device",
+			"BlockStorage/2/0/attributes/device"): "VolBlockStoragetoCompute-0-device",
 		path.Join(consulutil.DeploymentKVPrefix, depID, "topology/relationship_instances",
-			"Compute/1/0/attributes/device"): "VolBlockStoragetoCompute-0-device",
+			"Compute/2/0/attributes/device"): "VolBlockStoragetoCompute-0-device",
 	}
 
 	tempdir, err := ioutil.TempDir("", depID)
@@ -112,6 +113,7 @@ func testGenerateTerraformInfo(t *testing.T, srv1 *testutil.TestServer, kv *api.
 		{"Compute", expectedComputeOutputs},
 		{"BlockStorage", map[string]string{}},
 		{"FIPCompute", map[string]string{}},
+		{"Network_2", map[string]string{}},
 	}
 	for _, tt := range testData {
 		res, outputs, _, _, err := g.generateTerraformInfraForNode(
@@ -144,9 +146,10 @@ func testGenerateTerraformInfo(t *testing.T, srv1 *testutil.TestServer, kv *api.
 	require.Error(t, err, "Expected to get an error on wrong node type")
 
 	// Case where the floating IP is available as a property
+	nodePrefix := path.Join(consulutil.DeploymentKVPrefix, depID, "topology/nodes")
+
 	srv1.PopulateKV(t, map[string][]byte{
-		path.Join(consulutil.DeploymentKVPrefix, depID, "topology/nodes",
-			"FIPCompute/0/properties/ip"): []byte("1.2.3.4"),
+		path.Join(nodePrefix, "FIPCompute/properties/ip"): []byte("1.2.3.4"),
 	})
 	_, outputs, _, _, err = g.generateTerraformInfraForNode(
 		context.Background(), kv, cfg, depID, "FIPCompute", tempdir)

--- a/prov/terraform/openstack/generator_test.go
+++ b/prov/terraform/openstack/generator_test.go
@@ -15,11 +15,22 @@
 package openstack
 
 import (
+	"context"
 	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path"
 	"testing"
 
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/testutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ystia/yorc/v4/config"
+	"github.com/ystia/yorc/v4/deployments"
+	"github.com/ystia/yorc/v4/helper/consulutil"
+	"github.com/ystia/yorc/v4/log"
 	"github.com/ystia/yorc/v4/prov/terraform/commons"
 )
 
@@ -44,4 +55,73 @@ func Test_addOutput(t *testing.T) {
 			require.Equal(t, tt.jsonResult, string(res))
 		})
 	}
+}
+
+func testGenerateTerraformInfo(t *testing.T, srv1 *testutil.TestServer, kv *api.KV) {
+	t.Parallel()
+	log.SetDebug(true)
+
+	depID := path.Base(t.Name())
+	yamlName := "testdata/topology_test.yaml"
+	err := deployments.StoreDeploymentDefinition(context.Background(), kv, depID, yamlName)
+	require.Nil(t, err, "Failed to parse "+yamlName+" definition")
+
+	// Simulate the persistent disk "volume_id" attribute registration
+	instancesPrefix := path.Join(consulutil.DeploymentKVPrefix,
+		depID, "topology/instances")
+	srv1.PopulateKV(t, map[string][]byte{
+		path.Join(instancesPrefix, "BlockStorage/0/attributes/volume_id"): []byte("my_vol_id"),
+		path.Join(instancesPrefix, "/FIPCompute/0/capabilities/endpoint",
+			"attributes/floating_ip_address"): []byte("1.2.3.4"),
+	})
+
+	cfg := config.Configuration{
+		Infrastructures: map[string]config.DynamicMap{
+			infrastructureName: config.DynamicMap{
+				"auth_url":                "http://1.2.3.4:5000/v2.0",
+				"default_security_groups": []string{"default", "sec2"},
+				"password":                "test",
+				"private_network_name":    "private-net",
+				"region":                  "RegionOne",
+				"tenant_name":             "test",
+				"user_name":               "test",
+			}}}
+	g := osGenerator{}
+
+	expectedComputeOutputs := map[string]string{
+		path.Join(instancesPrefix, "BlockStorage/0/attributes/device"):                      "VolBlockStoragetoCompute-0-device",
+		path.Join(instancesPrefix, "Compute/0/attributes/ip_address"):                       "Compute-0-IPAddress",
+		path.Join(instancesPrefix, "Compute/0/attributes/private_address"):                  "Compute-0-privateIP",
+		path.Join(instancesPrefix, "Compute/0/attributes/public_address"):                   "Compute-0-publicIP",
+		path.Join(instancesPrefix, "Compute/0/attributes/public_ip_address"):                "Compute-0-publicIP",
+		path.Join(instancesPrefix, "Compute/0/capabilities/endpoint/attributes/ip_address"): "Compute-0-IPAddress",
+		path.Join(consulutil.DeploymentKVPrefix, depID, "topology/relationship_instances",
+			"BlockStorage/1/0/attributes/device"): "VolBlockStoragetoCompute-0-device",
+		path.Join(consulutil.DeploymentKVPrefix, depID, "topology/relationship_instances",
+			"Compute/1/0/attributes/device"): "VolBlockStoragetoCompute-0-device",
+	}
+
+	tempdir, err := ioutil.TempDir("", depID)
+	require.NoError(t, err, "Failed to to create temporary directory")
+	defer os.RemoveAll(tempdir)
+
+	var testData = []struct {
+		nodeName        string
+		expectedOutputs map[string]string
+	}{
+		{"Compute", expectedComputeOutputs},
+		{"BlockStorage", map[string]string{}},
+		{"FIPCompute", map[string]string{}},
+	}
+	for _, tt := range testData {
+		res, outputs, _, _, err := g.generateTerraformInfraForNode(
+			context.Background(), kv, cfg, depID, tt.nodeName, tempdir)
+		require.NoError(t, err, "Unexpected error generating %s terraform info", tt.nodeName)
+		assert.Equal(t, true, res, "Unexpect result for node name %s", tt.nodeName)
+
+		for k, v := range tt.expectedOutputs {
+			assert.Equal(t, v, outputs[k], "Unexpected output")
+		}
+	}
+
 }

--- a/prov/terraform/openstack/network.go
+++ b/prov/terraform/openstack/network.go
@@ -63,59 +63,53 @@ func (g *osGenerator) generateSubnet(kv *api.KV, cfg config.Configuration, deplo
 
 	subnet := Subnet{}
 
-	netName, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "network_name")
+	subnet.Name, err = getSubnetName(kv, cfg, deploymentID, nodeName)
 	if err != nil {
 		return Subnet{}, err
-	} else if netName != nil && netName.RawString() != "" {
-		subnet.Name = cfg.ResourcesPrefix + netName.RawString() + "_subnet"
-	} else {
-		subnet.Name = cfg.ResourcesPrefix + nodeName + "_subnet"
 	}
-	ipVersion, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "ip_version")
+
+	subnet.IPVersion, err = getSubnetIPVersion(kv, cfg, deploymentID, nodeName)
 	if err != nil {
 		return Subnet{}, err
-	} else if ipVersion != nil && ipVersion.RawString() != "" {
-		subnet.IPVersion, err = strconv.Atoi(ipVersion.RawString())
+	}
+
+	subnet.NetworkID, err = getSubnetNetworkID(kv, cfg, deploymentID, nodeName, resourceType)
+	if err != nil {
+		return Subnet{}, err
+	}
+
+	subnet.CIDR, err = getSubnetProperty(kv, cfg, deploymentID, nodeName, "cidr")
+	if err != nil {
+		return Subnet{}, err
+	}
+
+	subnet.GatewayIP, err = getSubnetProperty(kv, cfg, deploymentID, nodeName, "gateway_ip")
+	if err != nil {
+		return Subnet{}, err
+	}
+
+	startIP, err := getSubnetProperty(kv, cfg, deploymentID, nodeName, "start_ip")
+	if err != nil {
+		return Subnet{}, err
+	}
+	if startIP != "" {
+		endIP, err := getSubnetProperty(kv, cfg, deploymentID, nodeName, "end_ip")
 		if err != nil {
 			return Subnet{}, err
 		}
-	} else {
-		subnet.IPVersion = 4
-	}
-	nodeID, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "network_id")
-	if err != nil {
-		return Subnet{}, err
-	} else if nodeID != nil && nodeID.RawString() != "" {
-		subnet.NetworkID = nodeID.RawString()
-	} else {
-		subnet.NetworkID = fmt.Sprintf("${%s.%s.id}", resourceType, nodeName)
-	}
-	if nodeCIDR, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "cidr"); err != nil {
-		return Subnet{}, err
-	} else if nodeCIDR != nil && nodeCIDR.RawString() != "" {
-		subnet.CIDR = nodeCIDR.RawString()
-	}
-	if gatewayIP, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "gateway_ip"); err != nil {
-		return Subnet{}, err
-	} else if gatewayIP != nil && gatewayIP.RawString() != "" {
-		subnet.GatewayIP = gatewayIP.RawString()
-	}
-	if startIP, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "start_ip"); err != nil {
-		return Subnet{}, err
-	} else if startIP != nil && startIP.RawString() != "" {
-		endIP, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "end_ip")
-		if err != nil {
-			return Subnet{}, err
-		}
-		if endIP == nil || endIP.RawString() == "" {
+		if endIP == "" {
 			return Subnet{}, errors.Errorf("A start_ip and a end_ip need to be provided")
 		}
-		subnet.AllocationPools = &AllocationPool{Start: startIP.RawString(), End: endIP.RawString()}
+		subnet.AllocationPools = &AllocationPool{Start: startIP, End: endIP}
 	}
-	if dhcp, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "dhcp_enabled"); err != nil {
+
+	dhcpVal, err := getSubnetProperty(kv, cfg, deploymentID, nodeName, "dhcp_enabled")
+	if err != nil {
 		return Subnet{}, err
-	} else if dhcp != nil && dhcp.RawString() != "" {
-		subnet.EnableDHCP, err = strconv.ParseBool(dhcp.RawString())
+	}
+	if dhcpVal != "" {
+
+		subnet.EnableDHCP, err = strconv.ParseBool(dhcpVal)
 		if err != nil {
 			return Subnet{}, err
 		}
@@ -126,4 +120,64 @@ func (g *osGenerator) generateSubnet(kv *api.KV, cfg config.Configuration, deplo
 	subnet.Region = cfg.Infrastructures[infrastructureName].GetStringOrDefault("region", defaultOSRegion)
 
 	return subnet, nil
+}
+
+func getSubnetName(kv *api.KV, cfg config.Configuration, deploymentID, nodeName string) (string, error) {
+
+	var subnetName string
+	netName, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "network_name")
+	if err != nil {
+		return "", err
+	}
+	if netName != nil && netName.RawString() != "" {
+		subnetName = cfg.ResourcesPrefix + netName.RawString() + "_subnet"
+	} else {
+		subnetName = cfg.ResourcesPrefix + nodeName + "_subnet"
+	}
+	return subnetName, err
+}
+
+func getSubnetIPVersion(kv *api.KV, cfg config.Configuration, deploymentID, nodeName string) (int, error) {
+
+	ipVersion := 4
+	ipVersionProp, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "ip_version")
+	if err != nil {
+		return ipVersion, err
+	}
+	if ipVersionProp != nil && ipVersionProp.RawString() != "" {
+		ipVersion, err = strconv.Atoi(ipVersionProp.RawString())
+	}
+
+	return ipVersion, err
+}
+
+func getSubnetNetworkID(kv *api.KV, cfg config.Configuration, deploymentID,
+	nodeName, resourceType string) (string, error) {
+
+	var networkID string
+	nodeID, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "network_id")
+	if err != nil {
+		return networkID, err
+	}
+	if nodeID != nil && nodeID.RawString() != "" {
+		networkID = nodeID.RawString()
+	} else {
+		networkID = fmt.Sprintf("${%s.%s.id}", resourceType, nodeName)
+	}
+	return networkID, err
+}
+
+func getSubnetProperty(kv *api.KV, cfg config.Configuration, deploymentID,
+	nodeName, propertyName string) (string, error) {
+
+	var stringValue string
+	propValue, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, propertyName)
+	if err != nil {
+		return stringValue, err
+	}
+	if propValue != nil && propValue.RawString() != "" {
+		stringValue = propValue.RawString()
+	}
+
+	return stringValue, err
 }

--- a/prov/terraform/openstack/network.go
+++ b/prov/terraform/openstack/network.go
@@ -78,22 +78,22 @@ func (g *osGenerator) generateSubnet(kv *api.KV, cfg config.Configuration, deplo
 		return Subnet{}, err
 	}
 
-	subnet.CIDR, err = getSubnetProperty(kv, deploymentID, nodeName, "cidr")
+	subnet.CIDR, err = getProperyValueString(kv, deploymentID, nodeName, "cidr")
 	if err != nil {
 		return Subnet{}, err
 	}
 
-	subnet.GatewayIP, err = getSubnetProperty(kv, deploymentID, nodeName, "gateway_ip")
+	subnet.GatewayIP, err = getProperyValueString(kv, deploymentID, nodeName, "gateway_ip")
 	if err != nil {
 		return Subnet{}, err
 	}
 
-	startIP, err := getSubnetProperty(kv, deploymentID, nodeName, "start_ip")
+	startIP, err := getProperyValueString(kv, deploymentID, nodeName, "start_ip")
 	if err != nil {
 		return Subnet{}, err
 	}
 	if startIP != "" {
-		endIP, err := getSubnetProperty(kv, deploymentID, nodeName, "end_ip")
+		endIP, err := getProperyValueString(kv, deploymentID, nodeName, "end_ip")
 		if err != nil {
 			return Subnet{}, err
 		}
@@ -157,24 +157,10 @@ func getSubnetNetworkID(kv *api.KV, deploymentID, nodeName, resourceType string)
 	return networkID, err
 }
 
-func getSubnetProperty(kv *api.KV, deploymentID, nodeName, propertyName string) (string, error) {
-
-	var stringValue string
-	propValue, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, propertyName)
-	if err != nil {
-		return stringValue, err
-	}
-	if propValue != nil && propValue.RawString() != "" {
-		stringValue = propValue.RawString()
-	}
-
-	return stringValue, err
-}
-
 func isDHCPEnabled(kv *api.KV, deploymentID, nodeName string) (bool, error) {
 
 	dhcpEnabled := true
-	dhcpVal, err := getSubnetProperty(kv, deploymentID, nodeName, "dhcp_enabled")
+	dhcpVal, err := getProperyValueString(kv, deploymentID, nodeName, "dhcp_enabled")
 	if err != nil {
 		return dhcpEnabled, err
 	}

--- a/prov/terraform/openstack/network.go
+++ b/prov/terraform/openstack/network.go
@@ -15,6 +15,7 @@
 package openstack
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/hashicorp/consul/api"
@@ -49,7 +50,9 @@ func (g *osGenerator) generateNetwork(kv *api.KV, cfg config.Configuration, depl
 
 }
 
-func (g *osGenerator) generateSubnet(kv *api.KV, cfg config.Configuration, deploymentID, nodeName string) (Subnet, error) {
+func (g *osGenerator) generateSubnet(kv *api.KV, cfg config.Configuration, deploymentID,
+	nodeName, resourceType string) (Subnet, error) {
+
 	nodeType, err := deployments.GetNodeType(kv, deploymentID, nodeName)
 	if err != nil {
 		return Subnet{}, err
@@ -85,7 +88,7 @@ func (g *osGenerator) generateSubnet(kv *api.KV, cfg config.Configuration, deplo
 	} else if nodeID != nil && nodeID.RawString() != "" {
 		subnet.NetworkID = nodeID.RawString()
 	} else {
-		subnet.NetworkID = "${openstack_networking_network_v2." + nodeName + ".id}"
+		subnet.NetworkID = fmt.Sprintf("${%s.%s.id}", resourceType, nodeName)
 	}
 	if nodeCIDR, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "cidr"); err != nil {
 		return Subnet{}, err

--- a/prov/terraform/openstack/network.go
+++ b/prov/terraform/openstack/network.go
@@ -78,22 +78,26 @@ func (g *osGenerator) generateSubnet(kv *api.KV, cfg config.Configuration, deplo
 		return Subnet{}, err
 	}
 
-	subnet.CIDR, err = getProperyValueString(kv, deploymentID, nodeName, "cidr")
+	subnet.CIDR, err = deployments.GetStringNodeProperty(kv, deploymentID, nodeName,
+		"cidr", false)
 	if err != nil {
 		return Subnet{}, err
 	}
 
-	subnet.GatewayIP, err = getProperyValueString(kv, deploymentID, nodeName, "gateway_ip")
+	subnet.GatewayIP, err = deployments.GetStringNodeProperty(kv, deploymentID, nodeName,
+		"gateway_ip", false)
 	if err != nil {
 		return Subnet{}, err
 	}
 
-	startIP, err := getProperyValueString(kv, deploymentID, nodeName, "start_ip")
+	startIP, err := deployments.GetStringNodeProperty(kv, deploymentID, nodeName,
+		"start_ip", false)
 	if err != nil {
 		return Subnet{}, err
 	}
 	if startIP != "" {
-		endIP, err := getProperyValueString(kv, deploymentID, nodeName, "end_ip")
+		endIP, err := deployments.GetStringNodeProperty(kv, deploymentID, nodeName,
+			"end_ip", false)
 		if err != nil {
 			return Subnet{}, err
 		}
@@ -160,7 +164,8 @@ func getSubnetNetworkID(kv *api.KV, deploymentID, nodeName, resourceType string)
 func isDHCPEnabled(kv *api.KV, deploymentID, nodeName string) (bool, error) {
 
 	dhcpEnabled := true
-	dhcpVal, err := getProperyValueString(kv, deploymentID, nodeName, "dhcp_enabled")
+	dhcpVal, err := deployments.GetStringNodeProperty(kv, deploymentID, nodeName,
+		"dhcp_enabled", false)
 	if err != nil {
 		return dhcpEnabled, err
 	}

--- a/prov/terraform/openstack/osinstance.go
+++ b/prov/terraform/openstack/osinstance.go
@@ -32,6 +32,10 @@ import (
 	"github.com/ystia/yorc/v4/prov/terraform/commons"
 )
 
+const (
+	topologyTree = "topology"
+)
+
 type osInstanceOptions struct {
 	kv            *api.KV
 	cfg           config.Configuration
@@ -55,7 +59,7 @@ func (g *osGenerator) generateOSInstance(ctx context.Context, opts osInstanceOpt
 		return errors.Errorf("Unsupported node type for %q: %s", nodeName, nodeType)
 	}
 	instance := ComputeInstance{}
-	instancesPrefix := path.Join(consulutil.DeploymentKVPrefix, opts.deploymentID, "topology", "instances")
+	instancesPrefix := path.Join(consulutil.DeploymentKVPrefix, opts.deploymentID, topologyTree, "instances")
 	instancesKey := path.Join(instancesPrefix, nodeName)
 
 	instance.Name = cfg.ResourcesPrefix + nodeName + "-" + instanceName
@@ -238,8 +242,8 @@ func (g *osGenerator) generateOSInstance(ctx context.Context, opts osInstanceOpt
 				Value: fmt.Sprintf("${%s.%s.device}",
 					opts.resourceTypes[computeVolumeAttach], attachName)})
 			outputs[path.Join(instancesPrefix, volumeNodeName, instanceName, "attributes/device")] = key1
-			outputs[path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology", "relationship_instances", nodeName, requirementIndex, instanceName, "attributes/device")] = key1
-			outputs[path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology", "relationship_instances", volumeNodeName, requirementIndex, instanceName, "attributes/device")] = key1
+			outputs[path.Join(consulutil.DeploymentKVPrefix, deploymentID, topologyTree, "relationship_instances", nodeName, requirementIndex, instanceName, "attributes/device")] = key1
+			outputs[path.Join(consulutil.DeploymentKVPrefix, deploymentID, topologyTree, "relationship_instances", volumeNodeName, requirementIndex, instanceName, "attributes/device")] = key1
 		}
 	}
 

--- a/prov/terraform/openstack/osinstance.go
+++ b/prov/terraform/openstack/osinstance.go
@@ -143,11 +143,13 @@ func generateComputeInstance(opts osInstanceOptions) (ComputeInstance, error) {
 		return instance, err
 	}
 
-	instance.AvailabilityZone, err = getProperyValueString(kv, deploymentID, nodeName, "availability_zone")
+	instance.AvailabilityZone, err = deployments.GetStringNodeProperty(kv, deploymentID,
+		nodeName, "availability_zone", false)
 	if err != nil {
 		return instance, err
 	}
-	instance.Region, err = getProperyValueString(kv, deploymentID, nodeName, "region")
+	instance.Region, err = deployments.GetStringNodeProperty(kv, deploymentID, nodeName,
+		"region", false)
 	if err != nil {
 		return instance, err
 	}
@@ -155,13 +157,15 @@ func generateComputeInstance(opts osInstanceOptions) (ComputeInstance, error) {
 		instance.Region = cfg.Infrastructures[infrastructureName].GetStringOrDefault("region", defaultOSRegion)
 	}
 
-	instance.KeyPair, err = getProperyValueString(kv, deploymentID, nodeName, "key_pair")
+	instance.KeyPair, err = deployments.GetStringNodeProperty(kv, deploymentID, nodeName,
+		"key_pair", false)
 	if err != nil {
 		return instance, err
 	}
 
 	instance.SecurityGroups = cfg.Infrastructures[infrastructureName].GetStringSlice("default_security_groups")
-	secGroups, err := getProperyValueString(kv, deploymentID, nodeName, "security_groups")
+	secGroups, err := deployments.GetStringNodeProperty(kv, deploymentID, nodeName,
+		"security_groups", false)
 	if err != nil {
 		return instance, err
 	}
@@ -179,11 +183,11 @@ func computeInstanceMandatoryAttributeInPair(kv *api.KV, deploymentID, nodeName,
 	attr1, attr2 string) (string, string, error) {
 	var err error
 	var value1, value2 string
-	value1, err = getProperyValueString(kv, deploymentID, nodeName, attr1)
+	value1, err = deployments.GetStringNodeProperty(kv, deploymentID, nodeName, attr1, false)
 	if err != nil {
 		return value1, value2, err
 	}
-	value2, err = getProperyValueString(kv, deploymentID, nodeName, attr2)
+	value2, err = deployments.GetStringNodeProperty(kv, deploymentID, nodeName, attr2, false)
 	if err != nil {
 		return value1, value2, err
 	}
@@ -551,18 +555,4 @@ func computeNetworkAttributes(ctx context.Context, opts osInstanceOptions,
 	outputs[path.Join(prefix, "network_id")] = networkIDKey
 	outputs[path.Join(prefix, "addresses")] = networkAddressesKey
 	return nil
-}
-
-func getProperyValueString(kv *api.KV, deploymentID, nodeName, propertyName string) (string, error) {
-
-	var stringValue string
-	propValue, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, propertyName)
-	if err != nil {
-		return stringValue, err
-	}
-	if propValue != nil {
-		stringValue = propValue.RawString()
-	}
-
-	return stringValue, err
 }

--- a/prov/terraform/openstack/osinstance.go
+++ b/prov/terraform/openstack/osinstance.go
@@ -378,17 +378,14 @@ func computeConnectionSettings(ctx context.Context, opts osInstanceOptions,
 
 		if isFip {
 			fipAssociateName = "FIP" + instance.Name
-
 			err = computeFloatingIPAddress(ctx, opts, fipAssociateName, networkNodeName,
 				instancesKey, instance, outputs)
-			if err != nil {
-				return err
-			}
 		} else {
 			err = computeNetworkAttributes(ctx, opts, networkNodeName, instancesKey, instance, outputs)
-			if err != nil {
-				return err
-			}
+
+		}
+		if err != nil {
+			return err
 		}
 	}
 

--- a/prov/terraform/openstack/osinstance.go
+++ b/prov/terraform/openstack/osinstance.go
@@ -148,8 +148,7 @@ func generateComputeInstance(opts osInstanceOptions) (ComputeInstance, error) {
 	if err != nil {
 		return instance, err
 	}
-	instance.Region, err = deployments.GetStringNodeProperty(kv, deploymentID, nodeName,
-		"region", false)
+	instance.Region, err = deployments.GetStringNodeProperty(kv, deploymentID, nodeName, "region", false)
 	if err != nil {
 		return instance, err
 	}
@@ -157,15 +156,13 @@ func generateComputeInstance(opts osInstanceOptions) (ComputeInstance, error) {
 		instance.Region = cfg.Infrastructures[infrastructureName].GetStringOrDefault("region", defaultOSRegion)
 	}
 
-	instance.KeyPair, err = deployments.GetStringNodeProperty(kv, deploymentID, nodeName,
-		"key_pair", false)
+	instance.KeyPair, err = deployments.GetStringNodeProperty(kv, deploymentID, nodeName, "key_pair", false)
 	if err != nil {
 		return instance, err
 	}
 
 	instance.SecurityGroups = cfg.Infrastructures[infrastructureName].GetStringSlice("default_security_groups")
-	secGroups, err := deployments.GetStringNodeProperty(kv, deploymentID, nodeName,
-		"security_groups", false)
+	secGroups, err := deployments.GetStringNodeProperty(kv, deploymentID, nodeName, "security_groups", false)
 	if err != nil {
 		return instance, err
 	}

--- a/prov/terraform/openstack/osinstance_test.go
+++ b/prov/terraform/openstack/osinstance_test.go
@@ -58,14 +58,15 @@ func testSimpleOSInstance(t *testing.T, kv *api.KV) {
 	err := g.generateOSInstance(
 		context.Background(),
 		osInstanceOptions{
-			kv:            kv,
-			cfg:           cfg,
-			deploymentID:  deploymentID,
-			nodeName:      "Compute",
-			instanceName:  "0",
-			resourceTypes: resourceTypes,
+			kv:             kv,
+			cfg:            cfg,
+			infrastructure: &infrastructure,
+			deploymentID:   deploymentID,
+			nodeName:       "Compute",
+			instanceName:   "0",
+			resourceTypes:  resourceTypes,
 		},
-		&infrastructure, outputs, &env)
+		outputs, &env)
 	require.Nil(t, err)
 
 	require.Len(t, infrastructure.Resource["openstack_compute_instance_v2"], 1)
@@ -132,14 +133,15 @@ func testFipOSInstance(t *testing.T, kv *api.KV, srv *testutil.TestServer) {
 	err := g.generateOSInstance(
 		context.Background(),
 		osInstanceOptions{
-			kv:            kv,
-			cfg:           cfg,
-			deploymentID:  deploymentID,
-			nodeName:      "Compute",
-			instanceName:  "0",
-			resourceTypes: resourceTypes,
+			kv:             kv,
+			cfg:            cfg,
+			infrastructure: &infrastructure,
+			deploymentID:   deploymentID,
+			nodeName:       "Compute",
+			instanceName:   "0",
+			resourceTypes:  resourceTypes,
 		},
-		&infrastructure, outputs, &env)
+		outputs, &env)
 	require.Nil(t, err)
 
 	require.Len(t, infrastructure.Resource["openstack_compute_instance_v2"], 1)
@@ -211,14 +213,15 @@ func testFipOSInstanceNotAllowed(t *testing.T, kv *api.KV, srv *testutil.TestSer
 	err := g.generateOSInstance(
 		context.Background(),
 		osInstanceOptions{
-			kv:            kv,
-			cfg:           cfg,
-			deploymentID:  deploymentID,
-			nodeName:      "Compute",
-			instanceName:  "0",
-			resourceTypes: resourceTypes,
+			kv:             kv,
+			cfg:            cfg,
+			infrastructure: &infrastructure,
+			deploymentID:   deploymentID,
+			nodeName:       "Compute",
+			instanceName:   "0",
+			resourceTypes:  resourceTypes,
 		},
-		&infrastructure, make(map[string]string), &env)
+		make(map[string]string), &env)
 	require.Nil(t, err)
 
 	require.Len(t, infrastructure.Resource["openstack_compute_instance_v2"], 1)
@@ -286,14 +289,15 @@ func testOSInstanceWithServerGroup(t *testing.T, kv *api.KV, srv *testutil.TestS
 	err := g.generateOSInstance(
 		context.Background(),
 		osInstanceOptions{
-			kv:            kv,
-			cfg:           cfg,
-			deploymentID:  deploymentID,
-			nodeName:      "ComputeA",
-			instanceName:  "0",
-			resourceTypes: resourceTypes,
+			kv:             kv,
+			cfg:            cfg,
+			infrastructure: &infrastructure,
+			deploymentID:   deploymentID,
+			nodeName:       "ComputeA",
+			instanceName:   "0",
+			resourceTypes:  resourceTypes,
 		},
-		&infrastructure, outputs, &env)
+		outputs, &env)
 	require.Nil(t, err)
 
 	require.Len(t, infrastructure.Resource["openstack_compute_instance_v2"], 1)

--- a/prov/terraform/openstack/osinstance_test.go
+++ b/prov/terraform/openstack/osinstance_test.go
@@ -54,7 +54,18 @@ func testSimpleOSInstance(t *testing.T, kv *api.KV) {
 	env := make([]string, 0)
 	outputs := make(map[string]string, 0)
 
-	err := g.generateOSInstance(context.Background(), kv, cfg, deploymentID, "Compute", "0", &infrastructure, outputs, &env)
+	resourceTypes := getOpenstackResourceTypes(cfg, infrastructureName)
+	err := g.generateOSInstance(
+		context.Background(),
+		osInstanceOptions{
+			kv:            kv,
+			cfg:           cfg,
+			deploymentID:  deploymentID,
+			nodeName:      "Compute",
+			instanceName:  "0",
+			resourceTypes: resourceTypes,
+		},
+		&infrastructure, outputs, &env)
 	require.Nil(t, err)
 
 	require.Len(t, infrastructure.Resource["openstack_compute_instance_v2"], 1)
@@ -117,7 +128,18 @@ func testFipOSInstance(t *testing.T, kv *api.KV, srv *testutil.TestServer) {
 	infrastructure := commons.Infrastructure{}
 	env := make([]string, 0)
 	outputs := make(map[string]string, 0)
-	err := g.generateOSInstance(context.Background(), kv, cfg, deploymentID, "Compute", "0", &infrastructure, outputs, &env)
+	resourceTypes := getOpenstackResourceTypes(cfg, infrastructureName)
+	err := g.generateOSInstance(
+		context.Background(),
+		osInstanceOptions{
+			kv:            kv,
+			cfg:           cfg,
+			deploymentID:  deploymentID,
+			nodeName:      "Compute",
+			instanceName:  "0",
+			resourceTypes: resourceTypes,
+		},
+		&infrastructure, outputs, &env)
 	require.Nil(t, err)
 
 	require.Len(t, infrastructure.Resource["openstack_compute_instance_v2"], 1)
@@ -185,7 +207,18 @@ func testFipOSInstanceNotAllowed(t *testing.T, kv *api.KV, srv *testutil.TestSer
 	infrastructure := commons.Infrastructure{}
 	env := make([]string, 0)
 
-	err := g.generateOSInstance(context.Background(), kv, cfg, deploymentID, "Compute", "0", &infrastructure, make(map[string]string), &env)
+	resourceTypes := getOpenstackResourceTypes(cfg, infrastructureName)
+	err := g.generateOSInstance(
+		context.Background(),
+		osInstanceOptions{
+			kv:            kv,
+			cfg:           cfg,
+			deploymentID:  deploymentID,
+			nodeName:      "Compute",
+			instanceName:  "0",
+			resourceTypes: resourceTypes,
+		},
+		&infrastructure, make(map[string]string), &env)
 	require.Nil(t, err)
 
 	require.Len(t, infrastructure.Resource["openstack_compute_instance_v2"], 1)
@@ -249,7 +282,18 @@ func testOSInstanceWithServerGroup(t *testing.T, kv *api.KV, srv *testutil.TestS
 		path.Join(consulutil.DeploymentKVPrefix, deploymentID+"/topology/instances/ServerGroupPolicy_sg/0/attributes/id"): []byte("my_sg_id"),
 	})
 
-	err := g.generateOSInstance(context.Background(), kv, cfg, deploymentID, "ComputeA", "0", &infrastructure, outputs, &env)
+	resourceTypes := getOpenstackResourceTypes(cfg, infrastructureName)
+	err := g.generateOSInstance(
+		context.Background(),
+		osInstanceOptions{
+			kv:            kv,
+			cfg:           cfg,
+			deploymentID:  deploymentID,
+			nodeName:      "ComputeA",
+			instanceName:  "0",
+			resourceTypes: resourceTypes,
+		},
+		&infrastructure, outputs, &env)
 	require.Nil(t, err)
 
 	require.Len(t, infrastructure.Resource["openstack_compute_instance_v2"], 1)

--- a/prov/terraform/openstack/osinstance_test.go
+++ b/prov/terraform/openstack/osinstance_test.go
@@ -312,3 +312,44 @@ func testOSInstanceWithServerGroup(t *testing.T, kv *api.KV, srv *testutil.TestS
 	require.Equal(t, "4", compute.FlavorID)
 	require.Equal(t, "my_sg_id", compute.SchedulerHints.Group)
 }
+
+func testComputeNetworkAttributes(t *testing.T, kv *api.KV, srv *testutil.TestServer) {
+	t.Parallel()
+	deploymentID := loadTestYaml(t, kv)
+
+	cfg := config.Configuration{
+		Infrastructures: map[string]config.DynamicMap{
+			infrastructureName: config.DynamicMap{
+				"provisioning_over_fip_allowed": false,
+				"private_network_name":          "test",
+			}}}
+	infrastructure := commons.Infrastructure{}
+	outputs := make(map[string]string, 0)
+	resourceTypes := getOpenstackResourceTypes(cfg, infrastructureName)
+	opts := osInstanceOptions{
+		kv:             kv,
+		cfg:            cfg,
+		infrastructure: &infrastructure,
+		deploymentID:   deploymentID,
+		nodeName:       "ComputeA",
+		instanceName:   "0",
+		resourceTypes:  resourceTypes,
+	}
+
+	networkNodeName := "Network"
+	networkID := "netID"
+	instKey := "instKey"
+	srv.PopulateKV(t, map[string][]byte{
+		path.Join(consulutil.DeploymentKVPrefix, deploymentID,
+			"/topology/instances", networkNodeName, opts.instanceName, "attributes", "network_id"): []byte(networkID),
+	})
+
+	instance := ComputeInstance{
+		Name: "instanceName",
+	}
+	err := computeNetworkAttributes(context.Background(), opts, networkNodeName, instKey,
+		&instance, outputs)
+	require.NoError(t, err, "Failed to compute network attributes")
+	require.Equal(t, 1, len(instance.Networks), "Expected to have one compute instance network")
+	assert.Equal(t, networkID, instance.Networks[0].UUID, "Wrong network ID")
+}

--- a/prov/terraform/openstack/resource_types.go
+++ b/prov/terraform/openstack/resource_types.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ func getBlockStorageAPIVersion(cfg config.Configuration, infrastructureName stri
 	// However for tests purposes, it is possible to use obsolete OpenStack
 	// versions providing only block storage API version v1.
 	// A basic check is performed here to detect if we are on an obsolete
-	// OpenStack version: 
+	// OpenStack version:
 	// If the User Domain mandatory property required by the Identity v3 API is not set,
 	// then considering we are on an obsolete version of OpenStack providing
 	// only block storage v1 API.

--- a/prov/terraform/openstack/resource_types.go
+++ b/prov/terraform/openstack/resource_types.go
@@ -1,0 +1,93 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openstack
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ystia/yorc/v4/config"
+	"github.com/ystia/yorc/v4/log"
+)
+
+// Openstack resources that can be created on demand
+const (
+	blockStorageVolume         = "blockstorage_volume"
+	computeInstance            = "compute_instance"
+	computeFloatingIP          = "compute_floatingip"
+	computeFloatingIPAssociate = "compute_floatingip_associate"
+	computeServerGroup         = "compute_servergroup"
+	computeVolumeAttach        = "compute_volume_attach"
+	networkingNetwork          = "networking_network"
+	networkingSubnet           = "networking_subnet"
+	resourceTypeFormat         = "openstack_%s_%s"
+	version2                   = "v2"
+	latestBlockStorageVersion  = "v3"
+	userDomainProperty         = "user_domain_name"
+	userDomainEnvVar           = "OS_USER_DOMAIN_NAME"
+)
+
+// getOpenstackResourceTypes returns resource types supported by a given
+// OpenStack infrastructure, for each resource that can be created on demand
+// by the orchestrator
+func getOpenstackResourceTypes(cfg config.Configuration, infrastructureName string) map[string]string {
+
+	resourceTypes := make(map[string]string)
+
+	// Resources for which there is just one possible version supported
+	v2Resources := []string{
+		computeInstance, computeFloatingIP, computeFloatingIPAssociate, computeServerGroup,
+		computeVolumeAttach, networkingNetwork, networkingSubnet,
+	}
+
+	for _, resource := range v2Resources {
+		resourceTypes[resource] = fmt.Sprintf(resourceTypeFormat, resource, version2)
+	}
+
+	// Resources for which the version supported depends on the
+	// openstack version installed on the selected infrastructure
+	resourceTypes[blockStorageVolume] = fmt.Sprintf(resourceTypeFormat, blockStorageVolume,
+		getBlockStorageAPIVersion(cfg, infrastructureName))
+
+	return resourceTypes
+}
+
+// getBlockStorageAPIVersion returns the latest version supported on a given
+// OpenStack infrastructure
+func getBlockStorageAPIVersion(cfg config.Configuration, infrastructureName string) string {
+
+	version := latestBlockStorageVersion
+
+	// The supported block storage API version is v3.
+	// However for tests purposes, it is possible to use obsolete OpenStack
+	// versions providing only block storage API version v1.
+	// A basic check is performed here to detect if we are on an obsolete
+	// OpenStack version: 
+	// If the User Domain mandatory property required by the Identity v3 API is not set,
+	// then considering we are on an obsolete version of OpenStack providing
+	// only block storage v1 API.
+	// While on a supported OpenStack version, the user domain should be specified,
+	// in which case, we can rely on the supported block storage v3 API
+	infra := cfg.Infrastructures[infrastructureName]
+	if infra.GetString(userDomainProperty) == "" && os.Getenv(userDomainProperty) == "" {
+
+		version = "v1"
+		log.Printf("No OpenStack user domain specified in infrastructure %s => using obsolete Block Storage API %s",
+			infrastructureName, version)
+	}
+
+	return version
+
+}

--- a/prov/terraform/openstack/resource_types_test.go
+++ b/prov/terraform/openstack/resource_types_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/prov/terraform/openstack/resource_types_test.go
+++ b/prov/terraform/openstack/resource_types_test.go
@@ -1,0 +1,66 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openstack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/ystia/yorc/v4/config"
+)
+
+func Test_resourceTypes(t *testing.T) {
+
+	cfg := config.Configuration{
+		Infrastructures: map[string]config.DynamicMap{
+			"oldOpenStack": config.DynamicMap{
+				"auth_url":                "http://1.2.3.4:5000/v2.0",
+				"default_security_groups": []string{"sec1", "sec2"},
+				"user_name":               "user1",
+				"password":                "password1",
+				"tenant_name":             "tenant1",
+				"private_network_name":    "private-net",
+				"region":                  "RegionOne",
+			},
+			"newOpenStack": config.DynamicMap{
+				"auth_url":                "http://1.2.3.4:5000/v3",
+				"default_security_groups": []string{"sec1", "sec2"},
+				"user_name":               "user1",
+				"password":                "password1",
+				"user_domain_name":        "domain1",
+				"project_name":            "project1",
+				"private_network_name":    "private-net",
+				"region":                  "RegionOne",
+			},
+		},
+	}
+
+	tests := []struct {
+		name             string
+		infra            string
+		volumeTypeResult string
+	}{
+		{"testOldOpenStack", "oldOpenStack", "openstack_blockstorage_volume_v1"},
+		{"testNewOpenStack", "newOpenStack", "openstack_blockstorage_volume_v3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			resourceTypes := getOpenstackResourceTypes(cfg, tt.infra)
+			assert.Equal(t, tt.volumeTypeResult, resourceTypes[blockStorageVolume],
+				"Unexpected resource type on infra %s", tt.infra)
+		})
+	}
+}

--- a/prov/terraform/openstack/server_group_test.go
+++ b/prov/terraform/openstack/server_group_test.go
@@ -33,7 +33,16 @@ func testSimpleServerGroup(t *testing.T, kv *api.KV) {
 	g := osGenerator{}
 	cfg := config.Configuration{}
 	outputs := make(map[string]string, 0)
-	err := g.generateServerGroup(context.Background(), kv, cfg, deploymentID, "ServerGroupA", &infrastructure, outputs, nil)
+	resourceTypes := getOpenstackResourceTypes(cfg, infrastructureName)
+	err := g.generateServerGroup(
+		context.Background(),
+		serverGroupOptions{
+			kv:            kv,
+			deploymentID:  deploymentID,
+			nodeName:      "ServerGroupA",
+			resourceTypes: resourceTypes,
+		},
+		&infrastructure, outputs, nil)
 	require.NoError(t, err, "Unexpected error attempting to generate server group for %s", deploymentID)
 
 	require.Len(t, infrastructure.Resource["openstack_compute_servergroup_v2"], 1, "Expected one server group")

--- a/prov/terraform/openstack/testdata/topology_test.yaml
+++ b/prov/terraform/openstack/testdata/topology_test.yaml
@@ -1,0 +1,133 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: Test
+  template_version: 0.1.0-SNAPSHOT
+  template_author: ${template_author}
+
+description: ""
+
+imports:
+  - <yorc-types.yml>
+  - <normative-types.yml>
+  - <yorc-openstack-types.yml>
+
+topology_template:
+  node_templates:
+    BlockStorage:
+      type: yorc.nodes.openstack.BlockStorage
+      properties:
+        deletable: false
+        size: "10 GB"
+      requirements:
+        - attachToComputeAttach:
+            type_requirement: attachment
+            node: Compute
+            capability: tosca.capabilities.Attachment
+            relationship: tosca.relationships.AttachTo
+    Compute:
+      type: yorc.nodes.openstack.Compute
+      properties:
+        image: "a460db41-e574-416f-9634-96f2862f10fe"
+        flavor: 3
+        key_pair: yorc
+      requirements:
+        - Compute_FIPCompute:
+            type_requirement: network
+            node: FIPCompute
+            capability: yorc.capabilities.openstack.FIPConnectivity
+            relationship: tosca.relationships.Network
+      capabilities:
+        endpoint:
+          properties:
+            credentials: 
+              keys: 
+                0: "/home/centos/.ssh/yorc.pem"
+              user: centos
+            secure: true
+            protocol: tcp
+            network_name: PRIVATE
+            initiator: source
+        scalable:
+          properties:
+            min_instances: 1
+            max_instances: 1
+            default_instances: 1
+    FIPCompute:
+      type: yorc.nodes.openstack.FloatingIP
+      properties:
+        floating_network_name: "public-net1"
+  workflows:
+    install:
+      steps:
+        Compute_install:
+          target: Compute
+          activities:
+            - delegate: install
+        FIPCompute_install:
+          target: FIPCompute
+          activities:
+            - delegate: install
+          on_success:
+            - Compute_install
+        BlockStorage_install:
+          target: BlockStorage
+          activities:
+            - delegate: install
+          on_success:
+            - Compute_install
+    uninstall:
+      steps:
+        Compute_uninstall:
+          target: Compute
+          activities:
+            - delegate: uninstall
+          on_success:
+            - FIPCompute_uninstall
+            - BlockStorage_uninstall
+        FIPCompute_uninstall:
+          target: FIPCompute
+          activities:
+            - delegate: uninstall
+        BlockStorage_uninstall:
+          target: BlockStorage
+          activities:
+            - delegate: uninstall
+    start:
+      steps:
+        Compute_start:
+          target: Compute
+          activities:
+            - delegate: start
+          on_success:
+            - BlockStorage_start
+        FIPCompute_start:
+          target: FIPCompute
+          activities:
+            - delegate: start
+          on_success:
+            - Compute_start
+        BlockStorage_start:
+          target: BlockStorage
+          activities:
+            - delegate: start
+    stop:
+      steps:
+        FIPCompute_stop:
+          target: FIPCompute
+          activities:
+            - delegate: stop
+        BlockStorage_stop:
+          target: BlockStorage
+          activities:
+            - delegate: stop
+          on_success:
+            - Compute_stop
+        Compute_stop:
+          target: Compute
+          activities:
+            - delegate: stop
+          on_success:
+            - FIPCompute_stop
+    run:
+    cancel:

--- a/prov/terraform/openstack/testdata/topology_test.yaml
+++ b/prov/terraform/openstack/testdata/topology_test.yaml
@@ -32,6 +32,11 @@ topology_template:
         flavor: 3
         key_pair: yorc
       requirements:
+        - networkNetwork2Connection:
+            type_requirement: network
+            node: Network_2
+            capability: tosca.capabilities.Connectivity
+            relationship: tosca.relationships.Network
         - Compute_FIPCompute:
             type_requirement: network
             node: FIPCompute
@@ -40,8 +45,8 @@ topology_template:
       capabilities:
         endpoint:
           properties:
-            credentials:
-              keys:
+            credentials: 
+              keys: 
                 0: "/home/centos/.ssh/yorc.pem"
               user: centos
             secure: true
@@ -53,6 +58,11 @@ topology_template:
             min_instances: 1
             max_instances: 1
             default_instances: 1
+    Network_2:
+      type: yorc.nodes.openstack.Network
+      properties:
+        ip_version: 4
+        cidr: "10.1.0.0/24"
     FIPCompute:
       type: yorc.nodes.openstack.FloatingIP
       properties:
@@ -70,6 +80,12 @@ topology_template:
             - delegate: install
           on_success:
             - Compute_install
+        Network_2_install:
+          target: Network_2
+          activities:
+            - delegate: install
+          on_success:
+            - Compute_install
         BlockStorage_install:
           target: BlockStorage
           activities:
@@ -83,8 +99,13 @@ topology_template:
           activities:
             - delegate: uninstall
           on_success:
+            - Network_2_uninstall
             - FIPCompute_uninstall
             - BlockStorage_uninstall
+        Network_2_uninstall:
+          target: Network_2
+          activities:
+            - delegate: uninstall
         FIPCompute_uninstall:
           target: FIPCompute
           activities:
@@ -95,6 +116,12 @@ topology_template:
             - delegate: uninstall
     start:
       steps:
+        Network_2_start:
+          target: Network_2
+          activities:
+            - delegate: start
+          on_success:
+            - Compute_start
         Compute_start:
           target: Compute
           activities:
@@ -117,6 +144,10 @@ topology_template:
           target: FIPCompute
           activities:
             - delegate: stop
+        Network_2_stop:
+          target: Network_2
+          activities:
+            - delegate: stop
         BlockStorage_stop:
           target: BlockStorage
           activities:
@@ -129,5 +160,6 @@ topology_template:
             - delegate: stop
           on_success:
             - FIPCompute_stop
+            - Network_2_stop
     run:
     cancel:

--- a/prov/terraform/openstack/testdata/topology_test.yaml
+++ b/prov/terraform/openstack/testdata/topology_test.yaml
@@ -45,8 +45,8 @@ topology_template:
       capabilities:
         endpoint:
           properties:
-            credentials: 
-              keys: 
+            credentials:
+              keys:
                 0: "/home/centos/.ssh/yorc.pem"
               user: centos
             secure: true

--- a/prov/terraform/openstack/testdata/topology_test.yaml
+++ b/prov/terraform/openstack/testdata/topology_test.yaml
@@ -40,8 +40,8 @@ topology_template:
       capabilities:
         endpoint:
           properties:
-            credentials: 
-              keys: 
+            credentials:
+              keys:
                 0: "/home/centos/.ssh/yorc.pem"
               user: centos
             secure: true


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Using the OpenStack Block Storage API v3 instead of v1 not supported anymore (even v2 is deprecated).

To still be able to use Block Storage API v1 on old platforms for tests purposes, added a basic check:
checking if the User Domain mandatory required property (cf. https://developer.openstack.org/api-guide/quick-start/api-quick-start.html#authenticate ) is set in the Yorc OpenStack configuration.
If not set, considering this is an old platform on which Block Storage API v1 will be used.

### How I did it

Created a file  `prov/terraform/openstack/resource_types.go` where function `getOpenstackResourceTypes()` will return the API to use for the different OpenStack resources that can be created by Yorc.
Using the returned map `resource type` -> `api version` in other files in this package instead of using hard-coded strings.
Added a corresponding test file `prov/terraform/openstack/resource_types_test.go`.

All other changes are done to fix SonarCloud reported issues on existing code: complexity, number of lines in function, constants, test coverage.

### How to verify it

Bootstrap Yorc on an old OpenStack setup in insecure mode running (insecure mode to easily update the configuration later in the test):
```bash
$ ./yorc bootstrap -v inputs.yaml -n test --insecure
```

once done, login on the bootstrapped Alien4cloud, and edit the orchestrator configuration to add to the OpenStack location an on-demand BlockStorage resource of 10GB for example.
Create an application made of :
  * a compute nodes,
  * an attached block storage node,
  * a network attached to the compute node.

Deploy the application.
Login on the created compute instance.
Run this command:
```bash
$ lsblk
```
to check a disk `vdb` is attached to this compute instance.

Undeploy the application.

We will now redeploy this application on an new OpenStack Queens release.
For this, login on the Yorc host, edit `/etc/yorc/config.yorc.yaml` to change the openstack infrastructure configuration, to have something like :
```yaml
infrastructures:
  openstack:
    auth_url: http://1.2.3.4:5000/v3
    default_security_groups: [openbar, default]
    user_domain_name: Default
    user_name: xxx
    password: xxx
    project_name: myproject
    project_id: 36a1ae05995c4f099765c76825f3c30f
    private_network_name: private-xxx
    region: regionOne
    provisioning_over_fip_allowed: true
```

Then edit the yorc service `/etc/systemd/system/yorc.service` to replace one of the IP addresses listed in `NO_PROXY` env variable, by the IP address of your openstack setup, in this example `1.2.3.4`.
Then reload, stop then start the service:
```bash
systemctl daemon-reload
systemctl stop yorc
systemctl start yorc
```

Then login on Alien4Cloud, and change the orchestrator configuration on-demand compute instance resource to adapt the image id and the flavor id to values available on the new openstack setup :
```
image: 39ba04f8-2f2f-4721-943a-8c3752aac97b
flavor: a5fc3610-ff3f-4da9-a910-acbd634420de
```

Once done, deploy the application already created above, made of a Compute Node, an attached block storage node and a network.
Once done, login on the the created compute instance.
Run this command:
```bash
$ lsblk
```
to check a disk `vdb` is attached to this compute instance.

### Description for the changelog

Support OpenStack Block storage API v3 ([GH-440](https://github.com/ystia/yorc/issues/440))

## Applicable Issues

Fixes #440 
