### PR TITLE
Bugfix/gh 545 slurm error duplicate log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Duplicate SLURM job info log in case of failure ([GH-545](https://github.com/ystia/yorc/issues/545))
+
 ## 4.0.0-M6 (November 08, 2019)
 
 ### ENHANCEMENTS

--- a/prov/slurm/monitoring_jobs.go
+++ b/prov/slurm/monitoring_jobs.go
@@ -173,10 +173,8 @@ func (o *actionOperator) monitorJob(ctx context.Context, cfg config.Configuratio
 		// job's still running or its state is about to be set definitively: monitoring is keeping on (deregister stays false)
 	default:
 		// Other cases as FAILED, CANCELLED, STOPPED, SUSPENDED, TIMEOUT, etc : error is return with job state and job info is logged
-		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, deploymentID).RegisterAsString(fmt.Sprintf("job info:%+v", info))
 		deregister = true
 		// Log event containing all the slurm information
-
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, deploymentID).RegisterAsString(fmt.Sprintf("job info:%+v", info))
 		// Error to be returned
 		err = errors.Errorf("job with ID:%q finished unsuccessfully with state:%q", actionData.jobID, info["JobState"])


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Removed a duplicate log appearing in case of SLURM job error.

### How to verify it

On an A4C/Yorc setup with a SLURM location, upload in A4C catalog:
* a SLURM job component allowing to trigger a failure, available at https://github.com/ystia/tosca-samples/tree/develop/org/ystia/yorc/samples/job/slurm/components/failure
* A topology template using this component, available at https://github.com/ystia/tosca-samples/blob/develop/org/ystia/yorc/samples/job/slurm/topologies/failure/types.yaml

Create an application from this topology template and deploy this application on a SLURM location.
Execute the run workflow.
At some point, it should fail.
Check Yorc logs and verify there is one and only one error log providing the job info like this one:
```
[2019-11-15T09:46:52.86073261Z][ERROR][test-Environment][run][7ea172a6-d41e-4e4c-a79e-799d8fc2f003][][Job][][tosca.interfaces.node.lifecycle.runnable][run][]job info:map[Account:myuser AllocNode:Sid:myhost:32563 BatchFlag:1 BatchHost:hpda17 CPUs/Task:1 Command:/home_nfs/myuser/workFailure/bin/submit_err.sh Contiguous:0 CoreSpec:* Dependency:(null) EligibleTime:2019-11-15T10:46:41 EndTime:2019-11-15T10:46:42 ExcNodeList:(null) ExitCode:1:0 Features:(null) Gres:(null) GroupId:starlings(1000) JobId:10224 JobName:job_failure JobState:FAILED Licenses:(null) MinCPUsNode:1 MinMemoryNode:16G MinTmpDiskNode:0 Network:(null) Nice:0 NodeList:hpda17 NtasksPerN:B:S:C:0:0:*:* NumCPUs:1 NumNodes:1 Partition:all Power: PreemptTime:None Priority:4294901704 QOS:normal Reason:NonZeroExitCode Reboot:0 ReqB:S:C:T:0:0:*:* ReqNodeList:(null) Requeue:1 Reservation:(null) Restarts:0 RunTime:00:00:00 SICP:0 SecsPreSuspend:0 Shared:OK Socks/Node:* StartTime:2019-11-15T10:46:42 StdErr:/home_nfs/gannel/workFailure/slurm-10224.out StdIn:/dev/null StdOut:/home_nfs/gannel/workFailure/slurm-10224.out SubmitTime:2019-11-15T10:46:41 SuspendTime:None TRES:cpu TimeLimit:365-00:00:00 TimeMin:N/A UserId:gannel(1018) WorkDir:/home_nfs/myuser/workFailure]
```

### Description for the changelog

Duplicate SLURM job info log in case of failure ([GH-545](https://github.com/ystia/yorc/issues/545))

## Applicable Issues

Closes #545 