### PR TITLE
Feature/gh 533 update infra collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### ENHANCEMENTS
 
-Add Consul DB migration of hostspools due to locations modifications ([GH-531](https://github.com/ystia/yorc/issues/531))
+* Add Consul DB migration of hostspools due to locations modifications ([GH-531](https://github.com/ystia/yorc/issues/531))
+* Update Infrastructure collector feature to handle locations ([GH-533](https://github.com/ystia/yorc/issues/533))
 
 ## 4.0.0-M5 (October 11, 2019)
 

--- a/plugin/infra_usage_collector.go
+++ b/plugin/infra_usage_collector.go
@@ -64,7 +64,7 @@ type InfraUsageCollectorClient struct {
 
 // GetUsageInfo is public for use by reflexion and should be considered as private to this package.
 // Please do not use it directly.
-func (c *InfraUsageCollectorClient) GetUsageInfo(ctx context.Context, cfg config.Configuration, taskID, infraName string) (map[string]interface{}, error) {
+func (c *InfraUsageCollectorClient) GetUsageInfo(ctx context.Context, cfg config.Configuration, taskID, infraName, locationName string) (map[string]interface{}, error) {
 	lof, ok := events.FromContext(ctx)
 	if !ok {
 		return nil, errors.New("Missing contextual log optionnal fields")
@@ -81,6 +81,7 @@ func (c *InfraUsageCollectorClient) GetUsageInfo(ctx context.Context, cfg config
 		Conf:              cfg,
 		TaskID:            taskID,
 		InfraName:         infraName,
+		LocationName:      locationName,
 		LogOptionalFields: lof,
 	}
 	err := c.Client.Call("Plugin.GetUsageInfo", args, &resp)
@@ -117,6 +118,7 @@ type InfraUsageCollectorGetUsageInfoArgs struct {
 	Conf              config.Configuration
 	TaskID            string
 	InfraName         string
+	LocationName      string
 	LogOptionalFields events.LogOptionalFields
 }
 
@@ -141,7 +143,7 @@ func (s *InfraUsageCollectorServer) GetUsageInfo(args *InfraUsageCollectorGetUsa
 	defer cancelFunc()
 
 	go s.Broker.AcceptAndServe(args.ChannelID, &RPCContextCanceller{CancelFunc: cancelFunc})
-	usageInfo, err := s.InfraUsageCollector.GetUsageInfo(ctx, args.Conf, args.TaskID, args.InfraName)
+	usageInfo, err := s.InfraUsageCollector.GetUsageInfo(ctx, args.Conf, args.TaskID, args.InfraName, args.LocationName)
 
 	var resp InfraUsageCollectorGetUsageInfoResponse
 	resp.UsageInfo = usageInfo

--- a/prov/kubernetes/execution_test.go
+++ b/prov/kubernetes/execution_test.go
@@ -341,7 +341,7 @@ func Test_execution_scale_resources(t *testing.T) {
 			}
 		}(testRes)
 	}
-	if waitTimeout(&wg, 30 * time.Second) {
+	if waitTimeout(&wg, 30*time.Second) {
 		t.Fatal("timeout exceeded")
 	} else {
 		fmt.Println("Execution ok")
@@ -395,7 +395,7 @@ func Test_execution_del_resources(t *testing.T) {
 			}
 		}(testRes)
 	}
-	if waitTimeout(&wg, 30 * time.Second) {
+	if waitTimeout(&wg, 30*time.Second) {
 		t.Fatal("timeout exceeded")
 	} else {
 		fmt.Println("Execution ok")
@@ -455,7 +455,7 @@ func Test_execution_create_resource(t *testing.T) {
 			}
 		}(testRes)
 	}
-	if waitTimeout(&wg, 30 * time.Second) {
+	if waitTimeout(&wg, 30*time.Second) {
 		t.Fatal("timeout exceeded")
 	} else {
 		fmt.Println("Execution ok")

--- a/prov/provisioner.go
+++ b/prov/provisioner.go
@@ -88,11 +88,11 @@ type OperationExecutor interface {
 	ExecAsyncOperation(ctx context.Context, conf config.Configuration, taskID, deploymentID, nodeName string, operation Operation, stepName string) (*Action, time.Duration, error)
 }
 
-// InfraUsageCollector is the interface for collecting information about infrastructure usage
+// InfraUsageCollector is the interface for collecting information about infrastructure usage for a defined location
 //
-// GetUsageInfo returns data about infrastructure usage for defined infrastructure
+// GetUsageInfo returns data about infrastructure usage for defined infrastructure and location
 type InfraUsageCollector interface {
-	GetUsageInfo(ctx context.Context, cfg config.Configuration, taskID, infraName string) (map[string]interface{}, error)
+	GetUsageInfo(ctx context.Context, cfg config.Configuration, taskID, infraName, locationName string) (map[string]interface{}, error)
 }
 
 // Action represents an executable action

--- a/rest/consul_test.go
+++ b/rest/consul_test.go
@@ -79,5 +79,8 @@ func TestRunConsulRestPackageTests(t *testing.T) {
 		t.Run("testPostInfraUsageHandler", func(t *testing.T) {
 			testPostInfraUsageHandler(t, client, srv)
 		})
+		t.Run("testTaskQueryHandlers", func(t *testing.T) {
+			testTaskQueryHandlers(t, client, srv)
+		})
 	})
 }

--- a/rest/consul_test.go
+++ b/rest/consul_test.go
@@ -76,5 +76,8 @@ func TestRunConsulRestPackageTests(t *testing.T) {
 		t.Run("testDeploymentHandlers", func(t *testing.T) {
 			testDeploymentHandlers(t, client, srv)
 		})
+		t.Run("testPostInfraUsageHandler", func(t *testing.T) {
+			testPostInfraUsageHandler(t, client, srv)
+		})
 	})
 }

--- a/rest/http.go
+++ b/rest/http.go
@@ -180,9 +180,9 @@ func (s *Server) registerHandlers() {
 	s.router.Get("/registry/vaults", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listVaultsBuilderHandler))
 	s.router.Get("/registry/infra_usage_collectors", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listInfraHandler))
 
-	s.router.Post("/infra_usage/:infraName", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.postInfraUsageHandler))
-	s.router.Get("/infra_usage/:infraName/tasks/:taskId", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getTaskQueryHandler))
-	s.router.Delete("/infra_usage/:infraName/tasks/:taskId", commonHandlers.ThenFunc(s.deleteTaskQueryHandler))
+	s.router.Post("/infra_usage/:infraName/:locationName", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.postInfraUsageHandler))
+	s.router.Get("/infra_usage/:infraName/:locationName/tasks/:taskId", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getTaskQueryHandler))
+	s.router.Delete("/infra_usage/:infraName/:locationName/tasks/:taskId", commonHandlers.ThenFunc(s.deleteTaskQueryHandler))
 	s.router.Get("/infra_usage", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listTaskQueryHandler))
 
 	s.router.Put("/hosts_pool/:location/:host", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.newHostInPool))

--- a/rest/http_api.md
+++ b/rest/http_api.md
@@ -1171,25 +1171,25 @@ Content-Type: application/json
 
 ### Execute a query to retrieve infrastructure usage for a defined infrastructure usage collector <a name="infra-usage-query-exec"></a>
 
-Submit a query for a given infrastructure to retrieve usage information.
+Submit a query for a given infrastructure and a given location to retrieve usage information.
 'Content-Type' header should be set to 'application/json'.
 
-`POST    /infra_usage/<infra_name>`
+`POST    /infra_usage/<infra_name>/<location_name>`
 
 **Response**:
 
 ```HTTP
 HTTP/1.1 202 Accepted
 Content-Length: 0
-Location: /infra_usage/<infra_name>/tasks/<task_id>
+Location: /infra_usage/<infra_name>/<location_name>/tasks/<task_id>
 ```
 
 ### Get query information <a name="task-info"></a>
 
-Retrieve information about a task for a given infrastructure usage collector.
+Retrieve information about a task for a given infrastructure usage collector on a given location.
 'Accept' header should be set to 'application/json'.
 
-`GET    /infra_usage/<infra_name>/tasks/<taskId>`
+`GET    /infra_usage/<infra_name>/<location_name>/tasks/<taskId>`
 
 **Response**:
 
@@ -1250,7 +1250,7 @@ Content-Type: application/json
 Delete an existing query. The task should be in status "DONE" or "FAILED" to be deleted otherwise an HTTP 400
 (Bad request) error is returned.
 
-`DELETE    /infra_usage/<infra_name>/tasks/<taskId>`
+`DELETE    /infra_usage/<infra_name>/<location_name>/tasks/<taskId>`
 
 **Response**:
 
@@ -1275,12 +1275,12 @@ Content-Type: application/json
 "tasks": [
   {
     "rel": "task",
-    "href": "/infra_usage/slurm/tasks/b0d91e99-1970-4fc0-8cc2-2cb4f5007e27",
+    "href": "/infra_usage/slurm/myLocationOne/tasks/b0d91e99-1970-4fc0-8cc2-2cb4f5007e27",
     "type": "application/json"
   },
   {
     "rel": "task",
-    "href": "/infra_usage/slurm/tasks/b4f9682d-7020-45dc-b2db-d0c84b8c30e2",
+    "href": "/infra_usage/slurm/myLocationOne/tasks/b4f9682d-7020-45dc-b2db-d0c84b8c30e2",
     "type": "application/json"
   }
  ]

--- a/rest/infra_usage_test.go
+++ b/rest/infra_usage_test.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	"context"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/testutil"
+	"github.com/stretchr/testify/require"
+	"github.com/ystia/yorc/v4/config"
+	"github.com/ystia/yorc/v4/events"
+	"github.com/ystia/yorc/v4/registry"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type mockInfraUsageCollector struct {
+	getUsageInfoCalled bool
+	ctx                context.Context
+	conf               config.Configuration
+	taskID             string
+	infraName          string
+	locationName       string
+	contextCancelled   bool
+	lof                events.LogOptionalFields
+}
+
+func (m *mockInfraUsageCollector) GetUsageInfo(ctx context.Context, conf config.Configuration, taskID, infraName, locationName string) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func testPostInfraUsageHandler(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	t.Parallel()
+
+	mock := new(mockInfraUsageCollector)
+	var reg = registry.GetRegistry()
+	reg.RegisterInfraUsageCollector("myInfraName", mock, "mock")
+
+	req := httptest.NewRequest("POST", "/infra_usage/myInfraName/myLocationName", nil)
+	req.Header.Add("Content-Type", "application/json")
+	resp := newTestHTTPRouter(client, req)
+
+	require.NotNil(t, resp, "unexpected nil response")
+	require.Equal(t, http.StatusAccepted, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusAccepted)
+
+	require.Equal(t, 1, len(resp.Header["Location"]), "unexpected len(resp.Header[\"Location\"] equal to 1")
+	require.Equal(t, true, strings.HasPrefix(resp.Header["Location"][0], "/infra_usage/myInfraName/myLocationName/tasks"), "unexpected location header prefix")
+}

--- a/rest/task_query.go
+++ b/rest/task_query.go
@@ -137,7 +137,21 @@ func (s *Server) listTaskQueryHandler(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		target := split[1]
-		link := newAtomLink(LinkRelTask, path.Join("/", query, target, "tasks", taskID))
+
+		locationName, err := tasks.GetTaskData(kv, taskID, "locationName")
+		if err != nil {
+			if !tasks.IsTaskDataNotFoundError(err) {
+				log.Panic(err)
+			}
+		}
+
+		var link AtomLink
+		if locationName != "" {
+			link = newAtomLink(LinkRelTask, path.Join("/", query, target, locationName, "tasks", taskID))
+		} else {
+			link = newAtomLink(LinkRelTask, path.Join("/", query, target, "tasks", taskID))
+		}
+
 		tasksCol.Tasks[ind] = link
 	}
 	encodeJSONResponse(w, r, tasksCol)

--- a/rest/task_query_test.go
+++ b/rest/task_query_test.go
@@ -1,0 +1,98 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/testutil"
+	"github.com/stretchr/testify/require"
+	"github.com/ystia/yorc/v4/helper/consulutil"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testTaskQueryHandlers(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	t.Run("testTaskQueryHandlers", func(t *testing.T) {
+		testGetTaskQueryHandler(t, client, srv)
+	})
+	t.Run("testDeleteTaskQueryHandler", func(t *testing.T) {
+		testDeleteTaskQueryHandler(t, client, srv)
+	})
+	t.Run("testListTaskQueryHandler", func(t *testing.T) {
+		testListTaskQueryHandler(t, client, srv)
+	})
+}
+
+func testGetTaskQueryHandler(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	srv.PopulateKV(t, map[string][]byte{
+		consulutil.TasksPrefix + "/task123/type":              []byte("7"),
+		consulutil.TasksPrefix + "/task123/targetId":          []byte("infra_usage:slurm"),
+		consulutil.TasksPrefix + "/task123/status":            []byte("2"),
+		consulutil.TasksPrefix + "/task123/resultSet":         []byte("{\"result\": \"success\"}"),
+		consulutil.TasksPrefix + "/task123/data/locationName": []byte("slurm"),
+	})
+
+	req := httptest.NewRequest("GET", "/infra_usage/myInfraName/myLocationName/tasks/task123", nil)
+	req.Header.Add("Accept", "application/json")
+	resp := newTestHTTPRouter(client, req)
+
+	require.NotNil(t, resp, "unexpected nil response")
+	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusOK)
+
+	_, err := ioutil.ReadAll(resp.Body)
+	require.Nil(t, err, "unexpected error reading body")
+	client.KV().DeleteTree(consulutil.TasksPrefix, nil)
+}
+
+func testDeleteTaskQueryHandler(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	srv.PopulateKV(t, map[string][]byte{
+		consulutil.TasksPrefix + "/task123/type":              []byte("7"),
+		consulutil.TasksPrefix + "/task123/targetId":          []byte("infra_usage:slurm"),
+		consulutil.TasksPrefix + "/task123/status":            []byte("2"),
+		consulutil.TasksPrefix + "/task123/resultSet":         []byte("{\"result\": \"success\"}"),
+		consulutil.TasksPrefix + "/task123/data/locationName": []byte("slurm"),
+	})
+
+	req := httptest.NewRequest("DELETE", "/infra_usage/myInfraName/myLocationName/tasks/task123", nil)
+	resp := newTestHTTPRouter(client, req)
+
+	require.NotNil(t, resp, "unexpected nil response")
+	require.Equal(t, http.StatusAccepted, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusAccepted)
+
+	client.KV().DeleteTree(consulutil.TasksPrefix, nil)
+}
+
+func testListTaskQueryHandler(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	srv.PopulateKV(t, map[string][]byte{
+		consulutil.TasksPrefix + "/task123/type":              []byte("7"),
+		consulutil.TasksPrefix + "/task123/targetId":          []byte("infra_usage:slurm"),
+		consulutil.TasksPrefix + "/task123/status":            []byte("2"),
+		consulutil.TasksPrefix + "/task123/resultSet":         []byte("{\"result\": \"success\"}"),
+		consulutil.TasksPrefix + "/task123/data/locationName": []byte("slurm"),
+	})
+
+	req := httptest.NewRequest("GET", "/infra_usage", nil)
+	req.Header.Add("Accept", "application/json")
+	resp := newTestHTTPRouter(client, req)
+
+	require.NotNil(t, resp, "unexpected nil response")
+	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusOK)
+
+	_, err := ioutil.ReadAll(resp.Body)
+	require.Nil(t, err, "unexpected error reading body")
+	client.KV().DeleteTree(consulutil.TasksPrefix, nil)
+}

--- a/rest/task_query_test.go
+++ b/rest/task_query_test.go
@@ -35,6 +35,18 @@ func testTaskQueryHandlers(t *testing.T, client *api.Client, srv *testutil.TestS
 	t.Run("testListTaskQueryHandler", func(t *testing.T) {
 		testListTaskQueryHandler(t, client, srv)
 	})
+	t.Run("testDeleteTaskQueryHandlerWithTaskNotFound", func(t *testing.T) {
+		testDeleteTaskQueryHandlerWithTaskNotFound(t, client, srv)
+	})
+	t.Run("testGetTaskQueryHandlerWithTaskNotFound", func(t *testing.T) {
+		testGetTaskQueryHandlerWithTaskNotFound(t, client, srv)
+	})
+	t.Run("testDeleteTaskQueryHandlerWithRunningTask", func(t *testing.T) {
+		testDeleteTaskQueryHandlerWithRunningTask(t, client, srv)
+	})
+	t.Run("testDeleteTaskQueryHandlerWithNotTaskQuery", func(t *testing.T) {
+		testDeleteTaskQueryHandlerWithNotTaskQuery(t, client, srv)
+	})
 }
 
 func testGetTaskQueryHandler(t *testing.T, client *api.Client, srv *testutil.TestServer) {
@@ -58,6 +70,15 @@ func testGetTaskQueryHandler(t *testing.T, client *api.Client, srv *testutil.Tes
 	client.KV().DeleteTree(consulutil.TasksPrefix, nil)
 }
 
+func testGetTaskQueryHandlerWithTaskNotFound(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	req := httptest.NewRequest("GET", "/infra_usage/myInfraName/myLocationName/tasks/taskNotFound", nil)
+	req.Header.Add("Accept", "application/json")
+	resp := newTestHTTPRouter(client, req)
+
+	require.NotNil(t, resp, "unexpected nil response")
+	require.Equal(t, http.StatusNotFound, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusNotFound)
+}
+
 func testDeleteTaskQueryHandler(t *testing.T, client *api.Client, srv *testutil.TestServer) {
 	srv.PopulateKV(t, map[string][]byte{
 		consulutil.TasksPrefix + "/task123/type":              []byte("7"),
@@ -76,6 +97,50 @@ func testDeleteTaskQueryHandler(t *testing.T, client *api.Client, srv *testutil.
 	client.KV().DeleteTree(consulutil.TasksPrefix, nil)
 }
 
+func testDeleteTaskQueryHandlerWithRunningTask(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	srv.PopulateKV(t, map[string][]byte{
+		consulutil.TasksPrefix + "/task123/type":              []byte("7"),
+		consulutil.TasksPrefix + "/task123/targetId":          []byte("infra_usage:slurm"),
+		consulutil.TasksPrefix + "/task123/status":            []byte("1"),
+		consulutil.TasksPrefix + "/task123/resultSet":         []byte("{\"result\": \"success\"}"),
+		consulutil.TasksPrefix + "/task123/data/locationName": []byte("slurm"),
+	})
+
+	req := httptest.NewRequest("DELETE", "/infra_usage/myInfraName/myLocationName/tasks/task123", nil)
+	resp := newTestHTTPRouter(client, req)
+
+	require.NotNil(t, resp, "unexpected nil response")
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusBadRequest)
+
+	client.KV().DeleteTree(consulutil.TasksPrefix, nil)
+}
+
+func testDeleteTaskQueryHandlerWithNotTaskQuery(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	srv.PopulateKV(t, map[string][]byte{
+		consulutil.TasksPrefix + "/task123/type":              []byte("2"),
+		consulutil.TasksPrefix + "/task123/targetId":          []byte("infra_usage:slurm"),
+		consulutil.TasksPrefix + "/task123/status":            []byte("2"),
+		consulutil.TasksPrefix + "/task123/resultSet":         []byte("{\"result\": \"success\"}"),
+		consulutil.TasksPrefix + "/task123/data/locationName": []byte("slurm"),
+	})
+
+	req := httptest.NewRequest("DELETE", "/infra_usage/myInfraName/myLocationName/tasks/task123", nil)
+	resp := newTestHTTPRouter(client, req)
+
+	require.NotNil(t, resp, "unexpected nil response")
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusBadRequest)
+
+	client.KV().DeleteTree(consulutil.TasksPrefix, nil)
+}
+
+func testDeleteTaskQueryHandlerWithTaskNotFound(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	req := httptest.NewRequest("DELETE", "/infra_usage/myInfraName/myLocationName/tasks/taskNotFound", nil)
+	resp := newTestHTTPRouter(client, req)
+
+	require.NotNil(t, resp, "unexpected nil response")
+	require.Equal(t, http.StatusNotFound, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusNotFound)
+}
+
 func testListTaskQueryHandler(t *testing.T, client *api.Client, srv *testutil.TestServer) {
 	srv.PopulateKV(t, map[string][]byte{
 		consulutil.TasksPrefix + "/task123/type":              []byte("7"),
@@ -83,6 +148,16 @@ func testListTaskQueryHandler(t *testing.T, client *api.Client, srv *testutil.Te
 		consulutil.TasksPrefix + "/task123/status":            []byte("2"),
 		consulutil.TasksPrefix + "/task123/resultSet":         []byte("{\"result\": \"success\"}"),
 		consulutil.TasksPrefix + "/task123/data/locationName": []byte("slurm"),
+
+		consulutil.TasksPrefix + "/task124/type":              []byte("7"),
+		consulutil.TasksPrefix + "/task124/targetId":          []byte("infra_usage:slurm"),
+		consulutil.TasksPrefix + "/task124/status":            []byte("2"),
+		consulutil.TasksPrefix + "/task124/resultSet":         []byte("{\"result\": \"success\"}"),
+
+		consulutil.TasksPrefix + "/task125/type":              []byte("7"),
+		consulutil.TasksPrefix + "/task125/targetId":          []byte("bad format"),
+		consulutil.TasksPrefix + "/task125/status":            []byte("2"),
+		consulutil.TasksPrefix + "/task125/resultSet":         []byte("{\"result\": \"success\"}"),
 	})
 
 	req := httptest.NewRequest("GET", "/infra_usage", nil)

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -507,7 +507,12 @@ func (w *worker) runQuery(ctx context.Context, t *taskExecution) error {
 		if err != nil {
 			return err
 		}
-		res, err := collector.GetUsageInfo(ctx, w.cfg, t.taskID, target)
+
+		locationName, err := tasks.GetTaskData(w.consulClient.KV(), t.taskID, "locationName")
+		if err != nil {
+			return err
+		}
+		res, err := collector.GetUsageInfo(ctx, w.cfg, t.taskID, target, locationName)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Pull Request description

## Description of the change
Adapt collector interface to retrieve information from a specified infrastructure with defined locetion

### What I did
- Update GetUsageInfo method
- Update RPC's InfraUsageCollectorClient and InfraUsageCollectorServer to pass locationName argument.
- Update tests
- Update REST API infra_usage collectors to handle location
- Update REST doc

### How to verify it
This PR can be verified with related PRs on yorc-alien4cloud-collector-plugin and yorc-collector-plugin

## Applicable Issues
#533 