### PR TITLE
Delay purge if a task is still running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * mem_per_node slurm option parameter is limited to integer number of GB ([GH-446](https://github.com/ystia/yorc/issues/446))
 * Job node state remains to "executing" when Ansible job fails ([GH-455](https://github.com/ystia/yorc/issues/455))
 * Panic occurs uploading job slurm artifacts during load test ([GH-465](https://github.com/ystia/yorc/issues/465))
+* Slurm Job cancel operation is failing during undeploy in some cases when purge task is done before ([GH-473](https://github.com/ystia/yorc/issues/473))
 
 ### ENHANCEMENTS
 

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -585,18 +585,43 @@ func (w *worker) runUndeploy(ctx context.Context, t *taskExecution) error {
 	return nil
 }
 
+func (w *worker) delayPurge(ctx context.Context, t *taskExecution, taskID string) {
+	log.Debugf("let's delay purge as a task is still running:%q", taskID)
+	ticker := time.NewTicker(time.Second * 5)
+	for {
+		select {
+		case <-ctx.Done():
+			ticker.Stop()
+			return
+		case <-ticker.C:
+			state, err := tasks.GetTaskStatus(t.cc.KV(), taskID)
+			if err != nil {
+				log.Printf("error occurred during delaying purge:%+v, err")
+				ticker.Stop()
+				return
+			}
+			if state != tasks.TaskStatusRUNNING {
+				log.Debugf("stop delaying purge as task:%q is no more running", taskID)
+				ticker.Stop()
+				return
+			}
+		}
+	}
+}
+
 func (w *worker) runPurge(ctx context.Context, t *taskExecution) error {
 	kv := w.consulClient.KV()
-	_, err := kv.DeleteTree(path.Join(consulutil.DeploymentKVPrefix, t.targetID), nil)
-	if err != nil {
-		return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
-	}
 	tasksList, err := tasks.GetTasksIdsForTarget(kv, t.targetID)
 	if err != nil {
 		return err
 	}
 	for _, tid := range tasksList {
 		if tid != t.taskID {
+			state, _ := tasks.GetTaskStatus(t.cc.KV(), tid)
+
+			if state == tasks.TaskStatusRUNNING {
+				w.delayPurge(ctx, t, tid)
+			}
 			err = tasks.DeleteTask(kv, tid)
 			if err != nil {
 				return err
@@ -607,6 +632,13 @@ func (w *worker) runPurge(ctx context.Context, t *taskExecution) error {
 			return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 		}
 	}
+
+	// Delete deployment tree
+	_, err = kv.DeleteTree(path.Join(consulutil.DeploymentKVPrefix, t.targetID), nil)
+	if err != nil {
+		return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+	}
+
 	// Delete events tree corresponding to the deployment TaskExecution
 	err = events.PurgeDeploymentEvents(kv, t.targetID)
 	if err != nil {

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -596,7 +596,7 @@ func (w *worker) delayPurge(ctx context.Context, t *taskExecution, taskID string
 		case <-ticker.C:
 			state, err := tasks.GetTaskStatus(t.cc.KV(), taskID)
 			if err != nil {
-				log.Printf("error occurred during delaying purge:%+v, err")
+				log.Printf("error occurred during delaying purge:%+v", err)
 				ticker.Stop()
 				return
 			}

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -601,7 +601,7 @@ func (w *worker) delayPurge(ctx context.Context, t *taskExecution, taskID string
 				return
 			}
 			if state != tasks.TaskStatusRUNNING {
-				log.Debugf("stop delaying purge as task:%q is no more running", taskID)
+				log.Debugf("stop delaying purge as task:%q is no longer running", taskID)
 				ticker.Stop()
 				return
 			}


### PR DESCRIPTION
# Pull Request description

## Description of the change

Delay purge if a task is still running

### How to verify it
Run a slurm job long enough to undeploy the app when it's still running
Check the slurm job is cancelled and the app purged
### Description for the changelog
* Slurm Job cancel operation is failing during undeploy in some cases when purge task is done before ([GH-473](https://github.com/ystia/yorc/issues/473))
## Applicable Issues
#473 