### PR TITLE
Fix concurrent operations that could modify a dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Yorc bootstrap on 4.0.0-M7 doesn't work unless an alternative download URL is provided for Yorc ([GH-561](https://github.com/ystia/yorc/issues/561))
 * Location properties stored in Vault are no longer resolvable ([GH-565](https://github.com/ystia/yorc/issues/565))
+* Can have current deployment and undeployment on the same application on specific conditions ([GH-567](https://github.com/ystia/yorc/issues/567))
+  * API calls to deploy and update a deployment will now prevent other API calls that may modify a deployment to run at the same time
 
 ## 4.0.0-M7 (November 29, 2019)
 

--- a/deployments/definition_store.go
+++ b/deployments/definition_store.go
@@ -34,6 +34,25 @@ import (
 	"github.com/ystia/yorc/v4/tosca"
 )
 
+const blockingOperationOnDeploymentFlagName = ".blockingOp"
+
+// AddBlockingOperationOnDeploymentFlag set a flag on a given deployment to specify that an operation is ongoing and no other tasks should be run on this deployment
+func AddBlockingOperationOnDeploymentFlag(ctx context.Context, deploymentID string) error {
+	return consulutil.StoreConsulKey(path.Join(consulutil.DeploymentKVPrefix, deploymentID, blockingOperationOnDeploymentFlagName), nil)
+}
+
+// RemoveBlockingOperationOnDeploymentFlag removes a flag on a given deployment to specify that an operation is ongoing and no other tasks should be run on this deployment
+func RemoveBlockingOperationOnDeploymentFlag(ctx context.Context, deploymentID string) error {
+	_, err := consulutil.GetKV().Delete(path.Join(consulutil.DeploymentKVPrefix, deploymentID, blockingOperationOnDeploymentFlagName), nil)
+	return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+}
+
+// HasBlockingOperationOnDeploymentFlag checks if there is a flag on a given deployment to specify that an operation is ongoing and no other tasks should be run on this deployment
+func HasBlockingOperationOnDeploymentFlag(ctx context.Context, deploymentID string) (bool, error) {
+	kvp, _, err := consulutil.GetKV().Get(path.Join(consulutil.DeploymentKVPrefix, deploymentID, blockingOperationOnDeploymentFlagName), nil)
+	return kvp != nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+}
+
 // StoreDeploymentDefinition takes a defPath and parse it as a tosca.Topology then it store it in consul under
 // consulutil.DeploymentKVPrefix/deploymentID
 func StoreDeploymentDefinition(ctx context.Context, deploymentID string, defPath string) error {

--- a/rest/consul_test.go
+++ b/rest/consul_test.go
@@ -65,25 +65,23 @@ func TestRunConsulRestPackageTests(t *testing.T) {
 	defer srv.Stop()
 
 	t.Run("groupRest", func(t *testing.T) {
-		/*
-			t.Run("testHostsPoolHandlers", func(t *testing.T) {
-				testHostsPoolHandlers(t, client, srv)
-			})*/
+		t.Run("testHostsPoolHandlers", func(t *testing.T) {
+			testHostsPoolHandlers(t, client, srv)
+		})
 		t.Run("testLocationsHandlers", func(t *testing.T) {
 			testLocationsHandlers(t, client, srv)
 		})
-		/*
-			t.Run("testSSLRest", func(t *testing.T) {
-				testSSLREST(t, client, srv)
-			})
-			t.Run("testDeploymentHandlers", func(t *testing.T) {
-				testDeploymentHandlers(t, client, srv)
-			})
-			t.Run("testPostInfraUsageHandler", func(t *testing.T) {
-				testPostInfraUsageHandler(t, client, srv)
-			})
-			t.Run("testTaskQueryHandlers", func(t *testing.T) {
-				testTaskQueryHandlers(t, client, srv)
-			})*/
+		t.Run("testSSLRest", func(t *testing.T) {
+			testSSLREST(t, client, srv)
+		})
+		t.Run("testDeploymentHandlers", func(t *testing.T) {
+			testDeploymentHandlers(t, client, srv)
+		})
+		t.Run("testPostInfraUsageHandler", func(t *testing.T) {
+			testPostInfraUsageHandler(t, client, srv)
+		})
+		t.Run("testTaskQueryHandlers", func(t *testing.T) {
+			testTaskQueryHandlers(t, client, srv)
+		})
 	})
 }

--- a/rest/consul_test.go
+++ b/rest/consul_test.go
@@ -52,7 +52,7 @@ func newTestHTTPRouter(client *api.Client, req *http.Request) *http.Response {
 		hostsPoolMgr:   hostspool.NewManagerWithSSHFactory(client, mockSSHClientFactory),
 		locationMgr:    locations.NewManager(client),
 		tasksCollector: collector.NewCollector(client),
-		config:         config.Configuration{},
+		config:         config.Configuration{WorkingDirectory: "../work"},
 	}
 	httpSrv.registerHandlers()
 	w := httptest.NewRecorder()

--- a/rest/dep_commons.go
+++ b/rest/dep_commons.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/ystia/yorc/v4/deployments"
+)
+
+func checkBlockingOperationOnDeployment(ctx context.Context, deploymentID string, w http.ResponseWriter, r *http.Request) bool {
+	hasBlocking, err := deployments.HasBlockingOperationOnDeploymentFlag(ctx, deploymentID)
+	if err != nil {
+		log.Panicf("%v", err)
+	}
+	if hasBlocking {
+		writeError(w, r, newBadRequestError(fmt.Errorf("deployment %q, is currently processing a blocking operation we can't proceed with your request until this operation finish", deploymentID)))
+		return false
+	}
+	return true
+}

--- a/rest/dep_custom.go
+++ b/rest/dep_custom.go
@@ -49,6 +49,10 @@ func (s *Server) newCustomCommandHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	if !checkBlockingOperationOnDeployment(ctx, id, w, r) {
+		return
+	}
+
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		log.Panic(err)

--- a/rest/dep_scale.go
+++ b/rest/dep_scale.go
@@ -45,6 +45,10 @@ func (s *Server) scaleHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !checkBlockingOperationOnDeployment(ctx, id, w, r) {
+		return
+	}
+
 	if len(nodeName) == 0 {
 		log.Panic("You must provide a nodename")
 	}

--- a/rest/dep_tasks.go
+++ b/rest/dep_tasks.go
@@ -135,6 +135,10 @@ func (s *Server) updateTaskStepStatusHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	if !checkBlockingOperationOnDeployment(ctx, deploymentID, w, r) {
+		return
+	}
+
 	// Check TaskStep/Task existence
 	stExists, stepBefore, err := tasks.TaskStepExists(taskID, stepID)
 	if err != nil {
@@ -183,6 +187,9 @@ func (s *Server) resumeTaskHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !checkBlockingOperationOnDeployment(ctx, id, w, r) {
+		return
+	}
 	if taskStatus, err := tasks.GetTaskStatus(taskID); err != nil {
 		log.Panic(err)
 	} else if taskStatus != tasks.TaskStatusFAILED {

--- a/rest/dep_workflow.go
+++ b/rest/dep_workflow.go
@@ -47,6 +47,10 @@ func (s *Server) newWorkflowHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !checkBlockingOperationOnDeployment(ctx, deploymentID, w, r) {
+		return
+	}
+
 	deploymentStatus, err := deployments.GetDeploymentStatus(ctx, deploymentID)
 	if err != nil {
 		log.Panicf("%v", err)

--- a/rest/deployments.go
+++ b/rest/deployments.go
@@ -175,6 +175,9 @@ func (s *Server) newDeploymentHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// TODO(loicalbertin) why do we create a new context here?
+	// I was expecting to use the one from http.Request
+	// To be checked if there is a good reason for this.
 	ctx := context.Background()
 	err := deployments.CleanupPurgedDeployments(ctx, s.consulClient, s.config.PurgedDeploymentsEvictionTimeout, uid)
 	if err != nil {


### PR DESCRIPTION
Fixes #567

# Pull Request description

## Description of the change

On deploy and update API add a flag that indicate that other modifications should not be allowed.
Other API endpoints that perform modifications on a deployment now check if this flag exists and fail if so.

### Description for the changelog

* Can have current deployment and undeployment on the same application on specific conditions ([GH-567](https://github.com/ystia/yorc/issues/567))
  * API calls to deploy and update a deployment will now prevent other API calls that may modify a deployment to run at the same time

## Applicable Issues

Fixes #567 