### PR TITLE
Fix BadAccess error in deployments.resolveValueAssignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,15 @@
 
 ## UNRELEASED
 
-### BUG FIXES
-
-* Bootstrap wrongly configures on-demand resources on OpenStack ([GH-520](https://github.com/ystia/yorc/issues/520))
-
 ### FEATURES
 
 * Yorc support of Kubernetes StatefulSet ([GH-206](https://github.com/ystia/yorc/issues/206))
 
 ### BUG FIXES
 
+* BadAccess error may be thrown when trying to resolve a TOSCA function end up in error ([GH-526](https://github.com/ystia/yorc/issues/526))
 * Fix possible overlap on generated batch wrappers scripts when submitting several singularity jobs in parallel ([GH-522](https://github.com/ystia/yorc/issues/522))
+* Bootstrap wrongly configures on-demand resources on OpenStack ([GH-520](https://github.com/ystia/yorc/issues/520))
 
 ## 4.0.0-M4 (September 19, 2019)
 

--- a/deployments/resolver.go
+++ b/deployments/resolver.go
@@ -336,7 +336,7 @@ func resolveValueAssignment(kv *api.KV, deploymentID, nodeName, instanceName, re
 	}
 	if valueAssignment == nil {
 		ctx := events.NewContext(context.Background(), events.LogOptionalFields{events.NodeID: nodeName, events.InstanceID: instanceName})
-		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).Registerf("[WARNING] The value assignment %q hasn't be resolved for deployment: %q, node: %q, instance: %q. An empty string is returned instead", valueAssignment, deploymentID, nodeName, instanceName)
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).Registerf("[WARNING] The value assignment %q hasn't be resolved for deployment: %q, node: %q, instance: %q. An empty string is returned instead", va, deploymentID, nodeName, instanceName)
 		valueAssignment = &TOSCAValue{Value: ""}
 	}
 	if fromSecret {


### PR DESCRIPTION
This fixes a BadAccess error by passing the passed valueAssignment to the log call instead of a null pointer.
As the variable is checked for nil two lines above, this is very likely to be a typo.

fixes #526 