### PR TITLE
Fix Having a deployment named as a prefix of another one causes several issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ env:
 install:
   - make tools
   - pip install --user --upgrade sphinx==1.8.1 semantic-version requests urllib3[secure]==1.23
-  - wget --output-document=build/bin/gotestsum.tgz  https://github.com/gotestyourself/gotestsum/releases/download/v0.3.5/gotestsum_0.3.5_linux_amd64.tar.gz
-  - tar xzf build/bin/gotestsum.tgz -C build/bin
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64  > ./cc-test-reporter
@@ -35,7 +33,6 @@ before_script:
 script:
   # Start sonar specific stuff
   - TESTARGS="-coverprofile coverage-sonar.out -coverpkg=./..." make json-test
-  - build/bin/gotestsum -f standard-quiet --raw-command cat tests-reports.json
   - sed -i -e "s@$(go list)@github.com/ystia/yorc@g" coverage-sonar.out
   - git fetch --no-tags origin "+refs/heads/develop:refs/remotes/origin/develop" "+refs/heads/release/*:refs/remotes/origin/release/*"
   - git fetch --unshallow --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
   global:
     # Make GO111MODULE=on globally for codecov
     - GO111MODULE=on
-    # Code climate key (CC_TEST_REPORTER_ID)
-    - secure: iyv/cQh7z/PjRyEySKELsd3L69AdRVlCnZrtozvM/Z+poeSnGtQIRLWgOw/Pe5ueNa/v7Wq2BKw1DHeTrgSnvNNt/uoTUWLY5UcHkPHQYm67DeB7CffSELgr8l6K7eBOqTn2Hu6mzPlmU6l3v8CBHg8uSJT6wv/XKqn2Ut74OBA7wCYRQyEXcnr26C7ytnN/XaaR/RPzXYyxoB6/l6aH1/PK9rt+btdBu4TPo5zZm6KVA8pp85KG7xfGjq6kNG+kDwFiaj6/DJmnxYKxsiyv/AsEtLmElxGKQQqCnOefbNwqSsdYDDqy5AikZ+ZfJQLRrLJzcHDzgREaiPCF0QVfGttcuX5AXpPkrBlKeixku91Dir4hebYAN7SWWwKktu8hqKTtQjc8eJMEbQVKTtk3yeRKqC4I8lUK6TBrJA7tnQpgq8w67Vm81P18UPPjKm6Wf6aCJEKSvrnVSwLvIrEN8q/ybrCupvvcze0l9nsQhJG/79BQX31mjZkqT9MdskgYgD3wrB2LexLYkw4BeyKOV1/fTyz7q82ocfEdNMHTnPKD4B2bXtl1Alx8wluIFjwOvy8QZ9Hopz+cNnfN/dOJcQn7hPQbjqIP7uumUTP2vVk3mtwPDKLYqfCeO1ZLwHClXog6Q2k8gb6mkEfVx6ygq/JxM5LkSnTdfyowLLTp7W0=
     # Docker hub key (DOCKER_HUB_USER)
     - secure: j6S26JA04B+6bwr6detZauFu/UVPwmPhWvEcbVfNhvnNX3YKma8D2X9hvE6jDUOKeapiE/UsCHVgg8GFyPGu4M0ixUXUmu7HPNHFQ2x4a0tDgTyu0p9im5fPeJv4qbV+ORuE4Kvg54ZaZec3iBN94MegPVISpme86pMKdJui0cMEy/YPMUd1sh13h95WkESAshJd0n5AHO4xwD0NJjCK2waoA6ygvcwXhIpfTc9HsNgs6S8WVpRAfjkTj7+VGjoXTqov5g9d6SxBYvcJI/iBa0KgY7LhBRiC6AsE2WowVZeGDpnvL1nFsA2DQKcCC6Tv4VlP7jcyZMWcnELn8n6ucsHzT52bEhGu60KtZc5eohqW/1Ejb0riHvEJQMy875keBwIjuzERgxRaKEVGPQ3nZFu/rjEjHZSm0qi9+usb/vBcdKeu9fgjBeEDIkL5bE632P379VLI1bzzQS+dt+sPw1gqqDP+FJ1nED5r3g4zSPh4WqXAz4ohrX8CCqbxpy+Wjirer/yc7S+Bqx/iI2gKjdb6kwy1xePobFJyAMlOyHrwh5Tb6K23wJqVMoHL5mqG0Ent/3iXmvRS6PxsxwNPscyATUbazyGwXMj4oMWzcfs7yf0ADy/nbZLYUPVfHuysRZ6LAjptn+V8bdJ9A0rQmFUFDcP6VmMidxRlTcHR8yA=
     # Docker hub key (DOCKER_HUB_PASS)
@@ -25,11 +23,6 @@ install:
   - make tools
   - pip install --user --upgrade sphinx==1.8.1 semantic-version requests urllib3[secure]==1.23
 
-before_script:
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64  > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - "./cc-test-reporter before-build"
-
 script:
   # Test and compute coverage
   - TESTARGS="-coverprofile coverage-sonar.out -coverpkg=./..." make json-test
@@ -38,9 +31,6 @@ script:
   - SKIP_TESTS=1 make dist
   - "./docker_build.sh"
   - bash build/deploy_artifactory.sh
-
-after_script:
-  - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
 
 before_deploy:
   - "bash ./build/pre_bintray_release.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ env:
 install:
   - make tools
   - pip install --user --upgrade sphinx==1.8.1 semantic-version requests urllib3[secure]==1.23
+  - wget --output-document=build/bin/gotestsum.tgz  https://github.com/gotestyourself/gotestsum/releases/download/v0.3.5/gotestsum_0.3.5_linux_amd64.tar.gz
+  - tar xzf build/bin/gotestsum.tgz -C build/bin
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64  > ./cc-test-reporter
@@ -31,28 +33,20 @@ before_script:
   - "./cc-test-reporter before-build"
 
 script:
-  # Go1.10 is required to have proper use of coverprofile for multiple packages
-  - TESTARGS="-coverprofile coverage.txt -coverpkg=./..." make dist
-  - cp coverage.txt c.out
-  # Tweak code climate profile as Go modules are not properly supported yet
-  # coverage.txt is for codecov.io while c.out is for codeclimate.com
-  - sed -i -e "s@$(go list)/@@g" c.out
   # Start sonar specific stuff
-  - cp coverage.txt coverage-sonar.out
+  - TESTARGS="-coverprofile coverage-sonar.out -coverpkg=./..." make json-test
+  - build/bin/gotestsum -f standard-quiet --raw-command cat tests-reports.json
   - sed -i -e "s@$(go list)@github.com/ystia/yorc@g" coverage-sonar.out
-  - make json-test
   - git fetch --no-tags origin "+refs/heads/develop:refs/remotes/origin/develop" "+refs/heads/release/*:refs/remotes/origin/release/*"
   - git fetch --unshallow --quiet
   - sonar-scanner --define "sonar.projectVersion=$(grep "yorc_version" versions.yaml | awk '{print $2}')"
   # End of sonar specific stuff
+  - SKIP_TESTS=1 make dist
   - "./docker_build.sh"
   - bash build/deploy_artifactory.sh
 
 after_script:
   - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
 
 before_deploy:
   - "bash ./build/pre_bintray_release.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,10 @@ before_script:
   - "./cc-test-reporter before-build"
 
 script:
-  # Start sonar specific stuff
+  # Test and compute coverage
   - TESTARGS="-coverprofile coverage-sonar.out -coverpkg=./..." make json-test
-  - sed -i -e "s@$(go list)@github.com/ystia/yorc@g" coverage-sonar.out
-  - git fetch --no-tags origin "+refs/heads/develop:refs/remotes/origin/develop" "+refs/heads/release/*:refs/remotes/origin/release/*"
-  - git fetch --unshallow --quiet
-  - sonar-scanner --define "sonar.projectVersion=$(grep "yorc_version" versions.yaml | awk '{print $2}')"
-  # End of sonar specific stuff
+  - ./build/travis-sonar.sh
+  # Generate distribution
   - SKIP_TESTS=1 make dist
   - "./docker_build.sh"
   - bash build/deploy_artifactory.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### BUG FIXES
 
-
+* Having a deployment named as a prefix of another one causes several issues ([GH-504](https://github.com/ystia/yorc/issues/512))
 * A deployment may disappear from the deployments list while its currently running a purge task ([GH-504](https://github.com/ystia/yorc/issues/504))
 * A4C Logs are displaying stack error when workflow step fails ([GH-460](https://github.com/ystia/yorc/issues/503))
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ endif
 json-test: generate header format
 	@echo "--> Running go test with json output"
 # -count is for disabling test cache
-	@go test -tags "testing $(BUILD_TAGS)" $(TESTARGS) -json -count=1 -p 1 ./... > tests-reports.json
+	@gotestsum --jsonfile tests-reports.json  -- -tags "testing $(BUILD_TAGS)" $(TESTARGS) -count=1 -p 1 ./...
 
 cover:
 	@go test -tags "testing $(BUILD_TAGS)"  -p 1 -cover $(COVERARGS) ./...

--- a/build/checks.sh
+++ b/build/checks.sh
@@ -73,6 +73,14 @@ else
     fi
 fi
 
+if [[ ! -x "${binDir}/gotestsum" ]]; then
+    rm -f "${binDir}/gotestsum"
+    wget --output-document=${binDir}/gotestsum.tgz  https://github.com/gotestyourself/gotestsum/releases/download/v0.3.5/gotestsum_0.3.5_linux_amd64.tar.gz
+    tar xzf ${binDir}/gotestsum.tgz -C ${binDir}
+    rm -f ${binDir}/gotestsum.tgz
+fi
+
+
 if [[ ! -r "${HOME}/.ssh/yorc.pem" ]]; then
     echo "Installing a testing ssh key under ${HOME}/.ssh/yorc.pem"
     mkdir -p "${HOME}/.ssh/" || error_exit "Can't create ${HOME}/.ssh/ directory"

--- a/build/checks.sh
+++ b/build/checks.sh
@@ -75,9 +75,9 @@ fi
 
 if [[ ! -x "${binDir}/gotestsum" ]]; then
     rm -f "${binDir}/gotestsum"
-    wget --output-document=${binDir}/gotestsum.tgz  https://github.com/gotestyourself/gotestsum/releases/download/v0.3.5/gotestsum_0.3.5_linux_amd64.tar.gz
-    tar xzf ${binDir}/gotestsum.tgz -C ${binDir}
-    rm -f ${binDir}/gotestsum.tgz
+    wget --output-document="${binDir}/gotestsum.tgz" https://github.com/gotestyourself/gotestsum/releases/download/v0.3.5/gotestsum_0.3.5_linux_amd64.tar.gz
+    tar xzf "${binDir}/gotestsum.tgz" -C "${binDir}"
+    rm -f "${binDir}/gotestsum.tgz"
 fi
 
 

--- a/build/travis-sonar.sh
+++ b/build/travis-sonar.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -eo pipefail
 
 scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -21,7 +22,7 @@ if [[ -z "${SONAR_TOKEN}" ]] ; then
     exit 0
 fi
 
-cd "${scriptDir}/.."
+cd "${scriptDir}/.." || { echo "failed to move to yorc directory ${scriptDir}/.."; exit 1; }
 sed -i -e "s@$(go list)@github.com/ystia/yorc@g" coverage-sonar.out
 git fetch --no-tags origin "+refs/heads/develop:refs/remotes/origin/develop" "+refs/heads/release/*:refs/remotes/origin/release/*"
 git fetch --unshallow --quiet

--- a/build/travis-sonar.sh
+++ b/build/travis-sonar.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [[ -z "${SONAR_TOKEN}" ]] ; then
+    echo "No sonar token detected, we are probably building an external PR, lets skip sonar publication..."
+    exit 0
+fi
+
+cd "${scriptDir}/.."
+sed -i -e "s@$(go list)@github.com/ystia/yorc@g" coverage-sonar.out
+git fetch --no-tags origin "+refs/heads/develop:refs/remotes/origin/develop" "+refs/heads/release/*:refs/remotes/origin/release/*"
+git fetch --unshallow --quiet
+sonar-scanner --define "sonar.projectVersion=$(grep "yorc_version" versions.yaml | awk '{print $2}')"

--- a/deployments/attribute_notifications.go
+++ b/deployments/attribute_notifications.go
@@ -137,7 +137,7 @@ func (an *AttributeNotifier) NotifyValueChange(kv *api.KV, deploymentID string) 
 }
 
 func notifyAttributeOnValueChange(kv *api.KV, notificationsPath, deploymentID string) error {
-	kvps, _, err := kv.List(notificationsPath, nil)
+	kvps, _, err := kv.List(notificationsPath+"/", nil)
 	if err != nil {
 		return err
 	}

--- a/deployments/consul_test.go
+++ b/deployments/consul_test.go
@@ -112,6 +112,18 @@ func TestRunConsulDeploymentsPackageTests(t *testing.T) {
 		t.Run("testPurgedDeployments", func(t *testing.T) {
 			testPurgedDeployments(t, client)
 		})
+		t.Run("testDeleteDeployment", func(t *testing.T) {
+			testDeleteDeployment(t, kv)
+		})
+		t.Run("testDeleteInstance", func(t *testing.T) {
+			testDeleteInstance(t, kv)
+		})
+		t.Run("testDeleteAllInstances", func(t *testing.T) {
+			testDeleteAllInstances(t, kv)
+		})
+		t.Run("testDeleteRelationshipInstance", func(t *testing.T) {
+			testDeleteRelationshipInstance(t, kv)
+		})
 	})
 
 	t.Run("CommonsTestsOn_test_topology.yml", func(t *testing.T) {

--- a/deployments/definition_store.go
+++ b/deployments/definition_store.go
@@ -417,6 +417,7 @@ func fixAlienBlockStorages(ctx context.Context, kv *api.KV, deploymentID, nodeNa
 			}
 
 			// Get all requirement properties
+			// Appending a final "/" here is not necessary as there is no other keys starting with "properties" prefix
 			kvps, _, err := kv.List(path.Join(attachReq, "properties"), nil)
 			if err != nil {
 				return errors.Wrapf(err, "Failed to fix Alien-specific BlockStorage %q", nodeName)

--- a/deployments/deployments.go
+++ b/deployments/deployments.go
@@ -206,6 +206,7 @@ func CleanupPurgedDeployments(ctx context.Context, cc *api.Client, evictionTimeo
 		return err
 	}
 	defer lock.Unlock()
+	// Appending a final "/" here is not necessary as there is no other keys starting with consulutil.PurgedDeploymentKVPrefix prefix
 	kvpList, _, err := cc.KV().List(consulutil.PurgedDeploymentKVPrefix, nil)
 	if err != nil {
 		return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
@@ -273,4 +274,12 @@ func acquirePurgedDeploymentsLock(ctx context.Context, cc *api.Client) (*api.Loc
 		}
 	}
 	return lock, leaderCh, nil
+}
+
+// DeleteDeployment deletes a given deploymentID from the deployments path
+func DeleteDeployment(kv *api.KV, deploymentID string) error {
+	// Remove from KV this purge tasks
+	_, err := kv.DeleteTree(path.Join(consulutil.DeploymentKVPrefix, deploymentID)+"/", nil)
+	return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+
 }

--- a/deployments/instances.go
+++ b/deployments/instances.go
@@ -77,13 +77,13 @@ func GetInstanceStateString(kv *api.KV, deploymentID, nodeName, instanceName str
 
 // DeleteInstance deletes the given instance of the given node from the Consul store
 func DeleteInstance(kv *api.KV, deploymentID, nodeName, instanceName string) error {
-	_, err := kv.DeleteTree(path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/instances", nodeName, instanceName), nil)
+	_, err := kv.DeleteTree(path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/instances", nodeName, instanceName)+"/", nil)
 	return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 }
 
 // DeleteAllInstances deletes all instances of the given node from the Consul store
 func DeleteAllInstances(kv *api.KV, deploymentID, nodeName string) error {
-	_, err := kv.DeleteTree(path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/instances", nodeName), nil)
+	_, err := kv.DeleteTree(path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/instances", nodeName)+"/", nil)
 	return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 }
 

--- a/deployments/instances_test.go
+++ b/deployments/instances_test.go
@@ -1,0 +1,99 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployments
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ystia/yorc/v4/testutil"
+)
+
+func testDeleteInstance(t *testing.T, kv *api.KV) {
+	ctx := context.Background()
+	deploymentID := testutil.BuildDeploymentID(t)
+	nodeName := "SomeNode"
+	instanceName1 := "1"
+	instanceName11 := "11"
+	state := "created"
+	err := SetInstanceStateStringWithContextualLogs(ctx, kv, deploymentID, nodeName, instanceName1, state)
+	require.NoError(t, err)
+	err = SetInstanceStateStringWithContextualLogs(ctx, kv, deploymentID, nodeName, instanceName11, state)
+	require.NoError(t, err)
+
+	actualState, err := GetInstanceStateString(kv, deploymentID, nodeName, instanceName1)
+	require.NoError(t, err)
+	require.Equal(t, state, actualState)
+	actualState, err = GetInstanceStateString(kv, deploymentID, nodeName, instanceName11)
+	require.NoError(t, err)
+	require.Equal(t, state, actualState)
+
+	err = DeleteInstance(kv, deploymentID, nodeName, instanceName1)
+
+	actualState, err = GetInstanceStateString(kv, deploymentID, nodeName, instanceName1)
+	require.Error(t, err)
+	actualState, err = GetInstanceStateString(kv, deploymentID, nodeName, instanceName11)
+	require.NoError(t, err)
+	require.Equal(t, state, actualState)
+
+}
+
+func testDeleteAllInstances(t *testing.T, kv *api.KV) {
+	ctx := context.Background()
+	deploymentID := testutil.BuildDeploymentID(t)
+	nodeName1 := "SomeNode1"
+	nodeName11 := "SomeNode11"
+	instanceName1 := "1"
+	instanceName11 := "11"
+	state := "created"
+	err := SetInstanceStateStringWithContextualLogs(ctx, kv, deploymentID, nodeName1, instanceName1, state)
+	require.NoError(t, err)
+	err = SetInstanceStateStringWithContextualLogs(ctx, kv, deploymentID, nodeName1, instanceName11, state)
+	require.NoError(t, err)
+	err = SetInstanceStateStringWithContextualLogs(ctx, kv, deploymentID, nodeName11, instanceName1, state)
+	require.NoError(t, err)
+	err = SetInstanceStateStringWithContextualLogs(ctx, kv, deploymentID, nodeName11, instanceName11, state)
+	require.NoError(t, err)
+
+	actualState, err := GetInstanceStateString(kv, deploymentID, nodeName1, instanceName1)
+	require.NoError(t, err)
+	require.Equal(t, state, actualState)
+	actualState, err = GetInstanceStateString(kv, deploymentID, nodeName1, instanceName11)
+	require.NoError(t, err)
+	require.Equal(t, state, actualState)
+	actualState, err = GetInstanceStateString(kv, deploymentID, nodeName11, instanceName1)
+	require.NoError(t, err)
+	require.Equal(t, state, actualState)
+	actualState, err = GetInstanceStateString(kv, deploymentID, nodeName11, instanceName11)
+	require.NoError(t, err)
+	require.Equal(t, state, actualState)
+
+	err = DeleteAllInstances(kv, deploymentID, nodeName1)
+
+	actualState, err = GetInstanceStateString(kv, deploymentID, nodeName1, instanceName1)
+	require.Error(t, err)
+	actualState, err = GetInstanceStateString(kv, deploymentID, nodeName1, instanceName11)
+	require.Error(t, err)
+	actualState, err = GetInstanceStateString(kv, deploymentID, nodeName11, instanceName1)
+	require.NoError(t, err)
+	require.Equal(t, state, actualState)
+	actualState, err = GetInstanceStateString(kv, deploymentID, nodeName11, instanceName11)
+	require.NoError(t, err)
+	require.Equal(t, state, actualState)
+
+}

--- a/deployments/nodes.go
+++ b/deployments/nodes.go
@@ -866,6 +866,6 @@ func NodeHasProperty(kv *api.KV, deploymentID, nodeName, propertyName string, ex
 
 // DeleteNode deletes the given node from the Consul store
 func DeleteNode(kv *api.KV, deploymentID, nodeName string) error {
-	_, err := kv.DeleteTree(path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/nodes", nodeName), nil)
+	_, err := kv.DeleteTree(path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/nodes", nodeName)+"/", nil)
 	return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 }

--- a/deployments/relationships.go
+++ b/deployments/relationships.go
@@ -191,7 +191,7 @@ func SetRelationshipAttributeComplexForAllInstances(kv *api.KV, deploymentID, no
 	for _, instanceName := range ids {
 		attrPath := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/relationship_instances", nodeName, requirementIndex, instanceName, "attributes", attributeName)
 		internal.StoreComplexType(store, attrPath, attributeValue)
-		err := publishRelationshipAttributeValueChange(consulutil.GetKV(), deploymentID, nodeName, instanceName, requirementIndex, attributeName, attributeValue)
+		err := publishRelationshipAttributeValueChange(kv, deploymentID, nodeName, instanceName, requirementIndex, attributeName, attributeValue)
 		if err != nil {
 			return err
 		}
@@ -203,10 +203,10 @@ func SetRelationshipAttributeComplexForAllInstances(kv *api.KV, deploymentID, no
 func createRelationshipInstances(consulStore consulutil.ConsulStore, kv *api.KV, deploymentID, nodeName string) error {
 	relInstancePath := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/relationship_instances")
 	reqKeys, err := GetRequirementsIndexes(kv, deploymentID, nodeName)
-	nodeInstanceIds, err := GetNodeInstancesIds(kv, deploymentID, nodeName)
 	if err != nil {
 		return err
 	}
+	nodeInstanceIds, err := GetNodeInstancesIds(kv, deploymentID, nodeName)
 	if err != nil {
 		return err
 	}
@@ -241,6 +241,7 @@ func createRelationshipInstances(consulStore consulutil.ConsulStore, kv *api.KV,
 
 func addOrRemoveInstanceFromTargetRelationship(kv *api.KV, deploymentID, nodeName, instanceName string, add bool) error {
 	relInstancePath := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology/relationship_instances")
+	// Appending a final "/" here is not necessary has there is no other keys starting with "relationship_instances" prefix
 	relInstKVPairs, _, err := kv.List(relInstancePath, nil)
 	if err != nil {
 		return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
@@ -288,7 +289,7 @@ func DeleteRelationshipInstance(kv *api.KV, deploymentID, nodeName, instanceName
 		return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 	}
 	for _, reqindex := range reqIndices {
-		_, err := kv.DeleteTree(path.Join(reqindex, instanceName), nil)
+		_, err := kv.DeleteTree(path.Join(reqindex, instanceName)+"/", nil)
 		if err != nil {
 			return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 		}

--- a/deployments/relationships_test.go
+++ b/deployments/relationships_test.go
@@ -1,0 +1,78 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployments
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ystia/yorc/v4/helper/consulutil"
+	"github.com/ystia/yorc/v4/testutil"
+)
+
+func testDeleteRelationshipInstance(t *testing.T, kv *api.KV) {
+	deploymentID := testutil.BuildDeploymentID(t)
+	ctx := context.Background()
+	ctx, errGrp, consulStore := consulutil.WithContext(ctx)
+
+	err := StoreDeploymentDefinition(ctx, kv, deploymentID, "testdata/relationship_instances.yaml")
+	require.NoError(t, err, "Failed to store test topology deployment definition")
+
+	nodeAName := "NodeA"
+	nodeBName := "NodeB"
+	err = SetInstanceStateStringWithContextualLogs(ctx, kv, deploymentID, nodeAName, "1", "created")
+	require.NoError(t, err)
+	err = SetInstanceStateStringWithContextualLogs(ctx, kv, deploymentID, nodeAName, "11", "created")
+	require.NoError(t, err)
+	err = SetInstanceStateStringWithContextualLogs(ctx, kv, deploymentID, nodeBName, "1", "created")
+	require.NoError(t, err)
+	err = SetInstanceStateStringWithContextualLogs(ctx, kv, deploymentID, nodeBName, "11", "created")
+	require.NoError(t, err)
+
+	err = createRelationshipInstances(consulStore, kv, deploymentID, nodeAName)
+	require.NoError(t, err)
+	err = errGrp.Wait()
+	require.NoError(t, err)
+
+	attributeName := "someAttr"
+	attributeValue := "someValue"
+	err = SetRelationshipAttributeForAllInstances(kv, deploymentID, nodeAName, "0", attributeName, attributeValue)
+	require.NoError(t, err)
+
+	actualValue, err := GetRelationshipAttributeValueFromRequirement(kv, deploymentID, nodeAName, "1", "0", attributeName)
+	require.NoError(t, err)
+	require.NotNil(t, actualValue)
+	require.Equal(t, attributeValue, actualValue.RawString())
+	actualValue, err = GetRelationshipAttributeValueFromRequirement(kv, deploymentID, nodeAName, "11", "0", attributeName)
+	require.NoError(t, err)
+	require.NotNil(t, actualValue)
+	require.Equal(t, attributeValue, actualValue.RawString())
+
+	// Now we test
+	err = DeleteRelationshipInstance(kv, deploymentID, nodeAName, "1")
+	require.NoError(t, err)
+
+	actualValue, err = GetRelationshipAttributeValueFromRequirement(kv, deploymentID, nodeAName, "1", "0", attributeName)
+	require.NoError(t, err)
+	require.Nil(t, actualValue)
+	actualValue, err = GetRelationshipAttributeValueFromRequirement(kv, deploymentID, nodeAName, "11", "0", attributeName)
+	require.NoError(t, err)
+	require.NotNil(t, actualValue)
+	require.Equal(t, attributeValue, actualValue.RawString())
+
+}

--- a/deployments/testdata/relationship_instances.yaml
+++ b/deployments/testdata/relationship_instances.yaml
@@ -1,0 +1,34 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: TestWf
+  template_version: 0.1.0-SNAPSHOT
+  template_author: admin
+
+description: ""
+
+imports:
+  - normative-types: <yorc-types.yml>
+
+node_types:
+  yorc.test.NodeA:
+    derived_from: tosca.nodes.SoftwareComponent
+    requirements:
+      - connection:
+          capability: tosca.capabilities.Feature
+          relationship: tosca.relationships.ConnectsTo
+          occurrences: [1,1]
+
+topology_template:
+  node_templates:
+    NodeA:
+      type: yorc.test.NodeA
+      requirements:
+        - connectsToNodeBFeature:
+            type_requirement: connection
+            node: NodeB
+            capability: tosca.capabilities.Feature
+            relationship: tosca.relationships.ConnectsTo
+
+    NodeB:
+      type: tosca.nodes.SoftwareComponent

--- a/deployments/workflows.go
+++ b/deployments/workflows.go
@@ -89,6 +89,7 @@ func readWfStep(kv *api.KV, stepKey string, stepName string, wfName string) (*to
 		step.TargetRelationShip = string(kvp.Value)
 	}
 	// Get the step's activities
+	// Appending a final "/" here is not necessary as there is no other keys starting with "activities" prefix
 	activitiesKeys, _, err := kv.List(stepKey+"/activities", nil)
 	if err != nil {
 		return step, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
@@ -181,7 +182,7 @@ func readWfStep(kv *api.KV, stepKey string, stepName string, wfName string) (*to
 // DeleteWorkflow deletes the given workflow from the Consul store
 func DeleteWorkflow(kv *api.KV, deploymentID, workflowName string) error {
 	_, err := kv.DeleteTree(path.Join(consulutil.DeploymentKVPrefix, deploymentID,
-		workflowsPrefix, workflowName), nil)
+		workflowsPrefix, workflowName)+"/", nil)
 	return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 }
 

--- a/events/consul_test.go
+++ b/events/consul_test.go
@@ -75,5 +75,11 @@ func TestRunConsulEventsPackageTests(t *testing.T) {
 		t.Run("TestAttributeValueChange", func(t *testing.T) {
 			testconsulAttributeValueChange(t, kv)
 		})
+		t.Run("TestPurgeDeploymentEvents", func(t *testing.T) {
+			testPurgeDeploymentEvents(t, kv)
+		})
+		t.Run("TestPurgeDeploymentLogs", func(t *testing.T) {
+			testPurgeDeploymentLogs(t, kv)
+		})
 	})
 }

--- a/events/events.go
+++ b/events/events.go
@@ -231,7 +231,7 @@ func StatusEvents(kv *api.KV, deploymentID string, waitIndex uint64, timeout tim
 	var eventsPrefix string
 	if deploymentID != "" {
 		// the returned list of events must correspond to the provided deploymentID
-		eventsPrefix = path.Join(consulutil.EventsPrefix, deploymentID)
+		eventsPrefix = path.Join(consulutil.EventsPrefix, deploymentID) + "/"
 	} else {
 		// the returned list of events must correspond to all the deployments
 		eventsPrefix = path.Join(consulutil.EventsPrefix)
@@ -259,7 +259,7 @@ func LogsEvents(kv *api.KV, deploymentID string, waitIndex uint64, timeout time.
 	var logsPrefix string
 	if deploymentID != "" {
 		// the returned list of logs must correspond to the provided deploymentID
-		logsPrefix = path.Join(consulutil.LogsPrefix, deploymentID)
+		logsPrefix = path.Join(consulutil.LogsPrefix, deploymentID) + "/"
 	} else {
 		// the returned list of logs must correspond to all the deployments
 		logsPrefix = path.Join(consulutil.LogsPrefix)
@@ -306,13 +306,13 @@ func GetLogsEventsIndex(kv *api.KV, deploymentID string) (uint64, error) {
 
 // PurgeDeploymentEvents deletes all events for a given deployment
 func PurgeDeploymentEvents(kv *api.KV, deploymentID string) error {
-	_, err := kv.DeleteTree(path.Join(consulutil.EventsPrefix, deploymentID), nil)
+	_, err := kv.DeleteTree(path.Join(consulutil.EventsPrefix, deploymentID)+"/", nil)
 	return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 }
 
 // PurgeDeploymentLogs deletes all logs for a given deployment
 func PurgeDeploymentLogs(kv *api.KV, deploymentID string) error {
-	_, err := kv.DeleteTree(path.Join(consulutil.LogsPrefix, deploymentID), nil)
+	_, err := kv.DeleteTree(path.Join(consulutil.LogsPrefix, deploymentID)+"/", nil)
 	return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 }
 

--- a/prov/hostspool/consul_test.go
+++ b/prov/hostspool/consul_test.go
@@ -88,6 +88,9 @@ func TestRunConsulHostsPoolPackageTests(t *testing.T) {
 	t.Run("testConsulManagerAllocateShareableCompute", func(t *testing.T) {
 		testConsulManagerAllocateShareableCompute(t, client)
 	})
+	t.Run("testConsulManagerAllocateShareableComputeWithSameAllocationPrefix", func(t *testing.T) {
+		testConsulManagerAllocateShareableComputeWithSameAllocationPrefix(t, client)
+	})
 	t.Run("testConsulManagerApplyWithAllocation", func(t *testing.T) {
 		testConsulManagerApplyWithAllocation(t, client)
 	})

--- a/prov/hostspool/hostspool_mgr_label.go
+++ b/prov/hostspool/hostspool_mgr_label.go
@@ -211,6 +211,7 @@ func (cm *consulManager) GetHostLabels(hostname string) (map[string]string, erro
 	if err != nil {
 		return nil, err
 	}
+	// Appending a final "/" here is not necessary as there is no other keys starting with "labels" prefix
 	kvps, _, err := cm.cc.KV().List(path.Join(consulutil.HostsPoolPrefix, hostname, "labels"), nil)
 	if err != nil {
 		return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)

--- a/prov/monitoring/monitoring_mgr.go
+++ b/prov/monitoring/monitoring_mgr.go
@@ -265,6 +265,7 @@ func (mgr *monitoringMgr) buildHTTPExecution(key string, address string, port in
 		urlPath = string(kvp.Value)
 	}
 
+	// Appending a final "/" here is not necessary as there is no other keys starting with "headers" prefix
 	kvps, _, err := mgr.cc.KV().List(path.Join(key, "headers"), nil)
 	if err != nil {
 		return nil, err
@@ -275,6 +276,7 @@ func (mgr *monitoringMgr) buildHTTPExecution(key string, address string, port in
 			headersMap[path.Base(kvp.Key)] = string(kvp.Value)
 		}
 	}
+	// Appending a final "/" here is not necessary as there is no other keys starting with "tlsClient" prefix
 	kvps, _, err = mgr.cc.KV().List(path.Join(key, "tlsClient"), nil)
 	if err != nil {
 		return nil, err
@@ -346,8 +348,8 @@ func (mgr *monitoringMgr) registerHTTPCheck(deploymentID, nodeName, instance, ip
 	log.Debugf("Register HTTP check with id:%q, iPAddress:%q, port:%d, interval:%d", id, ipAddress, port, interval)
 
 	// Check is registered in a transaction to ensure to be read in its wholeness
-	checkPath := path.Join(consulutil.MonitoringKVPrefix, "checks", id)
-	checkReportPath := path.Join(consulutil.MonitoringKVPrefix, "reports", id)
+	checkPath := path.Join(consulutil.MonitoringKVPrefix, "checks", id) + "/"
+	checkReportPath := path.Join(consulutil.MonitoringKVPrefix, "reports", id) + "/"
 
 	kvps, _, err := mgr.cc.KV().List(checkPath, nil)
 	if err != nil {
@@ -453,8 +455,8 @@ func (mgr *monitoringMgr) flagCheckForRemoval(deploymentID, nodeName, instance s
 // unregisterCheck allows to unregister a check and its related report
 func (mgr *monitoringMgr) unregisterCheck(id string) error {
 	log.Debugf("Removing check with id:%q", id)
-	checkPath := path.Join(consulutil.MonitoringKVPrefix, "checks", id)
-	checkReportPath := path.Join(consulutil.MonitoringKVPrefix, "reports", id)
+	checkPath := path.Join(consulutil.MonitoringKVPrefix, "checks", id) + "/"
+	checkReportPath := path.Join(consulutil.MonitoringKVPrefix, "reports", id) + "/"
 	rmOps := api.KVTxnOps{
 		&api.KVTxnOp{
 			Verb: api.KVDeleteTree,

--- a/prov/monitoring/monitoring_mgr_test.go
+++ b/prov/monitoring/monitoring_mgr_test.go
@@ -125,10 +125,14 @@ func testAddAndRemoveCheck(t *testing.T, client *api.Client) {
 
 	dep := "monitoring5"
 	node := "Compute1"
-	instance := "0"
-	expectedCheck := NewCheck(dep, node, instance)
+	instance1 := "0"
+	instance11 := "02"
+	expectedCheck := NewCheck(dep, node, instance1)
+	NewCheck(dep, node, instance11)
 
-	err := defaultMonManager.registerTCPCheck(dep, node, instance, "1.2.3.4", 22, 1*time.Second)
+	err := defaultMonManager.registerTCPCheck(dep, node, instance1, "1.2.3.4", 22, 1*time.Second)
+	require.Nil(t, err, "Unexpected error while adding check")
+	err = defaultMonManager.registerTCPCheck(dep, node, instance11, "1.2.3.4", 22, 1*time.Second)
 	require.Nil(t, err, "Unexpected error while adding check")
 
 	time.Sleep(2 * time.Second)
@@ -139,7 +143,7 @@ func testAddAndRemoveCheck(t *testing.T, client *api.Client) {
 		return false
 	})
 	require.Nil(t, err, "Unexpected error while getting check reports list")
-	require.Len(t, checkReports, 1, "1 check is expected")
+	require.Len(t, checkReports, 2, "2 checks are expected")
 	require.Equal(t, expectedCheck.Report.DeploymentID, checkReports[0].DeploymentID, "unexpected deploymentID")
 	require.Equal(t, expectedCheck.Report.NodeName, checkReports[0].NodeName, "unexpected node name")
 	require.Equal(t, expectedCheck.Report.Instance, checkReports[0].Instance, "unexpected instance")
@@ -150,7 +154,7 @@ func testAddAndRemoveCheck(t *testing.T, client *api.Client) {
 	require.Nil(t, err, "Unexpected error while node state")
 	require.Equal(t, tosca.NodeStateError, state)
 
-	err = defaultMonManager.flagCheckForRemoval(dep, node, instance)
+	err = defaultMonManager.flagCheckForRemoval(dep, node, instance1)
 	time.Sleep(1 * time.Second)
 	require.Nil(t, err, "Unexpected error while removing check")
 
@@ -162,6 +166,6 @@ func testAddAndRemoveCheck(t *testing.T, client *api.Client) {
 		return false
 	})
 	require.Nil(t, err, "Unexpected error while getting check reports list")
-	require.Len(t, checkReports, 0, "0 check is expected")
-	require.Len(t, defaultMonManager.checks, 0, "0 check is expected in work map")
+	require.Len(t, checkReports, 1, "1 check is expected")
+	require.Len(t, defaultMonManager.checks, 1, "0 check is expected in work map")
 }

--- a/prov/scheduling/scheduler/scheduled_action.go
+++ b/prov/scheduling/scheduler/scheduled_action.go
@@ -147,6 +147,7 @@ func (sca *scheduledAction) updateData() error {
 	}
 	if meta.LastIndex > sca.latestDataIndex {
 		// re-read data
+		// Appending a final "/" here is not necessary as there is no other keys starting with "data" prefix
 		kvps, _, err := sca.kv.List(dataPath, nil)
 		if err != nil {
 			return errors.Wrap(err, consulutil.ConsulGenericErrMsg)

--- a/prov/scheduling/scheduler/scheduler.go
+++ b/prov/scheduling/scheduler/scheduler.go
@@ -47,7 +47,7 @@ type scheduler struct {
 // unregisterAction allows to unregister a scheduled action
 func (sc *scheduler) unregisterAction(id string) error {
 	log.Debugf("Removing scheduled action with id:%q", id)
-	scaPath := path.Join(consulutil.SchedulingKVPrefix, "actions", id)
+	scaPath := path.Join(consulutil.SchedulingKVPrefix, "actions", id) + "/"
 	_, err := sc.cc.KV().DeleteTree(scaPath, nil)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to delete scheduled action with id:%q", id)
@@ -225,7 +225,7 @@ func (sc *scheduler) buildScheduledAction(id string) (*scheduledAction, error) {
 	if kvp != nil && len(kvp.Value) > 0 {
 		sca.latestTaskID = string(kvp.Value)
 	}
-
+	// Appending a final "/" here is not necessary as there is no other keys starting with "data" prefix
 	kvps, _, err := sc.cc.KV().List(path.Join(consulutil.SchedulingKVPrefix, "actions", id, "data"), nil)
 	if err != nil {
 		return nil, err

--- a/server/upgradeschema/upgrade_111.go
+++ b/server/upgradeschema/upgrade_111.go
@@ -51,7 +51,7 @@ func up111RemoveCommonsImports(kv *api.KV, deploymentPrefix string) error {
 	for _, importPrefix := range iKeys {
 		importName := path.Base(importPrefix)
 		if strings.HasPrefix(importName, "<") && strings.HasSuffix(importName, ">") {
-			_, err = kv.DeleteTree(importPrefix, nil)
+			_, err = kv.DeleteTree(importPrefix+"/", nil)
 			if err != nil {
 				return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 			}
@@ -68,7 +68,7 @@ func up111RemoveCommonsTypes(kv *api.KV, commons []string, deploymentPrefix stri
 	for _, tPrefix := range tKeys {
 		if collections.ContainsString(commons, path.Base(tPrefix)) {
 			log.Debugf("\tRemoving type %q from deployment %q", path.Base(tPrefix), path.Base(deploymentPrefix))
-			_, err := kv.DeleteTree(tPrefix, nil)
+			_, err := kv.DeleteTree(tPrefix+"/", nil)
 			if err != nil {
 				return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 			}

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -262,7 +262,7 @@ func CancelTask(kv *api.KV, taskID string) error {
 
 // DeleteTask allows to delete a stored task
 func DeleteTask(kv *api.KV, taskID string) error {
-	_, err := kv.DeleteTree(path.Join(consulutil.TasksPrefix, taskID), nil)
+	_, err := kv.DeleteTree(path.Join(consulutil.TasksPrefix, taskID)+"/", nil)
 	return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 }
 
@@ -318,6 +318,7 @@ func GetTaskData(kv *api.KV, taskID, dataName string) (string, error) {
 // GetAllTaskData returns all registered data for a task
 func GetAllTaskData(kv *api.KV, taskID string) (map[string]string, error) {
 	dataPrefix := path.Join(consulutil.TasksPrefix, taskID, "data")
+	// Appending a final "/" here is not necessary as there is no other keys starting with "data" prefix
 	kvps, _, err := kv.List(dataPrefix, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
@@ -404,7 +405,7 @@ func EmitTaskEventWithContextualLogs(ctx context.Context, kv *api.KV, deployment
 func GetTaskRelatedSteps(kv *api.KV, taskID string) ([]TaskStep, error) {
 	steps := make([]TaskStep, 0)
 
-	kvps, _, err := kv.List(path.Join(consulutil.WorkflowsPrefix, taskID), nil)
+	kvps, _, err := kv.List(path.Join(consulutil.WorkflowsPrefix, taskID)+"/", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 	}

--- a/tasks/workflow/consul_test.go
+++ b/tasks/workflow/consul_test.go
@@ -15,8 +15,12 @@
 package workflow
 
 import (
+	"path"
 	"testing"
 
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+	"github.com/ystia/yorc/v4/helper/consulutil"
 	"github.com/ystia/yorc/v4/log"
 	"github.com/ystia/yorc/v4/testutil"
 )
@@ -33,6 +37,12 @@ func TestRunConsulWorkflowPackageTests(t *testing.T) {
 		t.Run("testRegisterInlineWorkflow", func(t *testing.T) {
 			testRegisterInlineWorkflow(t, srv, client)
 		})
+		t.Run("testDeleteExecutionTreeSamePrefix", func(t *testing.T) {
+			testDeleteExecutionTreeSamePrefix(t, client)
+		})
+		t.Run("testDeleteTaskExecutionSamePrefix", func(t *testing.T) {
+			testDeleteTaskExecutionSamePrefix(t, client)
+		})
 	})
 }
 
@@ -47,4 +57,10 @@ func TestRunConsulWorkerTests(t *testing.T) {
 	t.Run("TestRunPurge", func(t *testing.T) {
 		testRunPurge(t, srv, kv, client)
 	})
+}
+
+func createTaskExecutionKVWithKey(t *testing.T, kv *api.KV, execID, keyName, keyValue string) {
+	t.Helper()
+	_, err := kv.Put(&api.KVPair{Key: path.Join(consulutil.ExecutionsTaskPrefix, execID, keyName), Value: []byte(keyValue)}, nil)
+	require.NoError(t, err)
 }

--- a/tasks/workflow/dispatcher.go
+++ b/tasks/workflow/dispatcher.go
@@ -124,7 +124,7 @@ func getExecutionKeyValue(kv *api.KV, execID, execKey string) (string, error) {
 func (d *Dispatcher) deleteExecutionTree(execID string) {
 	// remove execution kv tree
 	log.Debugf("Remove task execution tree with ID:%q", execID)
-	_, err := d.client.KV().DeleteTree(path.Join(consulutil.ExecutionsTaskPrefix, execID), nil)
+	_, err := d.client.KV().DeleteTree(path.Join(consulutil.ExecutionsTaskPrefix, execID)+"/", nil)
 	if err != nil {
 		log.Printf("Failed to remove execution KV tree with ID:%q due to error:%+v", execID, err)
 		return

--- a/tasks/workflow/dispatcher_test.go
+++ b/tasks/workflow/dispatcher_test.go
@@ -1,0 +1,44 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ystia/yorc/v4/config"
+)
+
+func testDeleteExecutionTreeSamePrefix(t *testing.T, client *api.Client) {
+	shutdownCh := make(chan struct{})
+	defer close(shutdownCh)
+
+	cfg := config.Configuration{WorkersNumber: 1}
+	wg := &sync.WaitGroup{}
+	dispatcher := NewDispatcher(cfg, shutdownCh, client, wg)
+
+	createTaskExecutionKVWithKey(t, client.KV(), "testDeleteExecutionTreeSamePrefixExecID1", "somekey", "val")
+	createTaskExecutionKVWithKey(t, client.KV(), "testDeleteExecutionTreeSamePrefixExecID11", "somekey", "val")
+
+	dispatcher.deleteExecutionTree("testDeleteExecutionTreeSamePrefixExecID1")
+
+	actualValue, err := getExecutionKeyValue(client.KV(), "testDeleteExecutionTreeSamePrefixExecID11", "somekey")
+	assert.NoError(t, err)
+	assert.Equal(t, "val", actualValue)
+
+}

--- a/tasks/workflow/task_execution.go
+++ b/tasks/workflow/task_execution.go
@@ -132,7 +132,7 @@ func (t *taskExecution) notifyEnd() error {
 }
 
 func (t *taskExecution) delete() error {
-	_, err := t.cc.KV().DeleteTree(path.Join(consulutil.ExecutionsTaskPrefix, t.id), nil)
+	_, err := t.cc.KV().DeleteTree(path.Join(consulutil.ExecutionsTaskPrefix, t.id)+"/", nil)
 	return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 }
 

--- a/tasks/workflow/task_execution_test.go
+++ b/tasks/workflow/task_execution_test.go
@@ -1,0 +1,38 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func testDeleteTaskExecutionSamePrefix(t *testing.T, client *api.Client) {
+
+	t1 := &taskExecution{
+		id: "testDeleteTaskExecutionSamePrefixExec1",
+		cc: client,
+	}
+	createTaskExecutionKVWithKey(t, client.KV(), "testDeleteTaskExecutionSamePrefixExec1", "somekey", "val")
+	createTaskExecutionKVWithKey(t, client.KV(), "testDeleteTaskExecutionSamePrefixExec11", "somekey", "val")
+
+	t1.delete()
+
+	actualValue, err := getExecutionKeyValue(client.KV(), "testDeleteTaskExecutionSamePrefixExec11", "somekey")
+	assert.NoError(t, err)
+	assert.Equal(t, "val", actualValue)
+}

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -606,7 +606,7 @@ func (w *worker) runPurge(ctx context.Context, t *taskExecution) error {
 				return err
 			}
 		}
-		_, err = kv.DeleteTree(path.Join(consulutil.WorkflowsPrefix, tid), nil)
+		_, err = kv.DeleteTree(path.Join(consulutil.WorkflowsPrefix, tid)+"/", nil)
 		if err != nil {
 			return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 		}
@@ -628,9 +628,9 @@ func (w *worker) runPurge(ctx context.Context, t *taskExecution) error {
 		return errors.Wrapf(err, "failed to remove deployments artifacts stored on disk: %q", overlayPath)
 	}
 	// Remove from KV this purge tasks
-	_, err = kv.DeleteTree(path.Join(consulutil.DeploymentKVPrefix, t.targetID), nil)
+	err = deployments.DeleteDeployment(t.cc.KV(), t.targetID)
 	if err != nil {
-		return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+		return err
 	}
 	// Now cleanup: mark it as done so nobody will try to run it, clear the processing lock and finally delete the TaskExecution.
 	checkAndSetTaskStatus(ctx, t.cc.KV(), t.targetID, t.taskID, tasks.TaskStatusDONE)

--- a/tasks/workflow/worker_test.go
+++ b/tasks/workflow/worker_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ystia/yorc/v4/config"
 	"github.com/ystia/yorc/v4/helper/consulutil"
 
 	"github.com/hashicorp/consul/api"
@@ -36,8 +37,13 @@ func populateKV(t *testing.T, srv *testutil.TestServer) {
 }
 
 func testRunPurge(t *testing.T, srv *testutil.TestServer, kv *api.KV, client *api.Client) {
-	var myWorker worker
-	myWorker.consulClient = client
+	myWorker := &worker{
+		consulClient: client,
+		cfg: config.Configuration{
+			// Ensure we are not deleting filesystem files elsewhere
+			WorkingDirectory: "./testdata/work/",
+		},
+	}
 	var myTaskExecution taskExecution
 	myTaskExecution.cc = client
 	// This execution corresponds to the purge task


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fixed prefix issues on consul deleteTree & List
There is several fixes in this commit but most of them are very unlikely to happen as per our current usage (for instances when using uuids that can't be prefix of another uuid)

### Description for the changelog

* Having a deployment named as a prefix of another one causes several issues ([GH-504](https://github.com/ystia/yorc/issues/512))

## Applicable Issues

Closes #512 