### PR TITLE
Added support for Action Operator in plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### FEATURES
 
 * Yorc support of Kubernetes StatefulSet ([GH-206](https://github.com/ystia/yorc/issues/206))
+* Add support for asynchronous operations execution on plugins ([GH-525](https://github.com/ystia/yorc/issues/525))
 
 ### BUG FIXES
 

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -75,6 +75,13 @@ an operation executor for any implementation artifact.
 Those executors are typically designed to handle new configuration managers like chef or puppet for
 instance.
 
+Action Operators
+~~~~~~~~~~~~~~~~
+
+Action Operators handle the execution of asynchronous operations.
+These executors are typically designed to handle the monitoring of a job state.
+
+
 Infrastructure Usage Collector
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/plugin/action.go
+++ b/plugin/action.go
@@ -1,0 +1,164 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"context"
+	"net/rpc"
+
+	plugin "github.com/hashicorp/go-plugin"
+	"github.com/pkg/errors"
+
+	"github.com/ystia/yorc/v4/config"
+	"github.com/ystia/yorc/v4/events"
+	"github.com/ystia/yorc/v4/prov"
+)
+
+// ActionOperator is an extension of prov.ActionOperator that expose its supported action types
+type ActionOperator interface {
+	prov.ActionOperator
+	// Returns an array of action types types
+	GetActionTypes() ([]string, error)
+}
+
+// ActionPlugin is public for use by reflexion and should be considered as private to this package.
+// Please do not use it directly.
+type ActionPlugin struct {
+	F           func() prov.ActionOperator
+	ActionTypes []string
+}
+
+// Server is public for use by reflexion and should be considered as private to this package.
+// Please do not use it directly.
+func (p *ActionPlugin) Server(b *plugin.MuxBroker) (interface{}, error) {
+	aes := &ActionOperatorServer{Broker: b, ActionTypes: p.ActionTypes}
+	if p.F != nil {
+		aes.ActionOperator = p.F()
+	} else if len(p.ActionTypes) > 0 {
+		return nil, errors.New("If ActionTypes is defined then you have to defined an ActionFunc")
+	}
+
+	return aes, nil
+}
+
+// Client is public for use by reflexion and should be considered as private to this package.
+// Please do not use it directly.
+func (p *ActionPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+	return &ActionOperatorClient{Broker: b, Client: c}, nil
+}
+
+// ActionOperatorClient is public for use by reflexion and should be considered as private to this package.
+// Please do not use it directly.
+type ActionOperatorClient struct {
+	Broker *plugin.MuxBroker
+	Client *rpc.Client
+}
+
+// ExecAction is public for use by reflexion and should be considered as private to this package.
+// Please do not use it directly.
+func (c *ActionOperatorClient) ExecAction(ctx context.Context, conf config.Configuration, taskID, deploymentID string, action *prov.Action) (bool, error) {
+	lof, ok := events.FromContext(ctx)
+	if !ok {
+		return false, errors.New("Missing contextual log optional fields")
+	}
+	id := c.Broker.NextId()
+	closeChan := make(chan struct{}, 0)
+	defer close(closeChan)
+	go clientMonitorContextCancellation(ctx, closeChan, id, c.Broker)
+
+	var resp ActionOperatorExecOperationResponse
+	args := &ActionOperatorExecOperationArgs{
+		ChannelID:         id,
+		Conf:              conf,
+		TaskID:            taskID,
+		DeploymentID:      deploymentID,
+		Action:            action,
+		LogOptionalFields: lof,
+	}
+	err := c.Client.Call("Plugin.ExecAction", args, &resp)
+	if err != nil {
+		return false, errors.Wrap(err, "Failed to call ExecOperation for plugin")
+	}
+	return resp.Deregister, toError(resp.Error)
+}
+
+// ActionOperatorServer is public for use by reflexion and should be considered as private to this package.
+// Please do not use it directly.
+type ActionOperatorServer struct {
+	Broker         *plugin.MuxBroker
+	ActionOperator prov.ActionOperator
+	ActionTypes    []string
+}
+
+// ActionOperatorExecOperationArgs is public for use by reflexion and should be considered as private to this package.
+// Please do not use it directly.
+type ActionOperatorExecOperationArgs struct {
+	ChannelID         uint32
+	Conf              config.Configuration
+	TaskID            string
+	DeploymentID      string
+	Action            *prov.Action
+	LogOptionalFields events.LogOptionalFields
+}
+
+// ActionOperatorExecOperationResponse is public for use by reflexion and should be considered as private to this package.
+// Please do not use it directly.
+type ActionOperatorExecOperationResponse struct {
+	Deregister bool
+	Error      *RPCError
+}
+
+// ExecAction is public for use by reflexion and should be considered as private to this package.
+// Please do not use it directly.
+func (s *ActionOperatorServer) ExecAction(args *ActionOperatorExecOperationArgs, reply *ActionOperatorExecOperationResponse) error {
+
+	ctx, cancelFunc := context.WithCancel(events.NewContext(context.Background(), args.LogOptionalFields))
+	defer cancelFunc()
+
+	go s.Broker.AcceptAndServe(args.ChannelID, &RPCContextCanceller{CancelFunc: cancelFunc})
+	var resp ActionOperatorExecOperationResponse
+	var err error
+	resp.Deregister, err = s.ActionOperator.ExecAction(ctx, args.Conf, args.TaskID, args.DeploymentID, args.Action)
+	if err != nil {
+		resp.Error = NewRPCError(err)
+	}
+	*reply = resp
+	return nil
+}
+
+// GetActionTypes is public for use by reflexion and should be considered as private to this package.
+// Please do not use it directly.
+func (s *ActionOperatorServer) GetActionTypes(_ interface{}, reply *ActionOperatorGetTypesResponse) error {
+	*reply = ActionOperatorGetTypesResponse{ActionTypes: s.ActionTypes}
+	return nil
+}
+
+// ActionOperatorGetTypesResponse is public for use by reflexion and should be considered as private to this package.
+// Please do not use it directly.
+type ActionOperatorGetTypesResponse struct {
+	ActionTypes []string
+	Error       *RPCError
+}
+
+// GetActionTypes is public for use by reflexion and should be considered as private to this package.
+// Please do not use it directly.
+func (c *ActionOperatorClient) GetActionTypes() ([]string, error) {
+	var resp ActionOperatorGetTypesResponse
+	err := c.Client.Call("Plugin.GetActionTypes", new(interface{}), &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get supported types for plugin")
+	}
+	return resp.ActionTypes, toError(resp.Error)
+}

--- a/plugin/action_test.go
+++ b/plugin/action_test.go
@@ -141,6 +141,19 @@ func TestActionOperatorExecAction(t *testing.T) {
 	assert.Equal(t, lof, mock.lof)
 }
 
+func TestActionOperatorExecActionWrongContext(t *testing.T) {
+	t.Parallel()
+	_, client, plugin, action, _, _ := setupExecActionTestEnv(t)
+	defer client.Close()
+	var wrongContext context.Context
+	_, err := plugin.ExecAction(
+		wrongContext,
+		config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
+		"testTaskID", "testDeploymentID", &action)
+	require.Error(t, err, "Expected an error calling ExecAction with wrong context")
+
+}
+
 func TestActionOperatorExecActionWithFailure(t *testing.T) {
 	t.Parallel()
 	mock, client, plugin, action, _, ctx := setupExecActionTestEnv(t)

--- a/plugin/action_test.go
+++ b/plugin/action_test.go
@@ -1,0 +1,210 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	plugin "github.com/hashicorp/go-plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ystia/yorc/v4/config"
+	"github.com/ystia/yorc/v4/events"
+	"github.com/ystia/yorc/v4/prov"
+)
+
+type mockActionOperator struct {
+	execactionCalled     bool
+	ctx                  context.Context
+	conf                 config.Configuration
+	taskID, deploymentID string
+	action               *prov.Action
+	contextCancelled     bool
+	lof                  events.LogOptionalFields
+}
+
+func (m *mockActionOperator) ExecAction(ctx context.Context, conf config.Configuration, taskID, deploymentID string, action *prov.Action) (deregister bool, err error) {
+
+	m.execactionCalled = true
+	m.ctx = ctx
+	m.conf = conf
+	m.taskID = taskID
+	m.deploymentID = deploymentID
+	m.action = action
+	m.lof, _ = events.FromContext(ctx)
+
+	go func() {
+		<-m.ctx.Done()
+		m.contextCancelled = true
+	}()
+	if m.deploymentID == "TestCancel" {
+		<-m.ctx.Done()
+	}
+	if m.deploymentID == "TestFailure" {
+		return false, NewRPCError(errors.New("a failure occurred during plugin exec operation"))
+	}
+	return true, nil
+}
+
+func createMockActionOperatorClient(t *testing.T) (*mockActionOperator, *plugin.RPCClient) {
+	mock := new(mockActionOperator)
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			ActionPluginName: &ActionPlugin{F: func() prov.ActionOperator {
+				return mock
+			}},
+		},
+		nil)
+	return mock, client
+}
+
+func setupExecActionTestEnv(t *testing.T) (*mockActionOperator, *plugin.RPCClient,
+	prov.ActionOperator, prov.Action, events.LogOptionalFields, context.Context) {
+
+	mock, client := createMockActionOperatorClient(t)
+
+	raw, err := client.Dispense(ActionPluginName)
+	require.Nil(t, err)
+
+	plugin := raw.(prov.ActionOperator)
+	testOperation := prov.Operation{
+		Name:                   "testOperationName",
+		ImplementationArtifact: "tosca.artifacts.Implementation.Bash",
+		RelOp: prov.RelationshipOperation{
+			IsRelationshipOperation: true,
+			RequirementIndex:        "1",
+			TargetNodeName:          "AnotherNode",
+		},
+	}
+	testAsyncOperation := prov.AsyncOperation{
+		DeploymentID: "testDeploymentID",
+		TaskID:       "testTaskID",
+		ExecutionID:  "testExecutionID",
+		WorkflowName: "testWorkflowName",
+		StepName:     "testStepName",
+		NodeName:     "testNodeName",
+		Operation:    testOperation,
+	}
+	testData := map[string]string{
+		"data1": "value1",
+		"data2": "value2",
+	}
+	testAction := prov.Action{
+		ID:             "testActionID",
+		ActionType:     "testActionType",
+		AsyncOperation: testAsyncOperation,
+		Data:           testData,
+	}
+	lof := events.LogOptionalFields{
+		events.WorkFlowID:    "testWF",
+		events.InterfaceName: "action",
+		events.OperationName: "testOperationName",
+	}
+	ctx := events.NewContext(context.Background(), lof)
+
+	return mock, client, plugin, testAction, lof, ctx
+
+}
+func TestActionOperatorExecAction(t *testing.T) {
+	t.Parallel()
+	mock, client, plugin, action, lof, ctx := setupExecActionTestEnv(t)
+	defer client.Close()
+	deregister, err := plugin.ExecAction(
+		ctx,
+		config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
+		"testTaskID", "testDeploymentID", &action)
+	require.NoError(t, err, "Failed to cal plugin ExecAction")
+	require.True(t, mock.execactionCalled)
+	require.Equal(t, "test", mock.conf.Consul.Address)
+	require.Equal(t, "testdc", mock.conf.Consul.Datacenter)
+	require.Equal(t, "testTaskID", mock.taskID)
+	require.Equal(t, "testDeploymentID", mock.deploymentID)
+	require.Equal(t, action, *mock.action)
+	require.True(t, deregister, "Wrong return value for ExecAction")
+	assert.Equal(t, lof, mock.lof)
+}
+
+func TestActionOperatorExecActionWithFailure(t *testing.T) {
+	t.Parallel()
+	mock, client, plugin, action, _, ctx := setupExecActionTestEnv(t)
+	defer client.Close()
+	deregister, err := plugin.ExecAction(
+		ctx,
+		config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
+		"testTaskID", "TestFailure", &action)
+	require.True(t, mock.execactionCalled)
+	require.Error(t, err, "An error was expected during executing plugin operation")
+	require.EqualError(t, err, "a failure occurred during plugin exec operation")
+	require.False(t, deregister, "Wrong return value for ExecAction")
+}
+
+func TestActionOperatorExecActionWithCancel(t *testing.T) {
+	t.Parallel()
+	mock, client := createMockActionOperatorClient(t)
+	defer client.Close()
+
+	raw, err := client.Dispense(ActionPluginName)
+	require.NoError(t, err, "Unexpected error calling client.Dispense() for Action Plugin")
+
+	plugin := raw.(prov.ActionOperator)
+	lof := events.LogOptionalFields{
+		events.WorkFlowID:    "testWF",
+		events.InterfaceName: "delegate",
+		events.OperationName: "myTest",
+	}
+	ctx := events.NewContext(context.Background(), lof)
+	ctx, cancelF := context.WithCancel(ctx)
+	go func() {
+		_, err := plugin.ExecAction(
+			ctx,
+			config.Configuration{Consul: config.Consul{Address: "test", Datacenter: "testdc"}},
+			"testTaskID", "TestCancel", &prov.Action{})
+		require.NoError(t, err)
+	}()
+	cancelF()
+	// Wait for cancellation signal to be dispatched
+	time.Sleep(50 * time.Millisecond)
+	require.True(t, mock.contextCancelled, "Context not cancelled")
+}
+
+func TestActionOperatorGetActionTypes(t *testing.T) {
+	mock := new(mockActionOperator)
+	client, _ := plugin.TestPluginRPCConn(
+		t,
+		map[string]plugin.Plugin{
+			ActionPluginName: &ActionPlugin{
+				F: func() prov.ActionOperator {
+					return mock
+				},
+				ActionTypes: []string{"TestActionType1", "TestActionType2"}},
+		},
+		nil)
+	defer client.Close()
+	raw, err := client.Dispense(ActionPluginName)
+	require.NoError(t, err, "Unexpected error calling client.Dispense() for Action Plugin")
+	plugin := raw.(ActionOperator)
+
+	actionTypes, err := plugin.GetActionTypes()
+	require.NoError(t, err, "Unexpected error calling plugin.GetActionTypes()")
+	require.Len(t, actionTypes, 2)
+	require.Contains(t, actionTypes, "TestActionType1")
+	require.Contains(t, actionTypes, "TestActionType2")
+
+}

--- a/plugin/serve.go
+++ b/plugin/serve.go
@@ -35,6 +35,8 @@ const (
 	ConfigManagerPluginName = "cfgManager"
 	// OperationPluginName is the name of Operation Plugins it could be used as a lookup key in Client.Dispense
 	OperationPluginName = "operation"
+	// ActionPluginName is the name of Action Plugins it could be used as a lookup key in Client.Dispense
+	ActionPluginName = "action"
 	// InfraUsageCollectorPluginName is the name of InfraUsageCollector Plugins it could be used as a lookup key in Client.Dispense
 	InfraUsageCollectorPluginName = "infraUsageCollector"
 )
@@ -55,6 +57,9 @@ type DelegateFunc func() prov.DelegateExecutor
 // OperationFunc is a function that is called when creating a plugin server
 type OperationFunc func() prov.OperationExecutor
 
+// ActionFunc is a function that is called when creating a plugin server
+type ActionFunc func() prov.ActionOperator
+
 // InfraUsageCollectorFunc is a function that is called when creating a plugin server
 type InfraUsageCollectorFunc func() prov.InfraUsageCollector
 
@@ -65,6 +70,8 @@ type ServeOpts struct {
 	Definitions                        map[string][]byte
 	OperationFunc                      OperationFunc
 	OperationSupportedArtifactTypes    []string
+	ActionFunc                         ActionFunc
+	ActionTypes                        []string
 	InfraUsageCollectorFunc            InfraUsageCollectorFunc
 	InfraUsageCollectorSupportedInfras []string
 }
@@ -97,6 +104,7 @@ func getPlugins(opts *ServeOpts) map[string]plugin.Plugin {
 	return map[string]plugin.Plugin{
 		DelegatePluginName:            &DelegatePlugin{F: opts.DelegateFunc, SupportedTypes: opts.DelegateSupportedTypes},
 		OperationPluginName:           &OperationPlugin{F: opts.OperationFunc, SupportedTypes: opts.OperationSupportedArtifactTypes},
+		ActionPluginName:              &ActionPlugin{F: opts.ActionFunc, ActionTypes: opts.ActionTypes},
 		DefinitionsPluginName:         &DefinitionsPlugin{Definitions: opts.Definitions},
 		ConfigManagerPluginName:       &ConfigManagerPlugin{&defaultConfigManager{}},
 		InfraUsageCollectorPluginName: &InfraUsageCollectorPlugin{F: opts.InfraUsageCollectorFunc, SupportedInfras: opts.InfraUsageCollectorSupportedInfras},

--- a/server/plugins.go
+++ b/server/plugins.go
@@ -164,6 +164,24 @@ func (pm *pluginManager) loadPlugins(cfg config.Configuration) error {
 			log.Debugf("%+v", err)
 		}
 
+		// Request the action plugin
+		raw, err = rpcClient.Dispense(plugin.ActionPluginName)
+		if err == nil {
+			actionOperator := raw.(plugin.ActionOperator)
+			actionTypes, err := actionOperator.GetActionTypes()
+			if err != nil {
+				log.Printf("[Warning] Failed to retrieve action types for plugin %q.", pluginID)
+				log.Debugf("%+v", err)
+			}
+			if len(actionTypes) > 0 {
+				log.Debugf("Registering action types %v into registry for plugin %q", actionTypes, pluginID)
+				reg.RegisterActionOperator(actionTypes, actionOperator, pluginID)
+			}
+		} else {
+			log.Printf("[Warning] Can't retrieve action operator from plugin %q: %v. This is likely due to a outdated plugin.", pluginID, err)
+			log.Debugf("%+v", err)
+		}
+
 		// Request the definitions plugin
 		raw, err = rpcClient.Dispense(plugin.DefinitionsPluginName)
 		if err == nil {


### PR DESCRIPTION
# Pull Request description

## Description of the change

Added an extension point action operator to Yorc, to enable plugins to handle the execution of asynchronous operations.

### What I did

`plugin/action.go`
New file defining the plugin ActionOperator interface 
 
`plugin/operation.go`
Implementing ExecAsyncOperation() it calls the plugin ExecAsyncOperation() to return an action and a monitoring time interval

`plugin/serve.go`
Added a new extension point to plugins to b able to defined an Action Operator

`server/plugins.go`
Registering action operator with associated action types

### How to verify it


Bootstrap a Yorc from this Pull Request on OpenStack, then add in its configuration the definition of an infrastructure used by our test plugin (`heappe` infrastructure below):
```YAML
infrastructures:
  openstack:
    auth_url: http://1.2.3.4:5000
    default_security_groups: [test, default]
    password: '{{ secret "/secret/yorc/openstack" "data=password" | print }}'
    private_network_name: private-test
    provisioning_over_fip_allowed: 'False'
    tenant_name: '{{ secret "/secret/yorc/openstack" "data=tenant_name" | print }}'
    user_name: '{{ secret "/secret/yorc/openstack" "data=user_name" | print }}'
  heappe:
    url: http://3.4.5.6:5000
```
Then unzip the test plugin 
[testplugin.zip](https://github.com/ystia/yorc/files/3701820/testplugin.zip) into directory /var/yorc/plugins

Restart Yorc

Upload in Alien4Cloud catalog, data types and node types at https://github.com/laurentganne/yorc-heappe-plugin/blob/master/src/testdata/heappe-types-a4c.yaml
Then upload in Alien4Cloud to topology template at https://github.com/laurentganne/yorc-heappe-plugin/blob/master/src/testdata/topology.yaml

From Alien4Cloud, deploy an application from this template, This will create a Job.
Then select the workflow `run` and launch it, this will submit the job, then wait for its completion.



### Description for the changelog

Add support for asynchronous operations execution on plugins ([GH-525](https://github.com/ystia/yorc/issues/525))

## Applicable Issues

Closes #525 
