### PR TITLE
Tech/gh 531 upgrade schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### ENHANCEMENTS
+
+Add Consul DB migration of hostspools due to locations modifications ([GH-531(https://github.com/ystia/yorc/issues/531))
+
 ## 4.0.0-M5 (October 11, 2019)
 
 ### BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### ENHANCEMENTS
 
-Add Consul DB migration of hostspools due to locations modifications ([GH-531(https://github.com/ystia/yorc/issues/531))
+Add Consul DB migration of hostspools due to locations modifications ([GH-531](https://github.com/ystia/yorc/issues/531))
 
 ## 4.0.0-M5 (October 11, 2019)
 

--- a/helper/consulutil/schema.go
+++ b/helper/consulutil/schema.go
@@ -15,7 +15,7 @@
 package consulutil
 
 // YorcSchemaVersion is the version of the data schema in Consul understood by this version of Yorc
-const YorcSchemaVersion = "1.1.1"
+const YorcSchemaVersion = "1.1.2"
 
 // YorcSchemaVersionPath is the path where  the data schema version is stored in Consul
 const YorcSchemaVersionPath = yorcPrefix + "/database_schema_version"

--- a/prov/kubernetes/execution_test.go
+++ b/prov/kubernetes/execution_test.go
@@ -341,7 +341,7 @@ func Test_execution_scale_resources(t *testing.T) {
 			}
 		}(testRes)
 	}
-	if waitTimeout(&wg, 30 * time.Second) {
+	if waitTimeout(&wg, 30*time.Second) {
 		t.Fatal("timeout exceeded")
 	} else {
 		fmt.Println("Execution ok")
@@ -395,7 +395,7 @@ func Test_execution_del_resources(t *testing.T) {
 			}
 		}(testRes)
 	}
-	if waitTimeout(&wg, 30 * time.Second) {
+	if waitTimeout(&wg, 30*time.Second) {
 		t.Fatal("timeout exceeded")
 	} else {
 		fmt.Println("Execution ok")
@@ -455,7 +455,7 @@ func Test_execution_create_resource(t *testing.T) {
 			}
 		}(testRes)
 	}
-	if waitTimeout(&wg, 30 * time.Second) {
+	if waitTimeout(&wg, 30*time.Second) {
 		t.Fatal("timeout exceeded")
 	} else {
 		fmt.Println("Execution ok")

--- a/server/consul.go
+++ b/server/consul.go
@@ -32,6 +32,7 @@ var upgradeToMap = map[string]func(*api.KV, <-chan struct{}) error{
 	"1.0.0": upgradeschema.UpgradeFromPre31,
 	"1.1.0": upgradeschema.UpgradeTo110,
 	"1.1.1": upgradeschema.UpgradeTo111,
+	"1.1.2": upgradeschema.UpgradeTo112,
 }
 
 var orderedUpgradesVersions []semver.Version

--- a/server/upgradeschema/upgrade_112.go
+++ b/server/upgradeschema/upgrade_112.go
@@ -1,0 +1,60 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgradeschema
+
+import (
+	"github.com/hashicorp/consul/api"
+	"github.com/pkg/errors"
+	"github.com/ystia/yorc/v4/helper/consulutil"
+	"github.com/ystia/yorc/v4/log"
+	"path"
+	"strings"
+)
+
+// UpgradeTo112 allows to upgrade Consul schema from 1.1.1 to 1.1.2
+func UpgradeTo112(kv *api.KV, leaderch <-chan struct{}) error {
+	log.Print("Upgrading to database version 1.1.12..")
+	return up112UpgradeHostsPoolStorage(kv)
+}
+
+func up112UpgradeHostsPoolStorage(kv *api.KV) error {
+	log.Print("\tUpgrade hosts pool storage...")
+
+	locationDefaultName := "hostsPool111"
+	kvps, _, err := kv.List(consulutil.HostsPoolPrefix+"/", nil)
+	if err != nil {
+		return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+	}
+
+	if len(kvps) > 0 {
+		log.Debugf("Found a hosts pool: it will be associated to location name:%q. This name can be changed with the CLI/REST API locations.", locationDefaultName)
+	}
+	for _, kvp := range kvps {
+		if kvp != nil && len(kvp.Value) > 0 {
+			newKey := path.Join(consulutil.HostsPoolPrefix, locationDefaultName, strings.TrimPrefix(kvp.Key, consulutil.HostsPoolPrefix))
+			log.Debugf("Create new key: %q", newKey)
+			err = consulutil.StoreConsulKey(newKey, kvp.Value)
+			if err != nil {
+				return errors.Wrapf(err, "failed to store hosts pool key with location:%q", locationDefaultName)
+			}
+		}
+		log.Debugf("Delete old key: %q", kvp.Key)
+		_, err = kv.Delete(kvp.Key, nil)
+		if err != nil {
+			return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did
Define a default location name for the legacy hosts pool: "hostsPool111"
Move hostspool storage in Consul from _yorc/hostspool to -yorc/hosts_pool/hostsPool111

### How to verify it
Create a hosts pool with yorc in version before 4.0.0-M5
Upgrade Yorc with this PR version
Check hosts pool storage path in Consul is in _yorc/hosts_pool/hostsPool111/....

## Applicable Issues
#531 