### PR TITLE
Port to develop : Allow to disable Consul snapshot on upgrades 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### ENHANCEMENTS
+
+* Allow to disable automatic Consul snapshots and restore when upgrading Yorc using ̀`YORC_DISABLE_CONSUL_SNAPSHOTS_ON_UPGRADE` env variable ([GH-486](https://github.com/ystia/yorc/issues/486))
+
 ## 4.0.0-M1 (July 12, 2019)
 
 ### BREAKING CHANGES

--- a/doc/upgrade.rst
+++ b/doc/upgrade.rst
@@ -27,6 +27,11 @@ Upgrade dependencies like Consul, Terraform, Ansible for instance, then upgrade 
 Yorc will automatically take care of upgrading its database schema by its own from version 3.0.0 up to its
 current version.
 
+By default Yorc takes a snapshot of the Consul database before upgrading and automatically rollback to this snapshot
+if an error occurs during the upgrade process. If you are running Consul with ACL enabled the snapshot and restore
+feature requires to have the ``management`` ACL. It is possible to disable this feature by setting the
+``YORC_DISABLE_CONSUL_SNAPSHOTS_ON_UPGRADE`` environment variable to ``1`` or ``true``.
+
 .. note:: A rolling upgrade without interruption feature is planned for future versions.
 
 .. _yorc_upgrades_320_section:

--- a/server/consul.go
+++ b/server/consul.go
@@ -15,6 +15,10 @@
 package server
 
 import (
+	"io"
+	"os"
+	"strconv"
+
 	"github.com/blang/semver"
 	"github.com/hashicorp/consul/api"
 	"github.com/pkg/errors"
@@ -31,12 +35,22 @@ var upgradeToMap = map[string]func(*api.KV, <-chan struct{}) error{
 }
 
 var orderedUpgradesVersions []semver.Version
+var disableConsulSnapshotsOnUpgrades bool
 
 func init() {
 	for v := range upgradeToMap {
 		orderedUpgradesVersions = append(orderedUpgradesVersions, semver.MustParse(v))
 	}
 	semver.Sort(orderedUpgradesVersions)
+
+	var err error
+	disableConsulSnapEnv := os.Getenv("YORC_DISABLE_CONSUL_SNAPSHOTS_ON_UPGRADE")
+	if disableConsulSnapEnv != "" {
+		disableConsulSnapshotsOnUpgrades, err = strconv.ParseBool(disableConsulSnapEnv)
+		if err != nil {
+			log.Panicf(`Can't read value of "YORC_DISABLE_CONSUL_SNAPSHOTS_ON_UPGRADE" environment variable: %v`, err)
+		}
+	}
 }
 
 func synchronizeDBUpdate(client *api.Client) (*api.Lock, <-chan struct{}, error) {
@@ -121,32 +135,44 @@ func upgradeFromVersion(client *api.Client, leaderCh <-chan struct{}, fromVersio
 		// Same version nothing to do
 		return nil
 	case 1:
+		err = performUpgrade(client, leaderCh, vCurrent)
+		if err != nil {
+			return err
+		}
+	case -1:
+		return errors.Errorf("this version of Yorc is too old compared to the current DB schema (%s), an upgrade is needed.", vCurrent)
+	}
+
+	return setNewVersion(client.KV())
+}
+
+func performUpgrade(client *api.Client, leaderCh <-chan struct{}, vCurrent semver.Version) error {
+	snap := client.Snapshot()
+	var snapReader io.ReadCloser
+	if !disableConsulSnapshotsOnUpgrades {
 		// Make a Consul snapshot and restore it if any error occurs
-		snap := client.Snapshot()
 		snapReader, _, err := snap.Save(nil)
 		if err != nil {
 			return errors.Wrapf(err, "failed to upgrade consul db schema to %q", err)
 		}
 		defer snapReader.Close()
-		for _, vUp := range orderedUpgradesVersions {
-			if vUp.GT(vCurrent) {
-				err = upgradeToMap[vUp.String()](client.KV(), leaderCh)
-				if err != nil {
+	}
+	for _, vUp := range orderedUpgradesVersions {
+		if vUp.GT(vCurrent) {
+			err := upgradeToMap[vUp.String()](client.KV(), leaderCh)
+			if err != nil {
+				if !disableConsulSnapshotsOnUpgrades {
 					// Restore Consul snapshot
 					restoreErr := snap.Restore(nil, snapReader)
 					if restoreErr != nil {
-						log.Printf("failed to restore consul db schema to %q due to error:%+v", fromVersion, restoreErr)
+						log.Printf("failed to restore consul db schema to %q due to error:%+v", vCurrent, restoreErr)
 					} else {
-						log.Printf("As any error occurred, schema has been successfully restored to version %q", fromVersion)
+						log.Printf("As any error occurred, schema has been successfully restored to version %q", vCurrent)
 					}
-					return errors.Wrapf(err, "failed to upgrade consul db schema to %q.", vUp)
 				}
+				return errors.Wrapf(err, "failed to upgrade consul db schema to %q.", vUp)
 			}
 		}
-	case -1:
-		return errors.Errorf("this version of Yorc is too old compared to the current DB schema (%s), an upgrade is needed.", vCurrent)
-
 	}
-
-	return setNewVersion(client.KV())
+	return nil
 }

--- a/server/consul.go
+++ b/server/consul.go
@@ -151,7 +151,8 @@ func performUpgrade(client *api.Client, leaderCh <-chan struct{}, vCurrent semve
 	var snapReader io.ReadCloser
 	if !disableConsulSnapshotsOnUpgrades {
 		// Make a Consul snapshot and restore it if any error occurs
-		snapReader, _, err := snap.Save(nil)
+		var err error
+		snapReader, _, err = snap.Save(nil)
 		if err != nil {
 			return errors.Wrapf(err, "failed to upgrade consul db schema to %q", err)
 		}


### PR DESCRIPTION
# Pull Request description

## Description of the change

Port of #488 to develop

### What I did

Added an environment variable `YORC_DISABLE_CONSUL_SNAPSHOTS_ON_UPGRADE` to disable Consul snapshots & restore.

### Description for the changelog

* Allow to disable automatic Consul snapshots and restore when upgrading Yorc using ̀`YORC_DISABLE_CONSUL_SNAPSHOTS_ON_UPGRADE` env variable ([GH-486](https://github.com/ystia/yorc/issues/486))

## Applicable Issues

Fixes #486 