### PR TITLE
Display worker execution error in A4C log debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.12.x
+  - stable
 
 dist: trusty
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - stable
+  - 1.12.x
 
 dist: trusty
 sudo: required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Slurm job Logs are displaying stack error ([GH-460](https://github.com/ystia/yorc/issues/503))
+
 ## 4.0.0-M3 (August 30, 2019)
 
 ### SECURITY FIXES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### BUG FIXES
 
-* Slurm job Logs are displaying stack error ([GH-460](https://github.com/ystia/yorc/issues/503))
+* A4C Logs are displaying stack error when workflow step fails ([GH-460](https://github.com/ystia/yorc/issues/503))
 
 ## 4.0.0-M3 (August 30, 2019)
 

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -227,7 +227,7 @@ func (w *worker) handleExecution(t *taskExecution) {
 		err = errors.Errorf("Unknown TaskType %d (%s) for TaskExecution with id %q", t.taskType, t.taskType.String(), t.taskID)
 	}
 	if err != nil {
-		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, t.targetID).Registerf("%v", err)
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelDEBUG, t.targetID).Registerf("%v", err)
 		if log.IsDebug() {
 			log.Debugf("%+v", err)
 		}
@@ -741,7 +741,6 @@ func (w *worker) runWorkflowStep(ctx context.Context, t *taskExecution, workflow
 	s := wrapBuilderStep(bs, w.consulClient, t)
 	err = s.run(ctx, w.cfg, w.consulClient.KV(), t.targetID, continueOnError, workflowName, w)
 	if err != nil {
-		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, t.targetID).RegisterAsString(fmt.Sprintf("Error '%+v' happened in workflow %q.", err, workflowName))
 		return errors.Wrapf(err, "The workflow %s step %s ended with error:%+v", workflowName, t.step, err)
 	}
 	if !s.Async {

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -227,10 +227,7 @@ func (w *worker) handleExecution(t *taskExecution) {
 		err = errors.Errorf("Unknown TaskType %d (%s) for TaskExecution with id %q", t.taskType, t.taskType.String(), t.taskID)
 	}
 	if err != nil {
-		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelDEBUG, t.targetID).Registerf("%v", err)
-		if log.IsDebug() {
-			log.Debugf("%+v", err)
-		}
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, t.targetID).Registerf("%v", err)
 	}
 }
 
@@ -741,7 +738,7 @@ func (w *worker) runWorkflowStep(ctx context.Context, t *taskExecution, workflow
 	s := wrapBuilderStep(bs, w.consulClient, t)
 	err = s.run(ctx, w.cfg, w.consulClient.KV(), t.targetID, continueOnError, workflowName, w)
 	if err != nil {
-		return errors.Wrapf(err, "The workflow %s step %s ended with error:%+v", workflowName, t.step, err)
+		return errors.Wrapf(err, "The workflow %s step %s ended on error", workflowName, t.step)
 	}
 	if !s.Async {
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelINFO, t.targetID).RegisterAsString(fmt.Sprintf("DeploymentID:%q, Workflow:%q, step:%q ended without error", t.targetID, workflowName, t.step))

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -228,6 +228,7 @@ func (w *worker) handleExecution(t *taskExecution) {
 	}
 	if err != nil {
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, t.targetID).Registerf("%v", err)
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelDEBUG, t.targetID).Registerf("%+v", err)
 	}
 }
 


### PR DESCRIPTION
Remove duplicated error A4C log

# Pull Request description

## Description of the change

### What I did
- Remove duplicated error log in runWorkflowStep function
- Change log level to DEBUG for displaying error stack trace.

### How to verify it
See #503 
### Description for the changelog
* Slurm job Logs are displaying stack error ([GH-460](https://github.com/ystia/yorc/issues/503))
## Applicable Issues
Fixes #503 