### PR TITLE
Fix possible overlap on generated batch wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Yorc support of Kubernetes StatefulSet ([GH-206](https://github.com/ystia/yorc/issues/206))
 
+### BUG FIXES
+
+* Fix possible overlap on generated batch wrappers scripts when submitting several singularity jobs in parallel ([GH-522](https://github.com/ystia/yorc/issues/522))
+
 ## 4.0.0-M4 (September 19, 2019)
 
 ### BUG FIXES
@@ -13,7 +17,7 @@
 * Fixed a bug preventing OpenStack Networks from being created ([GH-515](https://github.com/ystia/yorc/issues/515))
 * Having a deployment named as a prefix of another one causes several issues ([GH-512](https://github.com/ystia/yorc/issues/512))
 * A deployment may disappear from the deployments list while its currently running a purge task ([GH-504](https://github.com/ystia/yorc/issues/504))
-* A4C Logs are displaying stack error when workflow step fails ([GH-460](https://github.com/ystia/yorc/issues/503))
+* A4C Logs are displaying stack error when workflow step fails ([GH-503](https://github.com/ystia/yorc/issues/503))
 * Bootstrap on OpenStack doesn't allow floating IP provisioning ([GH-516](https://github.com/ystia/yorc/issues/516))
 
 ## 4.0.0-M3 (August 30, 2019)

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/addlicense v0.0.0-20190107131845-2e5cf00261bf
 	github.com/google/gofuzz v1.0.0 // indirect
-	github.com/google/uuid v1.1.1 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.3.0 // indirect
 	github.com/goware/urlx v0.3.1
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect

--- a/prov/slurm/execution.go
+++ b/prov/slurm/execution.go
@@ -455,7 +455,7 @@ func (e *executionCommon) wrapCommand(innerCmd string) (string, error) {
 %s
 EOF
 `, pathScript, innerCmd)
-	return fmt.Sprintf("%s%s%ssbatch -D %s%s %s; rm %s", e.addWorkingDirCmd(), e.buildEnvVars(), cat, e.jobInfo.WorkingDir, e.buildJobOpts(), pathScript, pathScript), nil
+	return fmt.Sprintf("%s%s%ssbatch -D %s%s %s; rm -f %s", e.addWorkingDirCmd(), e.buildEnvVars(), cat, e.jobInfo.WorkingDir, e.buildJobOpts(), pathScript, pathScript), nil
 }
 
 func (e *executionCommon) addWorkingDirCmd() string {

--- a/prov/slurm/execution.go
+++ b/prov/slurm/execution.go
@@ -440,6 +440,9 @@ func (e *executionCommon) prepareAndSubmitJob(ctx context.Context) error {
 }
 
 func (e *executionCommon) wrapCommand(innerCmd string) (string, error) {
+	// Generate a random UUID to add it to the sbatch wrapper script name
+	// this will prevent collisions when running several jobs in parallel
+	// see https://github.com/ystia/yorc/issues/522
 	id, err := uuid.NewRandom()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to generate UUID for generated slurm batch script name")
@@ -455,6 +458,7 @@ func (e *executionCommon) wrapCommand(innerCmd string) (string, error) {
 %s
 EOF
 `, pathScript, innerCmd)
+	// Ensure generated script removal after its submission
 	return fmt.Sprintf("%s%s%ssbatch -D %s%s %s; rm -f %s", e.addWorkingDirCmd(), e.buildEnvVars(), cat, e.jobInfo.WorkingDir, e.buildJobOpts(), pathScript, pathScript), nil
 }
 

--- a/prov/slurm/execution_singularity.go
+++ b/prov/slurm/execution_singularity.go
@@ -106,7 +106,11 @@ func (e *executionSingularity) prepareAndSubmitSingularityJob(ctx context.Contex
 	} else {
 		inner = fmt.Sprintf("srun singularity %s run %s %s", debug, cmdOpts, e.imageURI)
 	}
-	return e.submitJob(ctx, e.wrapCommand(inner))
+	cmd, err := e.wrapCommand(inner)
+	if err != nil {
+		return err
+	}
+	return e.submitJob(ctx, cmd)
 }
 
 func (e *executionSingularity) resolveImageURI(ctx context.Context) error {

--- a/prov/slurm/execution_test.go
+++ b/prov/slurm/execution_test.go
@@ -1,0 +1,57 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slurm
+
+import (
+	"regexp"
+	"testing"
+)
+
+func Test_executionCommon_wrapCommand(t *testing.T) {
+	type fields struct {
+		Artifacts map[string]string
+		jobInfo   *jobInfo
+	}
+	type args struct {
+		innerCmd string
+	}
+	tests := []struct {
+		name        string
+		fields      fields
+		args        args
+		wantPattern *regexp.Regexp
+		wantErr     bool
+	}{
+		{"TestBasicGeneration", fields{
+			jobInfo: &jobInfo{Name: "MyJob", Nodes: 1, WorkingDir: "~"}},
+			args{"ping -c 3 1.1.1.1"}, regexp.MustCompile(`cat <<'EOF' > ~/b-[-a-f0-9]+.batch\n#!/bin/bash\n\nping -c 3 1.1.1.1\nEOF\nsbatch -D ~ --job-name='MyJob' --nodes=1 ~/b-[-a-f0-9]+.batch; rm -f ~/b-[-a-f0-9]+.batch`), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &executionCommon{
+				Artifacts: tt.fields.Artifacts,
+				jobInfo:   tt.fields.jobInfo,
+			}
+			got, err := e.wrapCommand(tt.args.innerCmd)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("executionCommon.wrapCommand() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantPattern.MatchString(got) {
+				t.Errorf("executionCommon.wrapCommand() = %v, want %v", got, tt.wantPattern.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fix possible overlap on generated batch wrappers scripts when submitting several jobs in parallel

### What I did / How I did it

Generate a script name with a random UUID.
Now those scripts are deleted after submission, this was not the case up to now.  

### Description for the changelog

* Fix possible overlap on generated batch wrappers scripts when submitting several singularity jobs in parallel ([GH-522](https://github.com/ystia/yorc/issues/522))

## Applicable Issues

Fixes #522 