### PR TITLE
Change the API endpoint for updating a deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## UNRELEASED
 
+### BREAKING CHANGES
+
+#### Changes on the REST API
+
+Until now deployments updates (which is a premium feature) were made on the same API operation than submitting a deployment with a given identifier:
+`PUT /deployments/<deployment_id>`.
+The decision on updating a deployment or creating a new one was based on the existence or not of a deployment with the given identifier.
+
+This was confusing and makes error handling on clients difficult. So we decided to split those operations on two different API endpoints.
+Submitting a deployment with a given identifier remain as it was, but updating a deployment is now available on the `PATCH /deployments/<deployment_id>` endpoint.
+
+Trying to update a deployment on an OSS version will now result in a `401 Forbiden` error instead of a `409 Conflict` error previously.
+Submitting a deployment with an identifier that is already used will still result in a `409 Conflict` error but without an informative message indicating that a
+premium version is required to perform a deployment update.
+
+This is tracked on ([GH-547: Refactor Deployment updates API](https://github.com/ystia/yorc/issues/547)).
+
 ### BUG FIXES
 
 * Duplicate SLURM job info log in case of failure ([GH-545](https://github.com/ystia/yorc/issues/545))

--- a/rest/deployments_test.go
+++ b/rest/deployments_test.go
@@ -17,9 +17,7 @@ package rest
 import (
 	"context"
 	"encoding/json"
-	"github.com/ystia/yorc/v4/deployments"
-	"github.com/ystia/yorc/v4/helper/consulutil"
-	"github.com/ystia/yorc/v4/tasks"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -33,6 +31,11 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ystia/yorc/v4/deployments"
+	"github.com/ystia/yorc/v4/helper/consulutil"
+	"github.com/ystia/yorc/v4/tasks"
+	ytestutil "github.com/ystia/yorc/v4/testutil"
 )
 
 func testDeploymentHandlers(t *testing.T, client *api.Client, srv *testutil.TestServer) {
@@ -47,6 +50,9 @@ func testDeploymentHandlers(t *testing.T, client *api.Client, srv *testutil.Test
 	})
 	t.Run("testListDeploymentHandler", func(t *testing.T) {
 		testListDeploymentHandler(t, client, srv)
+	})
+	t.Run("testUpdateDeploymentsOSS", func(t *testing.T) {
+		testUpdateDeploymentsOSS(t, client, srv)
 	})
 }
 
@@ -306,6 +312,49 @@ func testListDeploymentHandler(t *testing.T, client *api.Client, srv *testutil.T
 				}
 			}
 			cleanTest(tt.name, "")
+		})
+	}
+}
+
+func testUpdateDeploymentsOSS(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+	depID := ytestutil.BuildDeploymentID(t)
+
+	type result struct {
+		statusCode int
+		errors     *Errors
+	}
+
+	tests := []struct {
+		name         string
+		deploymentID string
+		want         *result
+	}{
+		{"updateExistingDep", depID, &result{statusCode: http.StatusForbidden, errors: &Errors{[]*Error{newForbiddenRequest(fmt.Sprintf("Trying to update deployment %q on an open source version. Updates are supported only on premium versions.", depID))}}}},
+		{"updateNotExistingDep", "noDeployment", &result{statusCode: http.StatusNotFound, errors: &Errors{[]*Error{errNotFound}}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prepareTest(t, tt.deploymentID, client, srv)
+
+			req := httptest.NewRequest("PATCH", "/deployments/"+tt.deploymentID, nil)
+			req.Header.Set("Content-Type", "application/zip")
+			resp := newTestHTTPRouter(client, req)
+			require.NotNil(t, resp, "unexpected nil response")
+			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)
+
+			body, err := ioutil.ReadAll(resp.Body)
+			require.Nil(t, err, "unexpected error reading body response")
+
+			if tt.want.errors != nil {
+				var errorsFound Errors
+				err := json.Unmarshal(body, &errorsFound)
+				require.Nil(t, err, "unexpected error unmarshalling json body")
+				if !reflect.DeepEqual(errorsFound, *tt.want.errors) {
+					t.Errorf("errors = %v, want %v", errorsFound, *tt.want.errors)
+				}
+			}
+			cleanTest(tt.deploymentID, "")
 		})
 	}
 }

--- a/rest/deployments_test.go
+++ b/rest/deployments_test.go
@@ -226,14 +226,14 @@ func testGetDeploymentHandler(t *testing.T, client *api.Client, srv *testutil.Te
 		//	{"getDeploymentWithBadID", "badDeploymentID", &result{statusCode: http.StatusNotFound, errors: &Errors{[]*Error{errNotFound}}}},
 		{"getDeployment", "getDeployment", &result{statusCode: http.StatusOK, errors: nil,
 			deployment: &Deployment{ID: "getDeployment", Status: "DEPLOYED",
-				Links: []AtomLink{{Href: "/deployments/getDeployment", Rel: "self", LinkType: "application/json"},
-					{Href: "/deployments/getDeployment/nodes/Compute", Rel: "node", LinkType: "application/json"}}}}},
+				Links: []AtomLink{{Href: "/deployments/getDeployment", Rel: "self", LinkType: mimeTypeApplicationJSON},
+					{Href: "/deployments/getDeployment/nodes/Compute", Rel: "node", LinkType: mimeTypeApplicationJSON}}}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			prepareTest(t, tt.name, client, srv)
 			req := httptest.NewRequest("GET", "/deployments/"+tt.deploymentID, nil)
-			req.Header.Set("Accept", "application/json")
+			req.Header.Set("Accept", mimeTypeApplicationJSON)
 			resp := newTestHTTPRouter(client, req)
 			require.NotNil(t, resp, "unexpected nil response")
 			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)
@@ -278,7 +278,7 @@ func testListDeploymentHandler(t *testing.T, client *api.Client, srv *testutil.T
 	}{
 		{"getDeployment", &result{statusCode: http.StatusOK, errors: nil,
 			deployments: &DeploymentsCollection{[]Deployment{{ID: "getDeployment", Status: "DEPLOYED",
-				Links: []AtomLink{{Href: "/deployments/getDeployment", Rel: "deployment", LinkType: "application/json"}}}}}}},
+				Links: []AtomLink{{Href: "/deployments/getDeployment", Rel: "deployment", LinkType: mimeTypeApplicationJSON}}}}}}},
 		{"noDeployment", &result{statusCode: http.StatusNoContent, errors: nil,
 			deployments: nil}},
 	}
@@ -286,7 +286,7 @@ func testListDeploymentHandler(t *testing.T, client *api.Client, srv *testutil.T
 		t.Run(tt.name, func(t *testing.T) {
 			prepareTest(t, tt.name, client, srv)
 			req := httptest.NewRequest("GET", "/deployments", nil)
-			req.Header.Set("Accept", "application/json")
+			req.Header.Set("Accept", mimeTypeApplicationJSON)
 			resp := newTestHTTPRouter(client, req)
 			require.NotNil(t, resp, "unexpected nil response")
 			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)
@@ -338,7 +338,7 @@ func testUpdateDeploymentsOSS(t *testing.T, client *api.Client, srv *testutil.Te
 			prepareTest(t, tt.deploymentID, client, srv)
 
 			req := httptest.NewRequest("PATCH", "/deployments/"+tt.deploymentID, nil)
-			req.Header.Set("Content-Type", "application/zip")
+			req.Header.Set("Content-Type", mimeTypeApplicationZip)
 			resp := newTestHTTPRouter(client, req)
 			require.NotNil(t, resp, "unexpected nil response")
 			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)

--- a/rest/errors.go
+++ b/rest/errors.go
@@ -77,3 +77,7 @@ func newBadRequestMessage(message string) *Error {
 func newConflictRequest(message string) *Error {
 	return &Error{"conflict", http.StatusConflict, "Conflict", message}
 }
+
+func newForbiddenRequest(message string) *Error {
+	return &Error{"forbidden", http.StatusForbidden, "Forbidden", message}
+}

--- a/rest/hosts_pool_test.go
+++ b/rest/hosts_pool_test.go
@@ -77,14 +77,14 @@ func testListHostsInPool(t *testing.T, client *api.Client, srv *testutil.TestSer
 	})
 
 	req := httptest.NewRequest("GET", "/hosts_pool/myHostsPoolLocationTest", nil)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", mimeTypeApplicationJSON)
 	resp := newTestHTTPRouter(client, req)
 	body, err := ioutil.ReadAll(resp.Body)
 
 	require.Nil(t, err, "unexpected error reading body response")
 	require.NotNil(t, resp, "unexpected nil response")
 	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusOK)
-	require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	require.Equal(t, mimeTypeApplicationJSON, resp.Header.Get("Content-Type"))
 
 	var collection HostsCollection
 	err = json.Unmarshal(body, &collection)
@@ -107,7 +107,7 @@ func testListNoHostsInPool(t *testing.T, client *api.Client, srv *testutil.TestS
 	t.Parallel()
 
 	req := httptest.NewRequest("GET", "/hosts_pool/myHostsPoolLocationTest", nil)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", mimeTypeApplicationJSON)
 	resp := newTestHTTPRouter(client, req)
 	_, err := ioutil.ReadAll(resp.Body)
 
@@ -127,7 +127,7 @@ func testListHostsInPoolWithBadFilter(t *testing.T, client *api.Client, srv *tes
 		q.Add("filter", filters[i])
 	}
 	req.URL.RawQuery = q.Encode()
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", mimeTypeApplicationJSON)
 	resp := newTestHTTPRouter(client, req)
 	_, err := ioutil.ReadAll(resp.Body)
 
@@ -182,7 +182,7 @@ func testNewHostInPool(t *testing.T, client *api.Client, srv *testutil.TestServe
 	tmp, err := json.Marshal(hostRequest)
 	require.Nil(t, err, "unexpected error marshalling data to provide body request")
 	req := httptest.NewRequest("PUT", "/hosts_pool/myHostsPoolLocationTest/host11", bytes.NewBuffer([]byte(string(tmp))))
-	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Content-Type", mimeTypeApplicationJSON)
 	resp := newTestHTTPRouter(client, req)
 	_, err = ioutil.ReadAll(resp.Body)
 	require.NotNil(t, resp, "unexpected nil response")
@@ -201,7 +201,7 @@ func testNewHostInPoolWithoutConnectionInfo(t *testing.T, client *api.Client, sr
 	tmp, err := json.Marshal(hostRequest)
 	require.Nil(t, err, "unexpected error marshalling data to provide body request")
 	req := httptest.NewRequest("PUT", "/hosts_pool/myHostsPoolLocationTest/host12", bytes.NewBuffer([]byte(string(tmp))))
-	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Content-Type", mimeTypeApplicationJSON)
 	resp := newTestHTTPRouter(client, req)
 	_, err = ioutil.ReadAll(resp.Body)
 	require.NotNil(t, resp, "unexpected nil response")
@@ -222,7 +222,7 @@ func testNewHostInPoolWithoutPrivateKeyOrPassword(t *testing.T, client *api.Clie
 	tmp, err := json.Marshal(hostRequest)
 	require.Nil(t, err, "unexpected error marshalling data to provide body request")
 	req := httptest.NewRequest("PUT", "/hosts_pool/myHostsPoolLocationTest/host11", bytes.NewBuffer([]byte(string(tmp))))
-	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Content-Type", mimeTypeApplicationJSON)
 	resp := newTestHTTPRouter(client, req)
 	_, err = ioutil.ReadAll(resp.Body)
 	require.NotNil(t, resp, "unexpected nil response")
@@ -241,7 +241,7 @@ func testGetHostInPool(t *testing.T, client *api.Client, srv *testutil.TestServe
 	})
 
 	req := httptest.NewRequest("GET", "/hosts_pool/myHostsPoolLocationTest/host17", nil)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", mimeTypeApplicationJSON)
 	resp := newTestHTTPRouter(client, req)
 	body, err := ioutil.ReadAll(resp.Body)
 
@@ -251,7 +251,7 @@ func testGetHostInPool(t *testing.T, client *api.Client, srv *testutil.TestServe
 	require.Nil(t, err, "unexpected error reading body response")
 	require.NotNil(t, resp, "unexpected nil response")
 	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusOK)
-	require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	require.Equal(t, mimeTypeApplicationJSON, resp.Header.Get("Content-Type"))
 
 	var host Host
 	err = json.Unmarshal(body, &host)
@@ -279,14 +279,14 @@ func testListHostsPoolLocations(t *testing.T, client *api.Client, srv *testutil.
 	})
 
 	req := httptest.NewRequest("GET", "/hosts_pool", nil)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", mimeTypeApplicationJSON)
 	resp := newTestHTTPRouter(client, req)
 	body, err := ioutil.ReadAll(resp.Body)
 
 	require.Nil(t, err, "unexpected error reading body response")
 	require.NotNil(t, resp, "unexpected nil response")
 	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusOK)
-	require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	require.Equal(t, mimeTypeApplicationJSON, resp.Header.Get("Content-Type"))
 
 	var hostsPoolLocations HostsPoolLocations
 	err = json.Unmarshal(body, &hostsPoolLocations)
@@ -306,7 +306,7 @@ func testApplyHostsPoolConfiguration(t *testing.T, client *api.Client, srv *test
 	require.Nil(t, err, "unexpected error marshalling data to provide body request")
 
 	req := httptest.NewRequest("PUT", "/hosts_pool/myHostsPoolLocationTest", bytes.NewBuffer([]byte(string(tmp))))
-	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Content-Type", mimeTypeApplicationJSON)
 	resp := newTestHTTPRouter(client, req)
 	_, err = ioutil.ReadAll(resp.Body)
 	require.NotNil(t, resp, "unexpected nil response")

--- a/rest/http.go
+++ b/rest/http.go
@@ -33,6 +33,11 @@ import (
 	"github.com/ystia/yorc/v4/tasks/collector"
 )
 
+const (
+	mimeTypeApplicationZip  = "application/zip"
+	mimeTypeApplicationJSON = "application/json"
+)
+
 type router struct {
 	*httprouter.Router
 }
@@ -143,57 +148,57 @@ func NewServer(configuration config.Configuration, client *api.Client, shutdownC
 
 func (s *Server) registerHandlers() {
 	commonHandlers := alice.New(telemetryHandler, loggingHandler, recoverHandler)
-	s.router.Get("/health", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getHealthHandler))
-	s.router.Post("/deployments", commonHandlers.Append(contentTypeHandler("application/zip")).ThenFunc(s.newDeploymentHandler))
-	s.router.Put("/deployments/:id", commonHandlers.Append(contentTypeHandler("application/zip")).ThenFunc(s.newDeploymentHandler))
-	s.router.Patch("/deployments/:id", commonHandlers.Append(contentTypeHandler("application/zip")).ThenFunc(s.updateDeploymentHandler))
+	s.router.Get("/health", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.getHealthHandler))
+	s.router.Post("/deployments", commonHandlers.Append(contentTypeHandler(mimeTypeApplicationZip)).ThenFunc(s.newDeploymentHandler))
+	s.router.Put("/deployments/:id", commonHandlers.Append(contentTypeHandler(mimeTypeApplicationZip)).ThenFunc(s.newDeploymentHandler))
+	s.router.Patch("/deployments/:id", commonHandlers.Append(contentTypeHandler(mimeTypeApplicationZip)).ThenFunc(s.updateDeploymentHandler))
 	s.router.Delete("/deployments/:id", commonHandlers.ThenFunc(s.deleteDeploymentHandler))
-	s.router.Get("/deployments/:id", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getDeploymentHandler))
-	s.router.Get("/deployments", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listDeploymentsHandler))
-	s.router.Get("/deployments/:id/events", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.pollEvents))
-	s.router.Get("/events", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.pollEvents))
+	s.router.Get("/deployments/:id", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.getDeploymentHandler))
+	s.router.Get("/deployments", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.listDeploymentsHandler))
+	s.router.Get("/deployments/:id/events", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.pollEvents))
+	s.router.Get("/events", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.pollEvents))
 	s.router.Head("/deployments/:id/events", commonHandlers.ThenFunc(s.headEventsIndex))
 	s.router.Head("/events", commonHandlers.ThenFunc(s.headEventsIndex))
-	s.router.Get("/deployments/:id/logs", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.pollLogs))
-	s.router.Get("/logs", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.pollLogs))
+	s.router.Get("/deployments/:id/logs", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.pollLogs))
+	s.router.Get("/logs", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.pollLogs))
 	s.router.Head("/deployments/:id/logs", commonHandlers.ThenFunc(s.headLogsEventsIndex))
 	s.router.Head("/logs", commonHandlers.ThenFunc(s.headLogsEventsIndex))
-	s.router.Get("/deployments/:id/nodes/:nodeName", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getNodeHandler))
-	s.router.Get("/deployments/:id/nodes/:nodeName/instances/:instanceId", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getNodeInstanceHandler))
-	s.router.Get("/deployments/:id/outputs", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listOutputsHandler))
-	s.router.Get("/deployments/:id/outputs/:opt", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getOutputHandler))
-	s.router.Get("/deployments/:id/tasks/:taskId", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getTaskHandler))
-	s.router.Get("/deployments/:id/tasks/:taskId/steps", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getTaskStepsHandler))
+	s.router.Get("/deployments/:id/nodes/:nodeName", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.getNodeHandler))
+	s.router.Get("/deployments/:id/nodes/:nodeName/instances/:instanceId", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.getNodeInstanceHandler))
+	s.router.Get("/deployments/:id/outputs", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.listOutputsHandler))
+	s.router.Get("/deployments/:id/outputs/:opt", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.getOutputHandler))
+	s.router.Get("/deployments/:id/tasks/:taskId", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.getTaskHandler))
+	s.router.Get("/deployments/:id/tasks/:taskId/steps", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.getTaskStepsHandler))
 	s.router.Delete("/deployments/:id/tasks/:taskId", commonHandlers.ThenFunc(s.cancelTaskHandler))
 	s.router.Put("/deployments/:id/tasks/:taskId", commonHandlers.ThenFunc(s.resumeTaskHandler))
-	s.router.Put("/deployments/:id/tasks/:taskId/steps/:stepId", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.updateTaskStepStatusHandler))
+	s.router.Put("/deployments/:id/tasks/:taskId/steps/:stepId", commonHandlers.Append(contentTypeHandler(mimeTypeApplicationJSON)).ThenFunc(s.updateTaskStepStatusHandler))
 	s.router.Post("/deployments/:id/scale/:nodeName", commonHandlers.ThenFunc(s.scaleHandler))
-	s.router.Get("/deployments/:id/nodes/:nodeName/instances/:instanceId/attributes", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getNodeInstanceAttributesListHandler))
-	s.router.Get("/deployments/:id/nodes/:nodeName/instances/:instanceId/attributes/:attributeName", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getNodeInstanceAttributeHandler))
-	s.router.Post("/deployments/:id/custom", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.newCustomCommandHandler))
+	s.router.Get("/deployments/:id/nodes/:nodeName/instances/:instanceId/attributes", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.getNodeInstanceAttributesListHandler))
+	s.router.Get("/deployments/:id/nodes/:nodeName/instances/:instanceId/attributes/:attributeName", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.getNodeInstanceAttributeHandler))
+	s.router.Post("/deployments/:id/custom", commonHandlers.Append(contentTypeHandler(mimeTypeApplicationJSON)).ThenFunc(s.newCustomCommandHandler))
 	s.router.Post("/deployments/:id/workflows/:workflowName", commonHandlers.ThenFunc(s.newWorkflowHandler))
-	s.router.Get("/deployments/:id/workflows/:workflowName", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getWorkflowHandler))
-	s.router.Get("/deployments/:id/workflows", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listWorkflowsHandler))
+	s.router.Get("/deployments/:id/workflows/:workflowName", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.getWorkflowHandler))
+	s.router.Get("/deployments/:id/workflows", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.listWorkflowsHandler))
 
-	s.router.Get("/registry/delegates", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listRegistryDelegatesHandler))
-	s.router.Get("/registry/implementations", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listRegistryImplementationsHandler))
-	s.router.Get("/registry/definitions", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listRegistryDefinitionsHandler))
-	s.router.Get("/registry/vaults", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listVaultsBuilderHandler))
-	s.router.Get("/registry/infra_usage_collectors", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listInfraHandler))
+	s.router.Get("/registry/delegates", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.listRegistryDelegatesHandler))
+	s.router.Get("/registry/implementations", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.listRegistryImplementationsHandler))
+	s.router.Get("/registry/definitions", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.listRegistryDefinitionsHandler))
+	s.router.Get("/registry/vaults", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.listVaultsBuilderHandler))
+	s.router.Get("/registry/infra_usage_collectors", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.listInfraHandler))
 
-	s.router.Post("/infra_usage/:infraName/:locationName", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.postInfraUsageHandler))
-	s.router.Get("/infra_usage/:infraName/:locationName/tasks/:taskId", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getTaskQueryHandler))
+	s.router.Post("/infra_usage/:infraName/:locationName", commonHandlers.Append(contentTypeHandler(mimeTypeApplicationJSON)).ThenFunc(s.postInfraUsageHandler))
+	s.router.Get("/infra_usage/:infraName/:locationName/tasks/:taskId", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.getTaskQueryHandler))
 	s.router.Delete("/infra_usage/:infraName/:locationName/tasks/:taskId", commonHandlers.ThenFunc(s.deleteTaskQueryHandler))
-	s.router.Get("/infra_usage", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listTaskQueryHandler))
+	s.router.Get("/infra_usage", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.listTaskQueryHandler))
 
-	s.router.Put("/hosts_pool/:location/:host", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.newHostInPool))
-	s.router.Patch("/hosts_pool/:location/:host", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.updateHostInPool))
+	s.router.Put("/hosts_pool/:location/:host", commonHandlers.Append(contentTypeHandler(mimeTypeApplicationJSON)).ThenFunc(s.newHostInPool))
+	s.router.Patch("/hosts_pool/:location/:host", commonHandlers.Append(contentTypeHandler(mimeTypeApplicationJSON)).ThenFunc(s.updateHostInPool))
 	s.router.Delete("/hosts_pool/:location/:host", commonHandlers.ThenFunc(s.deleteHostInPool))
-	s.router.Post("/hosts_pool/:location", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.applyHostsPool))
-	s.router.Put("/hosts_pool/:location", commonHandlers.Append(contentTypeHandler("application/json")).ThenFunc(s.applyHostsPool))
-	s.router.Get("/hosts_pool/:location", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listHostsInPool))
-	s.router.Get("/hosts_pool/:location/:host", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getHostInPool))
-	s.router.Get("/hosts_pool", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listHostsPoolLocations))
+	s.router.Post("/hosts_pool/:location", commonHandlers.Append(contentTypeHandler(mimeTypeApplicationJSON)).ThenFunc(s.applyHostsPool))
+	s.router.Put("/hosts_pool/:location", commonHandlers.Append(contentTypeHandler(mimeTypeApplicationJSON)).ThenFunc(s.applyHostsPool))
+	s.router.Get("/hosts_pool/:location", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.listHostsInPool))
+	s.router.Get("/hosts_pool/:location/:host", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.getHostInPool))
+	s.router.Get("/hosts_pool", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.listHostsPoolLocations))
 
 	if s.config.Telemetry.PrometheusEndpoint {
 		s.router.Get("/metrics", commonHandlers.Then(promhttp.Handler()))
@@ -205,7 +210,7 @@ func encodeJSONResponse(w http.ResponseWriter, r *http.Request, resp interface{}
 	if _, ok := r.URL.Query()["pretty"]; ok {
 		jEnc.SetIndent("", "  ")
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", mimeTypeApplicationJSON)
 	jEnc.Encode(resp)
 }
 

--- a/rest/http.go
+++ b/rest/http.go
@@ -148,7 +148,7 @@ func NewServer(configuration config.Configuration, client *api.Client, shutdownC
 
 func (s *Server) registerHandlers() {
 	commonHandlers := alice.New(telemetryHandler, loggingHandler, recoverHandler)
-  s.router.Get("/server/info", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.getInfoHandler))
+	s.router.Get("/server/info", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.getInfoHandler))
 	s.router.Get("/health", commonHandlers.Append(acceptHandler(mimeTypeApplicationJSON)).ThenFunc(s.getHealthHandler))
 	s.router.Post("/deployments", commonHandlers.Append(contentTypeHandler(mimeTypeApplicationZip)).ThenFunc(s.newDeploymentHandler))
 	s.router.Put("/deployments/:id", commonHandlers.Append(contentTypeHandler(mimeTypeApplicationZip)).ThenFunc(s.newDeploymentHandler))

--- a/rest/http.go
+++ b/rest/http.go
@@ -146,6 +146,7 @@ func (s *Server) registerHandlers() {
 	s.router.Get("/health", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getHealthHandler))
 	s.router.Post("/deployments", commonHandlers.Append(contentTypeHandler("application/zip")).ThenFunc(s.newDeploymentHandler))
 	s.router.Put("/deployments/:id", commonHandlers.Append(contentTypeHandler("application/zip")).ThenFunc(s.newDeploymentHandler))
+	s.router.Patch("/deployments/:id", commonHandlers.Append(contentTypeHandler("application/zip")).ThenFunc(s.updateDeploymentHandler))
 	s.router.Delete("/deployments/:id", commonHandlers.ThenFunc(s.deleteDeploymentHandler))
 	s.router.Get("/deployments/:id", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.getDeploymentHandler))
 	s.router.Get("/deployments", commonHandlers.Append(acceptHandler("application/json")).ThenFunc(s.listDeploymentsHandler))

--- a/rest/http_api.md
+++ b/rest/http_api.md
@@ -24,9 +24,7 @@ In this case you should use a `POST` method.
 In this case you should use a `PUT` method. There are some constraints on submitting a deployment with a given ID:
 
 * This ID should respect the following format: `^[-_0-9a-zA-Z]+$` and be less than 36 characters long (otherwise a `400 BadRequest` error is returned)
-* If this ID  is already in use, the behavior depends on the Yorc version, premium or open source :
-  * in the premium version, a deployment update will be performed as described in next section below,
-  * in the open source version, a `409 Conflict` error is returned.
+* This ID should not already be in used (otherwise a `409 Conflict` error is returned)
 
 `PUT /deployments/<deployment_id>`
 
@@ -49,10 +47,7 @@ A critical note is that the deployment is proceeded asynchronously and a success
 
 Updates a deployment by uploading an updated CSAR. 'Content-Type' header should be set to 'application/zip'.
 
-`PUT /deployments/<deployment_id>`
-
-If the given ID doesn't correspond to the ID of an existing deployment, this call
-won't perform an update, but will create a new deployment as described in the previous section.
+`PATCH /deployments/<deployment_id>`
 
 **Result**:
 
@@ -68,7 +63,7 @@ Content-Length: 0
 
 This endpoint produces no content except in case of error.
 As the ability to update a deployment is a premium feature, attempting to perform
-a deployment update using the open source version of Yorc will return the error `409 Conflict`.
+a deployment update using the open source version of Yorc will return the error `403 Forbidden`.
 
 ### List deployments <a name="list-deps"></a>
 
@@ -678,7 +673,7 @@ This endpoint will failed with an error "400 Bad Request" if:
 ### Execute a workflow <a name="workflow-exec"></a>
 
 Submit a custom workflow for a given deployment.
-By adding the optional 'continueOnError' url parameter to your request, 
+By adding the optional 'continueOnError' url parameter to your request,
 workflow will not stop at the first encountered error and will run to its end.
 
 By default the execution of the workflow's steps take place on all the instances of the workflow's nodes.

--- a/rest/infra_usage_test.go
+++ b/rest/infra_usage_test.go
@@ -51,7 +51,7 @@ func testPostInfraUsageHandler(t *testing.T, client *api.Client, srv *testutil.T
 	reg.RegisterInfraUsageCollector("myInfraName", mock, "mock")
 
 	req := httptest.NewRequest("POST", "/infra_usage/myInfraName/myLocationName", nil)
-	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Content-Type", mimeTypeApplicationJSON)
 	resp := newTestHTTPRouter(client, req)
 
 	require.NotNil(t, resp, "unexpected nil response")

--- a/rest/structs.go
+++ b/rest/structs.go
@@ -70,7 +70,7 @@ type AtomLink struct {
 }
 
 func newAtomLink(rel, href string) AtomLink {
-	return AtomLink{Rel: rel, Href: href, LinkType: "application/json"}
+	return AtomLink{Rel: rel, Href: href, LinkType: mimeTypeApplicationJSON}
 }
 
 // Health of a Yorc instance

--- a/rest/task_query_test.go
+++ b/rest/task_query_test.go
@@ -59,7 +59,7 @@ func testGetTaskQueryHandler(t *testing.T, client *api.Client, srv *testutil.Tes
 	})
 
 	req := httptest.NewRequest("GET", "/infra_usage/myInfraName/myLocationName/tasks/task123", nil)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", mimeTypeApplicationJSON)
 	resp := newTestHTTPRouter(client, req)
 
 	require.NotNil(t, resp, "unexpected nil response")
@@ -72,7 +72,7 @@ func testGetTaskQueryHandler(t *testing.T, client *api.Client, srv *testutil.Tes
 
 func testGetTaskQueryHandlerWithTaskNotFound(t *testing.T, client *api.Client, srv *testutil.TestServer) {
 	req := httptest.NewRequest("GET", "/infra_usage/myInfraName/myLocationName/tasks/taskNotFound", nil)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", mimeTypeApplicationJSON)
 	resp := newTestHTTPRouter(client, req)
 
 	require.NotNil(t, resp, "unexpected nil response")
@@ -161,7 +161,7 @@ func testListTaskQueryHandler(t *testing.T, client *api.Client, srv *testutil.Te
 	})
 
 	req := httptest.NewRequest("GET", "/infra_usage", nil)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", mimeTypeApplicationJSON)
 	resp := newTestHTTPRouter(client, req)
 
 	require.NotNil(t, resp, "unexpected nil response")

--- a/rest/tls_test.go
+++ b/rest/tls_test.go
@@ -93,7 +93,7 @@ func testSSLEnabledNoServerVerify(t *testing.T, client *api.Client, srv *testuti
 	defer httpsSrv.Shutdown()
 
 	req, _ := http.NewRequest("GET", url+"/deployments", nil)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", mimeTypeApplicationJSON)
 
 	hclient := makeSSLtestClient("", "", "", false)
 	resp, err := hclient.Do(req)
@@ -119,7 +119,7 @@ func testSSLEnabledServerVerifyUnsignedClientCerts(t *testing.T, client *api.Cli
 	defer httpsSrv.Shutdown()
 
 	req, _ := http.NewRequest("GET", url+"/deployments", nil)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", mimeTypeApplicationJSON)
 
 	hclient := makeSSLtestClient("testdata/unsigned-cert.pem", "testdata/unsigned-key.pem", "", false)
 	resp, err := hclient.Do(req)
@@ -141,7 +141,7 @@ func testSSLEnabledServerVerifyNoClientCerts(t *testing.T, client *api.Client, s
 	defer httpsSrv.Shutdown()
 
 	req, _ := http.NewRequest("GET", url+"/deployments", nil)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", mimeTypeApplicationJSON)
 
 	hclient := makeSSLtestClient("", "", "", false)
 	resp, err := hclient.Do(req)
@@ -163,7 +163,7 @@ func testSSLEnabledServerVerifySignedClientCerts(t *testing.T, client *api.Clien
 	defer httpsSrv.Shutdown()
 
 	req, _ := http.NewRequest("GET", url+"/deployments", nil)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", mimeTypeApplicationJSON)
 
 	hclient := makeSSLtestClient("testdata/client-cert.pem", "testdata/client-key.pem", "", false)
 	resp, err := hclient.Do(req)
@@ -190,7 +190,7 @@ func testSSLEnabledClientVerifyUnsignedServerCerts(t *testing.T, client *api.Cli
 	defer httpsSrv.Shutdown()
 
 	req, _ := http.NewRequest("GET", url+"/deployments", nil)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", mimeTypeApplicationJSON)
 
 	hclient := makeSSLtestClient("testdata/client-cert.pem", "testdata/client-key.pem", "testdata/ca-cert.pem", true)
 	resp, err := hclient.Do(req)
@@ -212,7 +212,7 @@ func testSSLEnabledMutualVerification(t *testing.T, client *api.Client, srv *tes
 	defer httpsSrv.Shutdown()
 
 	req, _ := http.NewRequest("GET", url+"/deployments", nil)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", mimeTypeApplicationJSON)
 
 	hclient := makeSSLtestClient("testdata/client-cert.pem", "testdata/client-key.pem", "testdata/ca-cert.pem", true)
 	resp, err := hclient.Do(req)

--- a/rest/updates_oss.go
+++ b/rest/updates_oss.go
@@ -25,7 +25,7 @@ import (
 
 // updateDeployment updates a deployment
 func (s *Server) updateDeployment(w http.ResponseWriter, r *http.Request, id string) {
-	msg := fmt.Sprintf("Deployment with id %q already exists - Update supported only in premium versions", id)
+	msg := fmt.Sprintf("Trying to update deployment %q on an open source version. Updates are supported only on premium versions.", id)
 	log.Printf("[ERROR]: %s", msg)
-	writeError(w, r, newConflictRequest(msg))
+	writeError(w, r, newForbiddenRequest(msg))
 }


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Now updates are available on `PATCH /deployments/<deployment_id>` API endpoint and `PUT /deployments/<deployment_id>` API endpoint is used only for submitting new deployments.

This makes error handling on clients easier.

## Applicable Issues

Fixes #547