### PR TITLE
Cancel running task after timeout when purge is delayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 
 * Expose bypass error parameter on workflow ([GH-425](https://github.com/ystia/yorc/issues/425))
 * Support Alien4Cloud 2.2 ([GH-441](https://github.com/ystia/yorc/issues/441))
->>>>>>> release/3.2
 
 ## 3.2.0 (May 31, 2019)
 

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -605,6 +605,20 @@ func (w *worker) delayPurge(ctx context.Context, t *taskExecution, taskID string
 				ticker.Stop()
 				return
 			}
+		case <-time.After(30 * time.Second):
+			state, err := tasks.GetTaskStatus(t.cc.KV(), taskID)
+			if err != nil {
+				log.Printf("error occurred during delaying purge:%+v", err)
+				ticker.Stop()
+				return
+			}
+			if state == tasks.TaskStatusRUNNING {
+				log.Debugf("Purge delay timeout is reached: we cancel the task with ID:%q", taskID)
+				tasks.CancelTask(t.cc.KV(), taskID)
+				ticker.Stop()
+				return
+			}
+
 		}
 	}
 }


### PR DESCRIPTION
# Pull Request description


## Description of the change
Cancel running task after timeout when purge is delayed as no cancel request has been sent

## Applicable Issues
#473 