### PR TITLE
Fix monitoring manager hooks on full cover

### DIFF
--- a/prov/monitoring/consul_test.go
+++ b/prov/monitoring/consul_test.go
@@ -29,12 +29,18 @@ func TestRunConsulMonitoringPackageTests(t *testing.T) {
 	cfg := config.Configuration{
 		HTTPAddress: "localhost",
 		ServerID:    "0",
+		Consul: config.Consul{
+			Address:        srv.HTTPAddr,
+			PubMaxRoutines: config.DefaultConsulPubMaxRoutines,
+		},
 	}
 
 	// Register the consul service
 	chStop := make(chan struct{})
-	consulutil.RegisterServerAsConsulService(cfg, client, chStop)
-
+	err := consulutil.RegisterServerAsConsulService(cfg, client, chStop)
+	if err != nil {
+		t.Fatalf("failed to setup Yorc Consul service %v", err)
+	}
 	// Start/Stop the monitoring manager
 	Start(cfg, client)
 	defer func() {
@@ -100,7 +106,7 @@ func TestRunConsulMonitoringPackageTests(t *testing.T) {
 
 	t.Run("groupMonitoring", func(t *testing.T) {
 		t.Run("testComputeMonitoringHook", func(t *testing.T) {
-			testComputeMonitoringHook(t, client, config.Configuration{})
+			testComputeMonitoringHook(t, client, cfg)
 		})
 		t.Run("testIsMonitoringRequiredWithNoPolicy", func(t *testing.T) {
 			testIsMonitoringRequiredWithNoPolicy(t, client)

--- a/prov/monitoring/consul_test.go
+++ b/prov/monitoring/consul_test.go
@@ -61,6 +61,13 @@ func TestRunConsulMonitoringPackageTests(t *testing.T) {
 		consulutil.DeploymentKVPrefix + "/monitoring1/topology/policies/TCPMonitoring/targets":                  []byte("Compute1"),
 		consulutil.DeploymentKVPrefix + "/monitoring1/topology/policies/TCPMonitoring/type":                     []byte("yorc.policies.monitoring.TCPMonitoring"),
 
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/yorc.policies.monitoring.HTTPMonitoring/derived_from": []byte("yorc.policies.Monitoring"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/types/yorc.policies.monitoring.HTTPMonitoring/targets": []byte("		tosca.nodes.Compute,tosca.nodes.SoftwareComponent"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/policies/HTTPMonitoring/properties/port":          []byte("22"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/policies/HTTPMonitoring/properties/time_interval": []byte("1s"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/policies/HTTPMonitoring/targets":                  []byte("Compute2"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/policies/HTTPMonitoring/type":                     []byte("yorc.policies.monitoring.HTTPMonitoring"),
+
 		consulutil.DeploymentKVPrefix + "/monitoring3/topology/types/yorc.policies.monitoring.TCPMonitoring/derived_from": []byte("yorc.policies.Monitoring"),
 		consulutil.DeploymentKVPrefix + "/monitoring3/topology/types/yorc.policies.monitoring.TCPMonitoring/targets": []byte("		tosca.nodes.Compute,tosca.nodes.SoftwareComponent"),
 		consulutil.DeploymentKVPrefix + "/monitoring3/topology/policies/TCPMonitoring/properties/port":          []byte("22"),
@@ -82,6 +89,9 @@ func TestRunConsulMonitoringPackageTests(t *testing.T) {
 		consulutil.DeploymentKVPrefix + "/monitoring1/topology/nodes/Compute1/type":                             []byte("yorc.nodes.openstack.Compute"),
 		consulutil.DeploymentKVPrefix + "/monitoring1/topology/instances/Compute1/0/attributes/ip_address":      []byte("1.2.3.4"),
 		consulutil.DeploymentKVPrefix + "/monitoring1/topology/instances/Compute1/0/attributes/state":           []byte("started"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/nodes/Compute2/type":                             []byte("yorc.nodes.openstack.Compute"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/instances/Compute2/0/attributes/ip_address":      []byte("10.20.30.40"),
+		consulutil.DeploymentKVPrefix + "/monitoring1/topology/instances/Compute2/0/attributes/state":           []byte("started"),
 
 		consulutil.DeploymentKVPrefix + "/monitoring2/topology/types/tosca.nodes.Root/name":                     []byte("tosca.nodes.Root"),
 		consulutil.DeploymentKVPrefix + "/monitoring2/topology/types/tosca.nodes.Compute/derived_from":          []byte("tosca.nodes.Root"),

--- a/prov/monitoring/monitoring_hooks.go
+++ b/prov/monitoring/monitoring_hooks.go
@@ -46,13 +46,19 @@ func addMonitoringHook(ctx context.Context, cfg config.Configuration, taskID, de
 	// Monitoring check are added after (post-hook):
 	// - Delegate activity and install operation
 	// - SetState activity and node state "Started"
-
+	cc, err := cfg.GetConsulClient()
+	if err != nil {
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, deploymentID).
+			Registerf("Failed to check if monitoring is required for node name:%q due to: %v", target, err)
+		return
+	}
+	kv := cc.KV()
 	switch {
 	case activity.Type() == builder.ActivityTypeDelegate && strings.ToLower(activity.Value()) == "install",
 		activity.Type() == builder.ActivityTypeSetState && activity.Value() == tosca.NodeStateStarted.String():
 
 		// Check if monitoring is required
-		isMonitorReq, policyName, err := checkExistingMonitoringPolicy(defaultMonManager.cc.KV(), deploymentID, target)
+		isMonitorReq, policyName, err := checkExistingMonitoringPolicy(kv, deploymentID, target)
 		if err != nil {
 			events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
 				Registerf("Failed to check if monitoring is required for node name:%q due to: %v", target, err)
@@ -62,7 +68,7 @@ func addMonitoringHook(ctx context.Context, cfg config.Configuration, taskID, de
 			return
 		}
 
-		err = addMonitoringPolicyForTarget(defaultMonManager.cc.KV(), taskID, deploymentID, target, policyName)
+		err = addMonitoringPolicyForTarget(kv, taskID, deploymentID, target, policyName)
 		if err != nil {
 			events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
 				Registerf("Failed to add monitoring policy for node name:%q due to: %v", target, err)
@@ -74,12 +80,19 @@ func removeMonitoringHook(ctx context.Context, cfg config.Configuration, taskID,
 	// Monitoring check are removed before (pre-hook):
 	// - Delegate activity and uninstall operation
 	// - SetState activity and node state "Deleted"
+	cc, err := cfg.GetConsulClient()
+	if err != nil {
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, deploymentID).
+			Registerf("Failed to check if monitoring is required for node name:%q due to: %v", target, err)
+		return
+	}
+	kv := cc.KV()
 	switch {
 	case activity.Type() == builder.ActivityTypeDelegate && strings.ToLower(activity.Value()) == "uninstall",
 		activity.Type() == builder.ActivityTypeSetState && activity.Value() == tosca.NodeStateDeleted.String():
 
 		// Check if monitoring has been required
-		isMonitorReq, _, err := checkExistingMonitoringPolicy(defaultMonManager.cc.KV(), deploymentID, target)
+		isMonitorReq, _, err := checkExistingMonitoringPolicy(kv, deploymentID, target)
 		if err != nil {
 			events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
 				Registerf("Failed to check if monitoring is required for node name:%q due to: %v", target, err)
@@ -89,7 +102,7 @@ func removeMonitoringHook(ctx context.Context, cfg config.Configuration, taskID,
 			return
 		}
 
-		instances, err := tasks.GetInstances(defaultMonManager.cc.KV(), taskID, deploymentID, target)
+		instances, err := tasks.GetInstances(kv, taskID, deploymentID, target)
 		if err != nil {
 			events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).
 				Registerf("Failed to retrieve instances for node name:%q due to: %v", target, err)
@@ -146,7 +159,7 @@ func addMonitoringPolicyForTarget(kv *api.KV, taskID, deploymentID, target, poli
 	if err != nil {
 		return errors.Errorf("Failed to retrieve port as correct integer for monitoring policy:%q due to: %v", policyName, err)
 	}
-	instances, err := tasks.GetInstances(defaultMonManager.cc.KV(), taskID, deploymentID, target)
+	instances, err := tasks.GetInstances(kv, taskID, deploymentID, target)
 	if err != nil {
 		return err
 	}
@@ -155,15 +168,15 @@ func addMonitoringPolicyForTarget(kv *api.KV, taskID, deploymentID, target, poli
 	case httpMonitoring:
 		return applyHTTPMonitoringPolicy(kv, policyName, deploymentID, target, timeInterval, port, instances)
 	case tcpMonitoring:
-		return applyTCPMonitoringPolicy(deploymentID, target, timeInterval, port, instances)
+		return applyTCPMonitoringPolicy(kv, deploymentID, target, timeInterval, port, instances)
 	default:
 		return errors.Errorf("Unsupported policy type:%q for policy:%q", policyType, policyName)
 	}
 }
 
-func applyTCPMonitoringPolicy(deploymentID, target string, timeInterval time.Duration, port int, instances []string) error {
+func applyTCPMonitoringPolicy(kv *api.KV, deploymentID, target string, timeInterval time.Duration, port int, instances []string) error {
 	for _, instance := range instances {
-		ipAddress, err := retrieveIPAddress(deploymentID, target, instance)
+		ipAddress, err := retrieveIPAddress(kv, deploymentID, target, instance)
 		if err != nil {
 			return err
 		}
@@ -176,7 +189,7 @@ func applyTCPMonitoringPolicy(deploymentID, target string, timeInterval time.Dur
 
 func applyHTTPMonitoringPolicy(kv *api.KV, policyName, deploymentID, target string, timeInterval time.Duration, port int, instances []string) error {
 	for _, instance := range instances {
-		ipAddress, err := retrieveIPAddress(deploymentID, target, instance)
+		ipAddress, err := retrieveIPAddress(kv, deploymentID, target, instance)
 		if err != nil {
 			return err
 		}
@@ -239,8 +252,8 @@ func retrieveTLSClientConfig(kv *api.KV, policyName, deploymentID string) (map[s
 	return tlsClientConfig, nil
 }
 
-func retrieveIPAddress(deploymentID, target, instance string) (string, error) {
-	ipAddress, err := deployments.GetInstanceAttributeValue(defaultMonManager.cc.KV(), deploymentID, target, instance, "ip_address")
+func retrieveIPAddress(kv *api.KV, deploymentID, target, instance string) (string, error) {
+	ipAddress, err := deployments.GetInstanceAttributeValue(kv, deploymentID, target, instance, "ip_address")
 	if err != nil {
 		return "", errors.Errorf("Failed to retrieve ip_address for node name:%q due to: %v", target, err)
 	}

--- a/prov/monitoring/monitoring_hooks.go
+++ b/prov/monitoring/monitoring_hooks.go
@@ -48,8 +48,7 @@ func addMonitoringHook(ctx context.Context, cfg config.Configuration, taskID, de
 	// - SetState activity and node state "Started"
 	cc, err := cfg.GetConsulClient()
 	if err != nil {
-		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, deploymentID).
-			Registerf("Failed to check if monitoring is required for node name:%q due to: %v", target, err)
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, deploymentID).Registerf("Failed to check if monitoring is required for node name:%q due to: %v", target, err)
 		return
 	}
 	kv := cc.KV()
@@ -82,8 +81,7 @@ func removeMonitoringHook(ctx context.Context, cfg config.Configuration, taskID,
 	// - SetState activity and node state "Deleted"
 	cc, err := cfg.GetConsulClient()
 	if err != nil {
-		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, deploymentID).
-			Registerf("Failed to check if monitoring is required for node name:%q due to: %v", target, err)
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, deploymentID).Registerf("Failed to check if monitoring is required for node name:%q due to: %v", target, err)
 		return
 	}
 	kv := cc.KV()

--- a/prov/monitoring/monitoring_hooks_test.go
+++ b/prov/monitoring/monitoring_hooks_test.go
@@ -1,0 +1,45 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ystia/yorc/v4/config"
+	"github.com/ystia/yorc/v4/tasks/workflow/builder"
+)
+
+func Test_addMonitoringHook(t *testing.T) {
+	type args struct {
+		ctx          context.Context
+		cfg          config.Configuration
+		taskID       string
+		deploymentID string
+		target       string
+		activity     builder.Activity
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addMonitoringHook(tt.args.ctx, tt.args.cfg, tt.args.taskID, tt.args.deploymentID, tt.args.target, tt.args.activity)
+		})
+	}
+}


### PR DESCRIPTION
# Pull Request description

## Description of the change

Do not depend monitoring manager to get consul KV
This will prevent failures for not initialized managers. We have this in tests with full-cover of packages.
