### PR TITLE
Fix missing service ip injection for k8s jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### BUG FIXES
 
+* Kubernetes Jobs do not support Service IP injection ([GH-528](https://github.com/ystia/yorc/issues/528))
 * BadAccess error may be thrown when trying to resolve a TOSCA function end up in error ([GH-526](https://github.com/ystia/yorc/issues/526))
 * Fix possible overlap on generated batch wrappers scripts when submitting several singularity jobs in parallel ([GH-522](https://github.com/ystia/yorc/issues/522))
 * Bootstrap wrongly configures on-demand resources on OpenStack ([GH-520](https://github.com/ystia/yorc/issues/520))

--- a/prov/kubernetes/controller_test.go
+++ b/prov/kubernetes/controller_test.go
@@ -133,7 +133,7 @@ func testK8sObjectsTest(t *testing.T, kv *api.KV) {
 			}
 
 			if tt.nodeName == "node-deploy" {
-				replacedRSpec, err := e.replaceServiceIPInDeploymentSpec(ctx, k8s.clientset, "dep-id", "{}")
+				replacedRSpec, err := replaceServiceIPInResourceSpec(ctx, kv, k8s.clientset, "dep-id", tt.nodeName, "", "{}")
 				// TODO test replaceRSpec value
 				require.Nil(t, err)
 				require.NotNil(t, replacedRSpec)

--- a/prov/kubernetes/execution_job.go
+++ b/prov/kubernetes/execution_job.go
@@ -46,7 +46,7 @@ func (e *execution) executeAsync(ctx context.Context, cfg config.Configuration, 
 		return nil, 0, err
 	}
 
-	job, err := getJob(e.kv, e.deploymentID, e.nodeName)
+	job, err := getJob(ctx, e.kv, clientset, e.deploymentID, e.nodeName)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -72,7 +72,7 @@ func (e *execution) executeAsync(ctx context.Context, cfg config.Configuration, 
 }
 
 func (e *execution) submitJob(ctx context.Context, clientset kubernetes.Interface) error {
-	job, err := getJob(e.kv, e.deploymentID, e.nodeName)
+	job, err := getJob(ctx, e.kv, clientset, e.deploymentID, e.nodeName)
 	if err != nil {
 		return err
 	}
@@ -122,7 +122,7 @@ func (e *execution) cancelJob(ctx context.Context, clientset kubernetes.Interfac
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelDEBUG, e.deploymentID).Registerf(
 			"k8s job cancellation called from a dedicated \"cancel\" workflow. JobID retrieved from node %q attribute. This may cause issues if multiple workflows are running in parallel. Prefer using a workflow cancellation.", e.nodeName)
 	}
-	job, err := getJob(e.kv, e.deploymentID, e.nodeName)
+	job, err := getJob(ctx, e.kv, clientset, e.deploymentID, e.nodeName)
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete job for node %q", e.nodeName)
 	}

--- a/prov/kubernetes/k8s_utils.go
+++ b/prov/kubernetes/k8s_utils.go
@@ -268,33 +268,35 @@ func getJob(ctx context.Context, kv *api.KV, clientset kubernetes.Interface, dep
 	return job, nil
 }
 
-func replaceServiceIPInResourceSpec(ctx context.Context, kv *api.KV, clientset kubernetes.Interface, deploymentID, nodeName, namespace, rSpec string) (string, error) {
-	serviceDepsLookups, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "service_dependency_lookups")
-	if err != nil {
-		return rSpec, err
-	}
-	if serviceDepsLookups != nil && serviceDepsLookups.RawString() != "" {
-		for _, srvLookup := range strings.Split(serviceDepsLookups.RawString(), ",") {
-			srvLookupArgs := strings.SplitN(srvLookup, ":", 2)
-			srvPlaceholder := "${" + srvLookupArgs[0] + "}"
-			if !strings.Contains(rSpec, srvPlaceholder) || len(srvLookupArgs) != 2 {
-				// No need to make an API call if there is no placeholder to replace
-				// Alien set services lookups on all nodes
-				continue
-			}
-			srvName := srvLookupArgs[1]
-			srv, err := clientset.CoreV1().Services(namespace).Get(srvName, metav1.GetOptions{})
-			if err != nil {
-				return rSpec, errors.Wrapf(err, "failed to retrieve ClusterIP for service %q", srvName)
-			}
-			if srv.Spec.ClusterIP == "" || srv.Spec.ClusterIP == "None" {
-				// Not supported
-				return rSpec, errors.Wrapf(err, "failed to retrieve ClusterIP for service %q, (value=%q)", srvName, srv.Spec.ClusterIP)
-			}
-			rSpec = strings.Replace(rSpec, srvPlaceholder, srv.Spec.ClusterIP, -1)
+func replaceServiceDepLookups(ctx context.Context, clientset kubernetes.Interface, namespace, rSpec, serviceDepsLookups string) (string, error) {
+	for _, srvLookup := range strings.Split(serviceDepsLookups, ",") {
+		srvLookupArgs := strings.SplitN(srvLookup, ":", 2)
+		srvPlaceholder := "${" + srvLookupArgs[0] + "}"
+		if !strings.Contains(rSpec, srvPlaceholder) || len(srvLookupArgs) != 2 {
+			// No need to make an API call if there is no placeholder to replace
+			// Alien set services lookups on all nodes
+			continue
 		}
+		srvName := srvLookupArgs[1]
+		srv, err := clientset.CoreV1().Services(namespace).Get(srvName, metav1.GetOptions{})
+		if err != nil {
+			return rSpec, errors.Wrapf(err, "failed to retrieve ClusterIP for service %q", srvName)
+		}
+		if srv.Spec.ClusterIP == "" || srv.Spec.ClusterIP == "None" {
+			// Not supported
+			return rSpec, errors.Errorf("failed to retrieve ClusterIP for service %q, (value=%q)", srvName, srv.Spec.ClusterIP)
+		}
+		rSpec = strings.Replace(rSpec, srvPlaceholder, srv.Spec.ClusterIP, -1)
 	}
 	return rSpec, nil
+}
+
+func replaceServiceIPInResourceSpec(ctx context.Context, kv *api.KV, clientset kubernetes.Interface, deploymentID, nodeName, namespace, rSpec string) (string, error) {
+	serviceDepsLookups, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "service_dependency_lookups")
+	if err != nil || serviceDepsLookups == nil || serviceDepsLookups.RawString() == "" {
+		return rSpec, err
+	}
+	return replaceServiceDepLookups(ctx, clientset, namespace, rSpec, serviceDepsLookups.RawString())
 }
 
 //Return the external IP of a given node

--- a/prov/kubernetes/k8s_utils.go
+++ b/prov/kubernetes/k8s_utils.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/ystia/yorc/v4/deployments"
 	"github.com/ystia/yorc/v4/events"
-	"github.com/ystia/yorc/v4/log"
 )
 
 func isDeploymentFailed(deployment *v1beta1.Deployment) (bool, string) {
@@ -236,7 +235,7 @@ type k8sJob struct {
 	namespaceProvided bool
 }
 
-func getJob(kv *api.KV, deploymentID, nodeName string) (*k8sJob, error) {
+func getJob(ctx context.Context, kv *api.KV, clientset kubernetes.Interface, deploymentID, nodeName string) (*k8sJob, error) {
 	rSpec, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "resource_spec")
 	if err != nil {
 		return nil, err
@@ -245,10 +244,20 @@ func getJob(kv *api.KV, deploymentID, nodeName string) (*k8sJob, error) {
 	if rSpec == nil {
 		return nil, errors.Errorf("no resource_spec defined for node %q", nodeName)
 	}
+	rSpecString := rSpec.RawString()
 	jobRepr := &batchv1.Job{}
-	log.Debugf("jobspec: %v", rSpec.RawString())
+	// Unmarshal JSON to k8s data structs just to retrieve namespace
+	if err = json.Unmarshal([]byte(rSpecString), jobRepr); err != nil {
+		return nil, errors.Wrap(err, "The resource-spec JSON unmarshaling failed")
+	}
+	namespace, _ := getNamespace(deploymentID, jobRepr.ObjectMeta)
+	rSpecString, err = replaceServiceIPInResourceSpec(ctx, kv, clientset, deploymentID, nodeName, namespace, rSpecString)
+	if err != nil {
+		return nil, err
+	}
+
 	// Unmarshal JSON to k8s data structs
-	if err = json.Unmarshal([]byte(rSpec.RawString()), jobRepr); err != nil {
+	if err = json.Unmarshal([]byte(rSpecString), jobRepr); err != nil {
 		return nil, errors.Wrap(err, "The resource-spec JSON unmarshaling failed")
 	}
 
@@ -257,6 +266,35 @@ func getJob(kv *api.KV, deploymentID, nodeName string) (*k8sJob, error) {
 	job.namespace, job.namespaceProvided = getNamespace(deploymentID, objectMeta)
 
 	return job, nil
+}
+
+func replaceServiceIPInResourceSpec(ctx context.Context, kv *api.KV, clientset kubernetes.Interface, deploymentID, nodeName, namespace, rSpec string) (string, error) {
+	serviceDepsLookups, err := deployments.GetNodePropertyValue(kv, deploymentID, nodeName, "service_dependency_lookups")
+	if err != nil {
+		return rSpec, err
+	}
+	if serviceDepsLookups != nil && serviceDepsLookups.RawString() != "" {
+		for _, srvLookup := range strings.Split(serviceDepsLookups.RawString(), ",") {
+			srvLookupArgs := strings.SplitN(srvLookup, ":", 2)
+			srvPlaceholder := "${" + srvLookupArgs[0] + "}"
+			if !strings.Contains(rSpec, srvPlaceholder) || len(srvLookupArgs) != 2 {
+				// No need to make an API call if there is no placeholder to replace
+				// Alien set services lookups on all nodes
+				continue
+			}
+			srvName := srvLookupArgs[1]
+			srv, err := clientset.CoreV1().Services(namespace).Get(srvName, metav1.GetOptions{})
+			if err != nil {
+				return rSpec, errors.Wrapf(err, "failed to retrieve ClusterIP for service %q", srvName)
+			}
+			if srv.Spec.ClusterIP == "" || srv.Spec.ClusterIP == "None" {
+				// Not supported
+				return rSpec, errors.Wrapf(err, "failed to retrieve ClusterIP for service %q, (value=%q)", srvName, srv.Spec.ClusterIP)
+			}
+			rSpec = strings.Replace(rSpec, srvPlaceholder, srv.Spec.ClusterIP, -1)
+		}
+	}
+	return rSpec, nil
 }
 
 //Return the external IP of a given node

--- a/prov/kubernetes/supported_resource.go
+++ b/prov/kubernetes/supported_resource.go
@@ -140,7 +140,7 @@ func (yorcDep *yorcK8sDeployment) unmarshalResource(ctx context.Context, e *exec
 		return err
 	}
 	ns, _ := getNamespace(e.deploymentID, yorcDep.ObjectMeta)
-	rSpec, err = e.replaceServiceIPInDeploymentSpec(ctx, clientset, ns, rSpec)
+	rSpec, err = replaceServiceIPInResourceSpec(ctx, e.kv, clientset, e.deploymentID, e.nodeName, ns, rSpec)
 	if err != nil {
 		return err
 	}
@@ -236,6 +236,16 @@ func (yorcDep *yorcK8sDeployment) streamLogs(ctx context.Context, deploymentID s
 	----------------------------------------------
 */
 func (yorcSts *yorcK8sStatefulSet) unmarshalResource(ctx context.Context, e *execution, deploymentID string, clientset kubernetes.Interface, rSpec string) error {
+	err := json.Unmarshal([]byte(rSpec), &yorcSts)
+	if err != nil {
+		return err
+	}
+	ns, _ := getNamespace(e.deploymentID, yorcSts.ObjectMeta)
+	rSpec, err = replaceServiceIPInResourceSpec(ctx, e.kv, clientset, e.deploymentID, e.nodeName, ns, rSpec)
+	if err != nil {
+		return err
+	}
+
 	return json.Unmarshal([]byte(rSpec), &yorcSts)
 }
 


### PR DESCRIPTION
# Pull Request description

## Description of the change

Resolve Service IP placeholders within the Job specifications

### How to verify it

Try to run a Job that connects to a service

### Description for the changelog

* Kubernetes Jobs do not support Service IP injection ([GH-528](https://github.com/ystia/yorc/issues/528))

## Applicable Issues

Fixes #528 