### PR TITLE
Refactor OpenStack instance network configuration

### DIFF
--- a/prov/terraform/openstack/osinstance_test.go
+++ b/prov/terraform/openstack/osinstance_test.go
@@ -384,9 +384,8 @@ func testComputeNetworkAttributes(t *testing.T, kv *api.KV, srv *testutil.TestSe
 	instance := ComputeInstance{
 		Name: "instanceName",
 	}
-	err := computeNetworkAttributes(context.Background(), opts, networkNodeName, instKey,
-		&instance, outputs)
+	networks, _, err := generateInstanceNetworking(context.Background(), opts, instKey, &instance, outputs)
 	require.NoError(t, err, "Failed to compute network attributes")
-	require.Equal(t, 1, len(instance.Networks), "Expected to have one compute instance network")
-	assert.Equal(t, networkID, instance.Networks[0].UUID, "Wrong network ID")
+	require.Equal(t, 1, len(networks), "Expected to have one compute instance network")
+	assert.Equal(t, networkID, networks[0].UUID, "Wrong network ID")
 }


### PR DESCRIPTION
While I worked through the code of OpenStack instance network configuration I noticed it's pretty inconsistent and confusing, including some weird behaviors and bad style in some areas.

I've started refactoring the configuration of instance networks now. The main goal is to make it more readable and easier to follow.

A side effect will potentially be a change on how `private_network_name` in the yorc config is used. The plan is to only add that network if it's not added explicitly. This could also be reverted to how it worked previously in order to keep this change a pure refactoring one. The refactor will in any case make implementation of this much easier.