### PR TITLE
Fix openstack network creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### BUG FIXES
 
-
+* Fixed a bug preventing OpenStack Networks from being created ([GH-515](https://github.com/ystia/yorc/issues/515))
 * A deployment may disappear from the deployments list while its currently running a purge task ([GH-504](https://github.com/ystia/yorc/issues/504))
 * A4C Logs are displaying stack error when workflow step fails ([GH-460](https://github.com/ystia/yorc/issues/503))
 

--- a/prov/terraform/openstack/generator.go
+++ b/prov/terraform/openstack/generator.go
@@ -335,7 +335,7 @@ func (g *osGenerator) generateNetworkInfra(opts generateInfraOptions) error {
 	}
 	var subnet Subnet
 	subnet, err = g.generateSubnet(opts.kv, opts.cfg, opts.deploymentID, opts.nodeName,
-		opts.resourceTypes[networkingSubnet])
+		opts.resourceTypes[networkingNetwork])
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description of the change
The creation of OpenStack networks was broken. The `generateSubnet` method needs the resource type for OpenStack networks in order to reference the network it should be attached to, but the resource type for subnets was passed.

### What I did
Fixed by passing the `networkingNetwork` type instead of `networkingSubnet`

### Description for the changelog
Fixed a bug preventing OpenStack Networks from being created.

## Applicable Issues
fixes #515 