### PR TITLE
Added support of inline sbatch options & source env file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Add Consul DB migration of hostspools due to locations modifications ([GH-531](https://github.com/ystia/yorc/issues/531))
 * Allow to provide inline configuration options for generated sbatch scripts ([GH-537](https://github.com/ystia/yorc/issues/537))
+* Optionally source an environment file before submitting slurm jobs ([GH-541](https://github.com/ystia/yorc/issues/541))
 * Update Infrastructure collector feature to handle locations ([GH-533](https://github.com/ystia/yorc/issues/533))
 
 ### BUG FIXES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The support of locations in Yorc (issue [GH-478](https://github.com/ystia/yorc/i
 It introduces breaking changes in Yorc configuration as described below.
 
 It is not anymore possible to define infrastructure properties through:
+
 * environment variables, like `YORC_INFRA_OPENSTACK_AUTH_URL`
 * yorc server command flags, like `--infrastructure_openstack_auth_url`.
 
@@ -87,20 +88,19 @@ But the CLI commands have now a mandatory argument to provide the location name:
 For example, this command was executed in previous Yorc version to create/update a Hosts Pool from a file:
 
 ```bash
-$ yorc hp apply myhostspool.yaml
+yorc hp apply myhostspool.yaml
 ```
 
 It is now:
 
 ```bash
-$ yorc hp apply -l myLocation myhostspool.yaml
+yorc hp apply -l myLocation myhostspool.yaml
 ```
 
 See Yorc documentation for additional details:
+
 * section [configuration](https://yorc.readthedocs.io/en/latest/configuration.html)
 * section on [CLI commands related to Hosts pool](https://yorc.readthedocs.io/en/latest/cli.html#cli-commands-related-to-hosts-pool)
-
-
 
 ### FEATURES
 
@@ -109,7 +109,7 @@ See Yorc documentation for additional details:
 
 ### ENHANCEMENTS
 
-* Locations concept in Yorc ([GH-478(https://github.com/ystia/yorc/issues/478))
+* Locations concept in Yorc ([GH-478](https://github.com/ystia/yorc/issues/478))
 
 ### BUG FIXES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### ENHANCEMENTS
 
-Add Consul DB migration of hostspools due to locations modifications ([GH-531](https://github.com/ystia/yorc/issues/531))
+* Add Consul DB migration of hostspools due to locations modifications ([GH-531](https://github.com/ystia/yorc/issues/531))
+* Allow to provide inline configuration options for generated sbatch scripts ([GH-537](https://github.com/ystia/yorc/issues/537))
 
 ### BUG FIXES
 
@@ -17,7 +18,7 @@ Add Consul DB migration of hostspools due to locations modifications ([GH-531](h
 The support of locations in Yorc (issue [GH-478](https://github.com/ystia/yorc/issues/478)), provides the ability to create several locations of a given infrastructure type (Openstack, Google Cloud, AWS, SLURM, Hosts Pool).
 
 It introduces breaking changes in Yorc configuration as described below.
- 
+
 It is not anymore possible to define infrastructure properties through:
 * environment variables, like `YORC_INFRA_OPENSTACK_AUTH_URL`
 * yorc server command flags, like `--infrastructure_openstack_auth_url`.
@@ -90,7 +91,7 @@ $ yorc hp apply myhostspool.yaml
 ```
 
 It is now:
- 
+
 ```bash
 $ yorc hp apply -l myLocation myhostspool.yaml
 ```

--- a/build/bootstrap-pr.sh
+++ b/build/bootstrap-pr.sh
@@ -27,7 +27,7 @@ function help () {
 
         -e: Yorc Engine PR number, defaults to develop if not provided
 
-        -p: Yorc a4c Plugin PR number, defaults to develop if not provided
+        -a: alternative Alien4Cloud download url
 
         -v: a Yorc bootstrap values file (see https://yorc.readthedocs.io/en/latest/bootstrap.html#bootstrapping-the-setup-using-a-configuration-file)
 
@@ -70,17 +70,13 @@ function getYorcURLFromPart () {
     getURLFromPart "$1" 'yorc-[0-9].*?.tgz'
 }
 
-function getYorcPluginURLFromPart () {
-    getURLFromPart "$1" 'alien4cloud-yorc-plugin-[0-9].*?.zip'
-}
-
 while getopts ":yv:e:p:" opt; do
   case $opt in
     v)
       VALUES_FILE=(--values "${OPTARG}")
       ;;
-    p)
-      PLUGIN_PR=${OPTARG}
+    a)
+      A4C_URL=${OPTARG}
       ;;
     e)
       ENGINE_PR=${OPTARG}
@@ -115,20 +111,17 @@ fi
 export YORC_DOWNLOAD_URL
 
 
-if [[ -n "${PLUGIN_PR}" ]] ; then
-    YORC_PLUGIN_DOWNLOAD_URL=$(getYorcPluginURLFromPart "https://ystia.jfrog.io/ystia/yorc-a4c-plugin-bin-dev-local/ystia/yorc-a4c-plugin/dist/PR-${PLUGIN_PR}")
+if [[ -n "${A4C_URL}" ]] ; then
+    YORC_ALIEN4CLOUD_DOWNLOAD_URL="${A4C_URL}"
+    extra_args="--alien4cloud_download_url=${YORC_ALIEN4CLOUD_DOWNLOAD_URL}"
 fi
 
-if [[ -z "${YORC_PLUGIN_DOWNLOAD_URL}" ]] ; then
-    confirmOrExit "PR number not provided or not found on on Artifactory for Yorc A4C Plugin, would you like to use develop"
-    YORC_PLUGIN_DOWNLOAD_URL=$(getYorcPluginURLFromPart "https://ystia.jfrog.io/ystia/yorc-a4c-plugin-bin-dev-local/ystia/yorc-a4c-plugin/dist/develop")
-fi
+export YORC_ALIEN4CLOUD_DOWNLOAD_URL
 
-export YORC_PLUGIN_DOWNLOAD_URL
 
 echo "Downloading ${YORC_DOWNLOAD_URL} please be patient..."
 curl "${YORC_DOWNLOAD_URL}" -o work/yorc.tgz
 
 tar xzvf work/yorc.tgz -C work
 
-./work/yorc bootstrap "${VALUES_FILE[@]}" --yorc_download_url "${YORC_DOWNLOAD_URL}" --yorc_plugin_download_url "${YORC_PLUGIN_DOWNLOAD_URL}"
+./work/yorc bootstrap "${VALUES_FILE[@]}" --yorc_download_url "${YORC_DOWNLOAD_URL}" "${extra_args}"

--- a/data/tosca/yorc-slurm-types.yml
+++ b/data/tosca/yorc-slurm-types.yml
@@ -90,6 +90,14 @@ data_types:
         required: false
         entry_schema:
           type: string
+      in_script_options:
+        type: list
+        description: |
+          List of options to be passed to sbatch as inline batch script options.
+          To be valid each element should start with a dash '#' character.
+        required: false
+        entry_schema:
+          type: string
 
 capability_types:
   yorc.capabilities.slurm.Endpoint:

--- a/data/tosca/yorc-slurm-types.yml
+++ b/data/tosca/yorc-slurm-types.yml
@@ -69,6 +69,8 @@ data_types:
         entry_schema:
           type: string
 
+# This type is backed by tosca.datatypes.SlurmExecutionOptions if modifying something here it should be reported
+# to tosca.datatypes.SlurmExecutionOptions.
   yorc.datatypes.slurm.ExecutionOptions:
     derived_from: tosca.datatypes.Root
     properties:
@@ -168,6 +170,12 @@ node_types:
           Time interval duration used for job monitoring as "5s" or "300ms"
           Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
         required: false
+      environment_file:
+        type: string
+        required: false
+        description: >
+          If specified and present on the client node the given file will be sourced before submitting the job.
+          This is useful when user-specific variables are required.
       credentials:
         type: tosca.datatypes.Credential
         description: >

--- a/helper/sshutil/mock.go
+++ b/helper/sshutil/mock.go
@@ -16,7 +16,7 @@ package sshutil
 
 import "io"
 
-// MockSSHSession allows to mock an SSH Client
+// MockSSHClient allows to mock an SSH Client
 type MockSSHClient struct {
 	MockRunCommand func(string) (string, error)
 	MockCopyFile   func(source io.Reader, remotePath string, permissions string) error
@@ -30,7 +30,7 @@ func (s *MockSSHClient) RunCommand(cmd string) (string, error) {
 	return "", nil
 }
 
-// RunCommand to mock a command ran via SSH
+// CopyFile to mock a file copy via SSH
 func (s *MockSSHClient) CopyFile(source io.Reader, remotePath string, permissions string) error {
 	if s.MockCopyFile != nil {
 		return s.MockCopyFile(source, remotePath, permissions)

--- a/helper/sshutil/mock.go
+++ b/helper/sshutil/mock.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sshutil
+
+import "io"
+
+// MockSSHSession allows to mock an SSH Client
+type MockSSHClient struct {
+	MockRunCommand func(string) (string, error)
+	MockCopyFile   func(source io.Reader, remotePath string, permissions string) error
+}
+
+// RunCommand to mock a command ran via SSH
+func (s *MockSSHClient) RunCommand(cmd string) (string, error) {
+	if s.MockRunCommand != nil {
+		return s.MockRunCommand(cmd)
+	}
+	return "", nil
+}
+
+// RunCommand to mock a command ran via SSH
+func (s *MockSSHClient) CopyFile(source io.Reader, remotePath string, permissions string) error {
+	if s.MockCopyFile != nil {
+		return s.MockCopyFile(source, remotePath, permissions)
+	}
+	return nil
+}

--- a/helper/sshutil/mock_test.go
+++ b/helper/sshutil/mock_test.go
@@ -1,0 +1,93 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sshutil
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+func TestMockSSHClient_RunCommand(t *testing.T) {
+
+	type args struct {
+		cmd string
+	}
+	tests := []struct {
+		name           string
+		MockRunCommand func(string) (string, error)
+		args           args
+		want           string
+		wantErr        bool
+	}{
+		{"MockWithNilFn", nil, args{""}, "", false},
+		{"MockWithFn", func(cmd string) (string, error) {
+			if cmd == "fail" {
+				return "", errors.New("expected error")
+			}
+			return "ok", nil
+		}, args{"fail"}, "", true},
+		{"MockWithFn", func(cmd string) (string, error) {
+			if cmd == "fail" {
+				return "", errors.New("expected error")
+			}
+			return "ok", nil
+		}, args{""}, "ok", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &MockSSHClient{
+				MockRunCommand: tt.MockRunCommand,
+			}
+			got, err := s.RunCommand(tt.args.cmd)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MockSSHClient.RunCommand() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("MockSSHClient.RunCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMockSSHClient_CopyFile(t *testing.T) {
+	type args struct {
+		source      io.Reader
+		remotePath  string
+		permissions string
+	}
+	tests := []struct {
+		name         string
+		MockCopyFile func(source io.Reader, remotePath string, permissions string) error
+		args         args
+		wantErr      bool
+	}{
+		{"MockWithNilFn", nil, args{nil, "", ""}, false},
+		{"MockWithFn", func(source io.Reader, remotePath string, permissions string) error {
+			return errors.New("expected error")
+		}, args{nil, "", ""}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &MockSSHClient{
+				MockCopyFile: tt.MockCopyFile,
+			}
+			if err := s.CopyFile(tt.args.source, tt.args.remotePath, tt.args.permissions); (err != nil) != tt.wantErr {
+				t.Errorf("MockSSHClient.CopyFile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/helper/sshutil/sshutil.go
+++ b/helper/sshutil/sshutil.go
@@ -40,6 +40,7 @@ import (
 // Client is interface allowing running command
 type Client interface {
 	RunCommand(string) (string, error)
+	CopyFile(source io.Reader, remotePath string, permissions string) error
 }
 
 // TODO(loicalbertin) sshSession and SSHSessionWrapper may be merged

--- a/prov/hostspool/hostspool_mgr_test.go
+++ b/prov/hostspool/hostspool_mgr_test.go
@@ -61,20 +61,16 @@ WSPb8a8DvmtjA0/IyWLtRhiKDPo0ultXa3DHINOC2+sZ5qJpsycNaqV4ObcmCJCc
 h5pSY3nqKgmTiTW5EGnhLxUnEmS0MMvVT59ldx2pZhzgDyxYWO09
 -----END RSA PRIVATE KEY-----`
 
-type mockSSHClient struct {
-	config *ssh.ClientConfig
-}
-
-func (m *mockSSHClient) RunCommand(string) (string, error) {
-	if m.config != nil && m.config.User == "fail" {
-		return "", errors.Errorf("Failed to connect")
-	}
-
-	return "ok", nil
-}
-
 var mockSSHClientFactory = func(config *ssh.ClientConfig, conn Connection) sshutil.Client {
-	return &mockSSHClient{config}
+	return &sshutil.MockSSHClient{
+		MockRunCommand: func(string) (string, error) {
+			if config != nil && config.User == "fail" {
+				return "", errors.Errorf("Failed to connect")
+			}
+
+			return "ok", nil
+		},
+	}
 }
 
 func cleanupHostsPool(t *testing.T, cc *api.Client) {

--- a/prov/slurm/consul_test.go
+++ b/prov/slurm/consul_test.go
@@ -77,5 +77,8 @@ func TestRunConsulSlurmPackageTests(t *testing.T) {
 		t.Run("ExecutionCommonBuildJobInfo", func(t *testing.T) {
 			testExecutionCommonBuildJobInfo(t, kv)
 		})
+		t.Run("ExecutionCommonPrepareAndSubmitJob", func(t *testing.T) {
+			testExecutionCommonPrepareAndSubmitJob(t, kv)
+		})
 	})
 }

--- a/prov/slurm/consul_test.go
+++ b/prov/slurm/consul_test.go
@@ -74,5 +74,8 @@ func TestRunConsulSlurmPackageTests(t *testing.T) {
 		t.Run("executorTest", func(t *testing.T) {
 			testExecutor(t, srv, kv, cfg)
 		})
+		t.Run("ExecutionCommonBuildJobInfo", func(t *testing.T) {
+			testExecutionCommonBuildJobInfo(t, kv)
+		})
 	})
 }

--- a/prov/slurm/execution.go
+++ b/prov/slurm/execution.go
@@ -75,7 +75,7 @@ type executionCommon struct {
 	locationProps  config.DynamicMap
 	deploymentID   string
 	taskID         string
-	client         *sshutil.SSHClient
+	client         sshutil.Client
 	NodeName       string
 	operation      prov.Operation
 	NodeType       string

--- a/prov/slurm/execution_singularity.go
+++ b/prov/slurm/execution_singularity.go
@@ -101,8 +101,8 @@ func (e *executionSingularity) prepareAndSubmitSingularityJob(ctx context.Contex
 		debug = "-d -v"
 	}
 	cmdOpts := strings.Join(e.commandOptions, " ")
-	if e.jobInfo.Command != "" {
-		inner = fmt.Sprintf("srun singularity %s exec %s %s %s %s", debug, cmdOpts, e.imageURI, e.jobInfo.Command, quoteArgs(e.jobInfo.Args))
+	if e.jobInfo.ExecutionOptions.Command != "" {
+		inner = fmt.Sprintf("srun singularity %s exec %s %s %s %s", debug, cmdOpts, e.imageURI, e.jobInfo.ExecutionOptions.Command, quoteArgs(e.jobInfo.ExecutionOptions.Args))
 	} else {
 		inner = fmt.Sprintf("srun singularity %s run %s %s", debug, cmdOpts, e.imageURI)
 	}

--- a/prov/slurm/execution_test.go
+++ b/prov/slurm/execution_test.go
@@ -15,9 +15,20 @@
 package slurm
 
 import (
+	"context"
 	"regexp"
 	"testing"
+	"time"
 
+	"github.com/ystia/yorc/v4/deployments"
+	"github.com/ystia/yorc/v4/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/ystia/yorc/v4/config"
+	"github.com/ystia/yorc/v4/prov/operations"
 	"github.com/ystia/yorc/v4/tosca/datatypes"
 )
 
@@ -42,6 +53,9 @@ func Test_executionCommon_wrapCommand(t *testing.T) {
 		{"TestWithInlineOptsGeneration", fields{
 			jobInfo: &jobInfo{Name: "MyJob", Nodes: 1, WorkingDir: "~", ExecutionOptions: datatypes.SlurmExecutionOptions{InScriptOptions: []string{"#BB ddd", "not dash prefixed so will not appear", "#another one"}}}},
 			args{"ping -c 3 1.1.1.1"}, regexp.MustCompile(`cat <<'EOF' > ~/b-[-a-f0-9]+.batch\n#!/bin/bash\n#BB ddd\n#another one\n\nping -c 3 1.1.1.1\nEOF\nsbatch -D ~ --job-name='MyJob' --nodes=1 ~/b-[-a-f0-9]+.batch; rm -f ~/b-[-a-f0-9]+.batch`), false},
+		{"TestWithSourceEnvFile", fields{
+			jobInfo: &jobInfo{Name: "MyJob", Nodes: 1, WorkingDir: "~", EnvFile: "~/.bash_profile"}},
+			args{"ping -c 3 1.1.1.1"}, regexp.MustCompile(`\[ -f ~/.bash_profile \] && \{ source ~/.bash_profile ; \} ;cat <<'EOF' > ~/b-[-a-f0-9]+.batch\n#!/bin/bash\n\nping -c 3 1.1.1.1\nEOF\nsbatch -D ~ --job-name='MyJob' --nodes=1 ~/b-[-a-f0-9]+.batch; rm -f ~/b-[-a-f0-9]+.batch`), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -56,6 +70,56 @@ func Test_executionCommon_wrapCommand(t *testing.T) {
 			}
 			if !tt.wantPattern.MatchString(got) {
 				t.Errorf("executionCommon.wrapCommand() = %v, want %v", got, tt.wantPattern.String())
+			}
+		})
+	}
+}
+
+func testExecutionCommonBuildJobInfo(t *testing.T, kv *api.KV) {
+
+	deploymentID := testutil.BuildDeploymentID(t)
+	ctx := context.Background()
+	err := deployments.StoreDeploymentDefinition(ctx, kv, deploymentID, "testdata/simple_job.yaml")
+	require.NoError(t, err)
+
+	type fields struct {
+		locationProps config.DynamicMap
+		deploymentID  string
+		NodeName      string
+		EnvInputs     []*operations.EnvInput
+		Primary       string
+		isSingularity bool
+	}
+
+	tests := []struct {
+		name            string
+		fields          fields
+		wantErr         bool
+		expectedJobInfo jobInfo
+	}{
+		{"CheckDefaultValues", fields{config.DynamicMap{}, deploymentID, "ClassificationJobUnit_Singularity", make([]*operations.EnvInput, 0), "primary", false}, false,
+			jobInfo{Name: deploymentID, Tasks: 1, Nodes: 1, MonitoringTimeInterval: 5 * time.Second, Inputs: make(map[string]string), WorkingDir: home}},
+		{"ChecklocationPropertiesValues", fields{config.DynamicMap{"default_job_name": "myjobname", "job_monitoring_time_interval": "1s"}, deploymentID, "ClassificationJobUnit_Singularity", make([]*operations.EnvInput, 0), "primary", false}, false,
+			jobInfo{Name: "myjobname", Tasks: 1, Nodes: 1, MonitoringTimeInterval: time.Second, Inputs: make(map[string]string), WorkingDir: home}},
+		{"CheckErrorIfNoCommandAndPrimary", fields{config.DynamicMap{}, deploymentID, "ClassificationJobUnit_Singularity", make([]*operations.EnvInput, 0), "", false}, true, jobInfo{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &executionCommon{
+				kv:            kv,
+				locationProps: tt.fields.locationProps,
+				deploymentID:  tt.fields.deploymentID,
+				NodeName:      tt.fields.NodeName,
+				EnvInputs:     tt.fields.EnvInputs,
+				Primary:       tt.fields.Primary,
+				isSingularity: tt.fields.isSingularity,
+			}
+			err := e.buildJobInfo(ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("executionCommon.buildJobInfo() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil {
+				assert.Equal(t, tt.expectedJobInfo, *e.jobInfo)
 			}
 		})
 	}

--- a/prov/slurm/execution_test.go
+++ b/prov/slurm/execution_test.go
@@ -17,6 +17,8 @@ package slurm
 import (
 	"regexp"
 	"testing"
+
+	"github.com/ystia/yorc/v4/tosca/datatypes"
 )
 
 func Test_executionCommon_wrapCommand(t *testing.T) {
@@ -37,6 +39,9 @@ func Test_executionCommon_wrapCommand(t *testing.T) {
 		{"TestBasicGeneration", fields{
 			jobInfo: &jobInfo{Name: "MyJob", Nodes: 1, WorkingDir: "~"}},
 			args{"ping -c 3 1.1.1.1"}, regexp.MustCompile(`cat <<'EOF' > ~/b-[-a-f0-9]+.batch\n#!/bin/bash\n\nping -c 3 1.1.1.1\nEOF\nsbatch -D ~ --job-name='MyJob' --nodes=1 ~/b-[-a-f0-9]+.batch; rm -f ~/b-[-a-f0-9]+.batch`), false},
+		{"TestWithInlineOptsGeneration", fields{
+			jobInfo: &jobInfo{Name: "MyJob", Nodes: 1, WorkingDir: "~", ExecutionOptions: datatypes.SlurmExecutionOptions{InScriptOptions: []string{"#BB ddd", "not dash prefixed so will not appear", "#another one"}}}},
+			args{"ping -c 3 1.1.1.1"}, regexp.MustCompile(`cat <<'EOF' > ~/b-[-a-f0-9]+.batch\n#!/bin/bash\n#BB ddd\n#another one\n\nping -c 3 1.1.1.1\nEOF\nsbatch -D ~ --job-name='MyJob' --nodes=1 ~/b-[-a-f0-9]+.batch; rm -f ~/b-[-a-f0-9]+.batch`), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/prov/slurm/helper.go
+++ b/prov/slurm/helper.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ystia/yorc/v4/tosca/datatypes"
 )
 
-const reSbatch = `^Submitted batch job (\d+)`
+const reSbatch = `Submitted batch job (\d+)`
 
 const invalidJob = "Invalid job id specified"
 

--- a/prov/slurm/helper.go
+++ b/prov/slurm/helper.go
@@ -308,7 +308,7 @@ func parseJobID(str string, regexp *regexp.Regexp) (string, error) {
 	return "", errors.Errorf("Unable to parse std:%q for retrieving jobID", str)
 }
 
-func cancelJobID(jobID string, client *sshutil.SSHClient) error {
+func cancelJobID(jobID string, client sshutil.Client) error {
 	scancelCmd := fmt.Sprintf("scancel %s", jobID)
 	sCancelOutput, err := client.RunCommand(scancelCmd)
 	if err != nil {

--- a/prov/slurm/helper_test.go
+++ b/prov/slurm/helper_test.go
@@ -291,6 +291,14 @@ func TestParseJobIDFromSbatchOut(t *testing.T) {
 	require.Equal(t, "4567", ret, "unexpected JobID parsing")
 }
 
+func TestParseJobIDFromSbatchOutWithInterferenceLogs(t *testing.T) {
+	t.Parallel()
+	str := "WARNING Verify of certificates disabled! ::TESTING USE ONLY::\nSubmitted batch job 4567"
+	ret, err := retrieveJobID(str)
+	require.Nil(t, err, "unexpected error")
+	require.Equal(t, "4567", ret, "unexpected JobID parsing")
+}
+
 func TestParseKeyValue(t *testing.T) {
 	t.Parallel()
 	type args struct {

--- a/prov/slurm/helper_test.go
+++ b/prov/slurm/helper_test.go
@@ -30,25 +30,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ystia/yorc/v4/config"
+	"github.com/ystia/yorc/v4/helper/sshutil"
 	"github.com/ystia/yorc/v4/tosca/datatypes"
 )
 
-// MockSSHSession allows to mock an SSH session
-type MockSSHClient struct {
-	MockRunCommand func(string) (string, error)
-}
-
-// RunCommand to mock a command ran via SSH
-func (s *MockSSHClient) RunCommand(cmd string) (string, error) {
-	if s.MockRunCommand != nil {
-		return s.MockRunCommand(cmd)
-	}
-	return "", nil
-}
-
 func TestGetAttributesWithCudaVisibleDeviceKey(t *testing.T) {
 	t.Parallel()
-	s := &MockSSHClient{
+	s := &sshutil.MockSSHClient{
 		MockRunCommand: func(cmd string) (string, error) {
 			return "CUDA_VISIBLE_DEVICES=NoDevFiles", nil
 		},
@@ -61,7 +49,7 @@ func TestGetAttributesWithCudaVisibleDeviceKey(t *testing.T) {
 
 func TestGetAttributesWithNodePartitionKey(t *testing.T) {
 	t.Parallel()
-	s := &MockSSHClient{
+	s := &sshutil.MockSSHClient{
 		MockRunCommand: func(cmd string) (string, error) {
 			return "node1,part1", nil
 		},
@@ -75,7 +63,7 @@ func TestGetAttributesWithNodePartitionKey(t *testing.T) {
 
 func TestGetAttributesWithNodePartitionKeyAndNotEnoughParameters(t *testing.T) {
 	t.Parallel()
-	s := &MockSSHClient{
+	s := &sshutil.MockSSHClient{
 		MockRunCommand: func(cmd string) (string, error) {
 			return "node1,part1", nil
 		},
@@ -86,7 +74,7 @@ func TestGetAttributesWithNodePartitionKeyAndNotEnoughParameters(t *testing.T) {
 
 func TestGetAttributesWithNodePartitionKeyAndMalformedResponse(t *testing.T) {
 	t.Parallel()
-	s := &MockSSHClient{
+	s := &sshutil.MockSSHClient{
 		MockRunCommand: func(cmd string) (string, error) {
 			return "a", nil
 		},
@@ -97,14 +85,14 @@ func TestGetAttributesWithNodePartitionKeyAndMalformedResponse(t *testing.T) {
 
 func TestGetAttributesWithUnknownKey(t *testing.T) {
 	t.Parallel()
-	s := &MockSSHClient{}
+	s := &sshutil.MockSSHClient{}
 	_, err := getAttributes(s, "unknown_key", "1234")
 	require.Error(t, err, "unknown key error expected")
 }
 
 func TestGetAttributesWithFailure(t *testing.T) {
 	t.Parallel()
-	s := &MockSSHClient{
+	s := &sshutil.MockSSHClient{
 		MockRunCommand: func(cmd string) (string, error) {
 			return "", errors.New("expected failure")
 		},
@@ -115,7 +103,7 @@ func TestGetAttributesWithFailure(t *testing.T) {
 
 func TestGetAttributesWithMalformedStdout(t *testing.T) {
 	t.Parallel()
-	s := &MockSSHClient{
+	s := &sshutil.MockSSHClient{
 		MockRunCommand: func(cmd string) (string, error) {
 			return "MALFORMED_VALUE", nil
 		},
@@ -351,7 +339,7 @@ func TestParseJob(t *testing.T) {
 
 func TestGetJobInfoWithInvalidJob(t *testing.T) {
 	t.Parallel()
-	s := &MockSSHClient{
+	s := &sshutil.MockSSHClient{
 		MockRunCommand: func(cmd string) (string, error) {
 			return "slurm_load_jobs error: Invalid job id specified", errors.New("")
 		},
@@ -364,7 +352,7 @@ func TestGetJobInfoWithInvalidJob(t *testing.T) {
 
 func TestGetJobInfo(t *testing.T) {
 	t.Parallel()
-	s := &MockSSHClient{
+	s := &sshutil.MockSSHClient{
 		MockRunCommand: func(cmd string) (string, error) {
 			content, err := ioutil.ReadFile("testdata/scontrol.txt")
 			require.Nil(t, err, "Unexpected error reading scontrol")
@@ -385,7 +373,7 @@ func TestGetJobInfo(t *testing.T) {
 
 func TestGetJobInfoWithEmptyResponse(t *testing.T) {
 	t.Parallel()
-	s := &MockSSHClient{
+	s := &sshutil.MockSSHClient{
 		MockRunCommand: func(cmd string) (string, error) {
 			return "", nil
 		},
@@ -398,7 +386,7 @@ func TestGetJobInfoWithEmptyResponse(t *testing.T) {
 
 func TestGetJobInfoWithError(t *testing.T) {
 	t.Parallel()
-	s := &MockSSHClient{
+	s := &sshutil.MockSSHClient{
 		MockRunCommand: func(cmd string) (string, error) {
 			return "oups, it's bad", errors.New("this is an error !")
 		},

--- a/prov/slurm/structs.go
+++ b/prov/slurm/structs.go
@@ -38,21 +38,19 @@ type nodeAllocation struct {
 }
 
 type jobInfo struct {
-	ID                     string            `json:"id,omitempty"`
-	Name                   string            `json:"name,omitempty"`
-	Tasks                  int               `json:"tasks,omitempty"`
-	Cpus                   int               `json:"cpus,omitempty"`
-	Nodes                  int               `json:"nodes,omitempty"`
-	Mem                    string            `json:"mem,omitempty"`
-	MaxTime                string            `json:"max_time,omitempty"`
-	Opts                   []string          `json:"opts,omitempty"`
-	Args                   []string          `json:"args,omitempty"`
-	EnvVars                []string          `json:"env_vars,omitempty"`
-	Inputs                 map[string]string `json:"inputs,omitempty"`
-	MonitoringTimeInterval time.Duration     `json:"monitoring_time_interval,omitempty"`
-	Account                string            `json:"account,omitempty"`
-	Reservation            string            `json:"reservation,omitempty"`
-	Command                string            `json:"command,omitempty"`
-	WorkingDir             string            `json:"working_directory,omitempty"`
-	Artifacts              []string          `json:"artifacts,omitempty"`
+	ID                     string                          `json:"id,omitempty"`
+	Name                   string                          `json:"name,omitempty"`
+	Tasks                  int                             `json:"tasks,omitempty"`
+	Cpus                   int                             `json:"cpus,omitempty"`
+	Nodes                  int                             `json:"nodes,omitempty"`
+	Mem                    string                          `json:"mem,omitempty"`
+	MaxTime                string                          `json:"max_time,omitempty"`
+	Opts                   []string                        `json:"opts,omitempty"`
+	ExecutionOptions       datatypes.SlurmExecutionOptions `json:"execution_options,omitempty"`
+	Inputs                 map[string]string               `json:"inputs,omitempty"`
+	MonitoringTimeInterval time.Duration                   `json:"monitoring_time_interval,omitempty"`
+	Account                string                          `json:"account,omitempty"`
+	Reservation            string                          `json:"reservation,omitempty"`
+	WorkingDir             string                          `json:"working_directory,omitempty"`
+	Artifacts              []string                        `json:"artifacts,omitempty"`
 }

--- a/prov/slurm/structs.go
+++ b/prov/slurm/structs.go
@@ -53,4 +53,5 @@ type jobInfo struct {
 	Reservation            string                          `json:"reservation,omitempty"`
 	WorkingDir             string                          `json:"working_directory,omitempty"`
 	Artifacts              []string                        `json:"artifacts,omitempty"`
+	EnvFile                string                          `json:"env_file,omitempty"`
 }

--- a/prov/slurm/testdata/job_with_options.yaml
+++ b/prov/slurm/testdata/job_with_options.yaml
@@ -1,0 +1,35 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: Classification
+  template_version: 0.1.0-SNAPSHOT
+  template_author: ${template_author}
+
+description: ""
+
+imports:
+  - <yorc-types.yml>
+  - <normative-types.yml>
+  - <yorc-slurm-types.yml>
+
+topology_template:
+
+  node_templates:
+    ClassificationJobUnit_Singularity:
+      type: yorc.nodes.slurm.Job
+      properties:
+        slurm_options:
+          name: "ClassificationJobUnit_Singularity"
+          # extra_options:
+          #   - "--singularity-image=/fs1/myuser/images/kdetect.simg"
+          #   - "-bb"
+          #   - "--singularity-bind=/fs1/myuser/bu:/mnt/data-bu"
+        execution_options:
+          args:
+            - "-c"
+            - "python3 /opt/kdetect.py ${STORAGE_PATH}"
+          in_script_options:
+            - "#BB volume=a4b4f33c-994f-4f3f-877e-395d21bd3fb2 user=bu key=key path=/sharing lustre_path=/fs1/myuser/bu size=1"
+          command: sh
+          env_vars:
+            - "STORAGE_PATH=/mnt/data-bu/models/C56A8BCD-380E-4E6C-B265-D50208641102-4203addf-aca9-3040-271d-d2bbe0719f79"

--- a/prov/slurm/testdata/simple_job.yaml
+++ b/prov/slurm/testdata/simple_job.yaml
@@ -1,0 +1,35 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: Classification
+  template_version: 0.1.0-SNAPSHOT
+  template_author: ${template_author}
+
+description: ""
+
+imports:
+  - <yorc-types.yml>
+  - <normative-types.yml>
+  - <yorc-slurm-types.yml>
+
+topology_template:
+
+  node_templates:
+    ClassificationJobUnit_Singularity:
+      type: yorc.nodes.slurm.Job
+      properties:
+        # slurm_options:
+        #   name: "ClassificationJobUnit_Singularity"
+        #   extra_options:
+        #     - "--singularity-image=/fs1/myuser/images/kdetect.simg"
+        #     - "-bb"
+        #     - "--singularity-bind=/fs1/myuser/bu:/mnt/data-bu"
+        # execution_options:
+        #   args:
+        #     - "-c"
+        #     - "python3 /opt/kdetect.py ${STORAGE_PATH}"
+        #   in_script_options:
+        #     - "#BB volume=a4b4f33c-994f-4f3f-877e-395d21bd3fb2 user=bu key=key path=/sharing lustre_path=/fs1/myuser/bu size=1"
+        #   command: sh
+        #   env_vars:
+        #     - "STORAGE_PATH=/mnt/data-bu/models/C56A8BCD-380E-4E6C-B265-D50208641102-4203addf-aca9-3040-271d-d2bbe0719f79"

--- a/rest/consul_test.go
+++ b/rest/consul_test.go
@@ -30,20 +30,16 @@ import (
 	"github.com/ystia/yorc/v4/testutil"
 )
 
-type mockSSHClient struct {
-	config *ssh.ClientConfig
-}
-
-func (m *mockSSHClient) RunCommand(string) (string, error) {
-	if m.config != nil && m.config.User == "fail" {
-		return "", errors.Errorf("Failed to connect")
-	}
-
-	return "ok", nil
-}
-
 var mockSSHClientFactory = func(config *ssh.ClientConfig, conn hostspool.Connection) sshutil.Client {
-	return &mockSSHClient{config}
+	return &sshutil.MockSSHClient{
+		MockRunCommand: func(string) (string, error) {
+			if config != nil && config.User == "fail" {
+				return "", errors.Errorf("Failed to connect")
+			}
+
+			return "ok", nil
+		},
+	}
 }
 
 func newTestHTTPRouter(client *api.Client, req *http.Request) *http.Response {

--- a/rest/task_query_test.go
+++ b/rest/task_query_test.go
@@ -149,15 +149,15 @@ func testListTaskQueryHandler(t *testing.T, client *api.Client, srv *testutil.Te
 		consulutil.TasksPrefix + "/task123/resultSet":         []byte("{\"result\": \"success\"}"),
 		consulutil.TasksPrefix + "/task123/data/locationName": []byte("slurm"),
 
-		consulutil.TasksPrefix + "/task124/type":              []byte("7"),
-		consulutil.TasksPrefix + "/task124/targetId":          []byte("infra_usage:slurm"),
-		consulutil.TasksPrefix + "/task124/status":            []byte("2"),
-		consulutil.TasksPrefix + "/task124/resultSet":         []byte("{\"result\": \"success\"}"),
+		consulutil.TasksPrefix + "/task124/type":      []byte("7"),
+		consulutil.TasksPrefix + "/task124/targetId":  []byte("infra_usage:slurm"),
+		consulutil.TasksPrefix + "/task124/status":    []byte("2"),
+		consulutil.TasksPrefix + "/task124/resultSet": []byte("{\"result\": \"success\"}"),
 
-		consulutil.TasksPrefix + "/task125/type":              []byte("7"),
-		consulutil.TasksPrefix + "/task125/targetId":          []byte("bad format"),
-		consulutil.TasksPrefix + "/task125/status":            []byte("2"),
-		consulutil.TasksPrefix + "/task125/resultSet":         []byte("{\"result\": \"success\"}"),
+		consulutil.TasksPrefix + "/task125/type":      []byte("7"),
+		consulutil.TasksPrefix + "/task125/targetId":  []byte("bad format"),
+		consulutil.TasksPrefix + "/task125/status":    []byte("2"),
+		consulutil.TasksPrefix + "/task125/resultSet": []byte("{\"result\": \"success\"}"),
 	})
 
 	req := httptest.NewRequest("GET", "/infra_usage", nil)

--- a/tosca/datatypes/slurm.go
+++ b/tosca/datatypes/slurm.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datatypes
+
+// SlurmExecutionOptions is a yorc.datatypes.slurm.ExecutionOptions
+type SlurmExecutionOptions struct {
+	Command         string   `mapstructure:"command" json:"command,omitempty"`
+	Args            []string `mapstructure:"args" json:"args,omitempty"`
+	EnvVars         []string `mapstructure:"env_vars" json:"env_vars,omitempty"`
+	InScriptOptions []string `mapstructure:"in_script_options" json:"in_script_options,omitempty"`
+}


### PR DESCRIPTION
# Pull Request description

## Description of the change

Allow to provide extra options to Slurm for sbatch scripts specifically generated by Yorc to execute commands.

Also support sourcing of a user profile environment if any.

### What I did

Added a new TOSCA property for SlurmJob. Add use it for generating sbatch inline options.


### Description for the changelog

* Allow to provide inline configuration options for generated sbatch scripts ([GH-537](https://github.com/ystia/yorc/issues/537))
* Optionnaly source an environment file before submitting slurm jobs ([GH-541](https://github.com/ystia/yorc/issues/541))

## Applicable Issues

Fixes #537 
Fixes #541