### PR TITLE
Apply locations config file even when no locations are configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Deployment stuck and cannot be resumed in certain circumstances ([GH-563](https://github.com/ystia/yorc/issues/563))
 * Yorc bootstrap on 4.0.0-M7 doesn't work unless an alternative download URL is provided for Yorc ([GH-561](https://github.com/ystia/yorc/issues/561))
 * Location properties stored in Vault are no longer resolvable ([GH-565](https://github.com/ystia/yorc/issues/565))
+* If no locations configured when first starting a Yorc server, the command "locations apply config_locations_file_path" won't work ([GH-574](https://github.com/ystia/yorc/issues/5674))
 * An error during deployment purge may let the deployment in a wrong state ([GH-572](https://github.com/ystia/yorc/issues/572))
 * Can have current deployment and undeployment on the same application on specific conditions ([GH-567](https://github.com/ystia/yorc/issues/567))
 * API calls to deploy and update a deployment will now prevent other API calls that may modify a deployment to run at the same time

--- a/commands/locations/locations_apply.go
+++ b/commands/locations/locations_apply.go
@@ -115,19 +115,21 @@ func applyLocationsConfig(client httputil.HTTPClient, args []string, autoApprove
 	// update newLocationsMap, updateLocationsMap and deleteLocationsMap
 	// based on already existent locations configurations
 	for _, locConfig := range existentLocsConfig {
-		if newLocConfig, ok := newLocationsMap[locConfig.Name]; ok {
+		newLocConfig, ok := newLocationsMap[locConfig.Name]
+		checkUpdate := false
+		if ok {
 			// newLocConfig corresponds to an already defined location
-			// Check if there is any change before registering the need to update
-			if locConfig.Type != newLocConfig.Type ||
-				!reflect.DeepEqual(locConfig.Properties, newLocConfig.Properties) {
-				// Add newLocConfig to the map for locations to update
-				updateLocationsMap[locConfig.Name] = newLocConfig
-			}
 			// Delete newLocConfig from the map of locations to create
 			delete(newLocationsMap, locConfig.Name)
+			checkUpdate = true
 		} else {
 			// locConfig is not in the new locations specifications, delete it from consul
 			deleteLocationsMap[locConfig.Name] = locConfig
+		}
+		// Check if there is any change before registering the need to update
+		if checkUpdate && (locConfig.Type != newLocConfig.Type || !reflect.DeepEqual(locConfig.Properties, newLocConfig.Properties)) {
+			// Add newLocConfig to the map for locations to update
+			updateLocationsMap[locConfig.Name] = newLocConfig
 		}
 	}
 

--- a/commands/locations/locations_apply.go
+++ b/commands/locations/locations_apply.go
@@ -100,8 +100,21 @@ func applyLocationsConfig(client httputil.HTTPClient, args []string, autoApprove
 	deleteLocationsMap := make(map[string]rest.LocationConfiguration)
 
 	// Get existent locations configuration
-	locsConfig, err := getLocationsConfig(client)
-	for _, locConfig := range locsConfig.Locations {
+	locsConfig, err := getLocationsConfig(client, false)
+	if err != nil {
+		return err
+	}
+	// Use an array for existent locations configuration
+	// to avoid nesting a for that contains if/the/else, in an if
+	var existentLocsConfig []rest.LocationConfiguration
+	if locsConfig != nil {
+		existentLocsConfig = locsConfig.Locations
+	} else {
+		existentLocsConfig = make([]rest.LocationConfiguration, 0)
+	}
+	// update newLocationsMap, updateLocationsMap and deleteLocationsMap
+	// based on already existent locations configurations
+	for _, locConfig := range existentLocsConfig {
 		if newLocConfig, ok := newLocationsMap[locConfig.Name]; ok {
 			// newLocConfig corresponds to an already defined location
 			// Check if there is any change before registering the need to update

--- a/commands/locations/locations_apply.go
+++ b/commands/locations/locations_apply.go
@@ -76,6 +76,15 @@ func readConfigFile(client httputil.HTTPClient, path string) (*rest.LocationsCol
 	return locationsApplied, nil
 }
 
+// Get locations definitions from a file proposed by the client
+func readLocationsConfig(client httputil.HTTPClient, configPath string) (*rest.LocationsCollection, error) {
+	locationsApplied, err := readConfigFile(client, configPath)
+	if err != nil {
+		return nil, err
+	}
+	return locationsApplied, nil
+}
+
 func applyLocationsConfig(client httputil.HTTPClient, args []string, autoApprove bool) error {
 	colorize := !noColor
 	if len(args) != 1 {
@@ -83,10 +92,7 @@ func applyLocationsConfig(client httputil.HTTPClient, args []string, autoApprove
 	}
 
 	// Get locations definitions proposed by the client
-	locationsApplied, err := readConfigFile(client, args[0])
-	if err != nil {
-		return err
-	}
+	locationsApplied, err := readLocationsConfig(client, args[0])
 
 	// Put all these desfinitions for the momemnt in a map of locations to create
 	newLocationsMap := make(map[string]rest.LocationConfiguration)

--- a/commands/locations/locations_apply.go
+++ b/commands/locations/locations_apply.go
@@ -77,8 +77,11 @@ func readConfigFile(client httputil.HTTPClient, path string) (*rest.LocationsCol
 }
 
 // Get locations definitions from a file proposed by the client
-func readLocationsConfig(client httputil.HTTPClient, configPath string) (*rest.LocationsCollection, error) {
-	locationsApplied, err := readConfigFile(client, configPath)
+func readLocationsConfig(client httputil.HTTPClient, args []string) (*rest.LocationsCollection, error) {
+	if len(args) != 1 {
+		return nil, errors.Errorf("Expecting a path to a file (got %d parameters)", len(args))
+	}
+	locationsApplied, err := readConfigFile(client, args[0])
 	if err != nil {
 		return nil, err
 	}
@@ -87,12 +90,12 @@ func readLocationsConfig(client httputil.HTTPClient, configPath string) (*rest.L
 
 func applyLocationsConfig(client httputil.HTTPClient, args []string, autoApprove bool) error {
 	colorize := !noColor
-	if len(args) != 1 {
-		return errors.Errorf("Expecting a path to a file (got %d parameters)", len(args))
-	}
 
 	// Get locations definitions proposed by the client
-	locationsApplied, err := readLocationsConfig(client, args[0])
+	locationsApplied, err := readLocationsConfig(client, args)
+	if err != nil {
+		return err
+	}
 
 	// Put all these desfinitions for the momemnt in a map of locations to create
 	newLocationsMap := make(map[string]rest.LocationConfiguration)

--- a/commands/locations/locations_apply_on_empty_test.go
+++ b/commands/locations/locations_apply_on_empty_test.go
@@ -1,0 +1,67 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package locations
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Mock client implementation for the apply command
+
+type httpMockClientApplyOnEmpty struct {
+}
+
+func (c *httpMockClientApplyOnEmpty) NewRequest(method, path string, body io.Reader) (*http.Request, error) {
+	return http.NewRequest(method, path, body)
+}
+
+func (c *httpMockClientApplyOnEmpty) Do(req *http.Request) (*http.Response, error) {
+
+	if req.Method == "POST" || req.Method == "PUT" {
+		res := httptest.ResponseRecorder{Code: 201}
+		return res.Result(), nil
+	}
+
+	w := httptest.NewRecorder()
+
+	return w.Result(), nil
+}
+
+func (c *httpMockClientApplyOnEmpty) Get(path string) (*http.Response, error) {
+	return &http.Response{}, nil
+}
+
+func (c *httpMockClientApplyOnEmpty) Head(path string) (*http.Response, error) {
+	return &http.Response{}, nil
+}
+
+func (c *httpMockClientApplyOnEmpty) Post(path string, contentType string, body io.Reader) (*http.Response, error) {
+	return &http.Response{}, nil
+}
+
+func (c *httpMockClientApplyOnEmpty) PostForm(path string, data url.Values) (*http.Response, error) {
+	return &http.Response{}, nil
+}
+
+func TestLocationApply(t *testing.T) {
+	err := applyLocationsConfig(&httpMockClientApplyOnEmpty{}, []string{"./testdata/locations.json"}, true)
+	require.NoError(t, err, "Failed to apply locations config on empty list")
+}

--- a/commands/locations/locations_apply_test.go
+++ b/commands/locations/locations_apply_test.go
@@ -112,7 +112,7 @@ func TestLocationApplyWithDirPath(t *testing.T) {
 	require.Error(t, err, "Expecting a path to a file")
 }
 
-func TestLocationApply(t *testing.T) {
+func TestLocationApplyOk(t *testing.T) {
 	err := applyLocationsConfig(&httpMockClientApply{}, []string{"./testdata/locations.json"}, true)
 	require.NoError(t, err, "Failed to apply locations config")
 }

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -338,18 +338,13 @@ Add a location defininition in JSON format.
 Flags:
   * ``--data`` or ``-d`` :  Specify a JSON format for location definition to add.
 
-Example of location definition named "testname", having type "t" and two properties "p1" and "p2":
 
-.. code-block:: JSON
+Example of location definition "testname" using ``--data`` flag:
 
-    {
-         "name": "testname",
-         "type": "t",
-         "properties" : {
-              "p1" : "v1",
-              "p2" : "v2"
-         }
-    }
+.. code-block:: bash
+
+     yorc locations add --data '{"name": "testname", "type": "t", "properties" : { "p1" : "v1", "p2" : "v2" }}'
+
 
 Update a location
 ~~~~~~~~~~~~~~~~~
@@ -364,17 +359,12 @@ Flags:
   * ``--data`` or ``-d`` :  Specify a JSON format for the location definition to update.
 
 
-Example:
+Example of "testname" location update using ``--data`` flag:
 
-.. code-block:: JSON
+.. code-block:: bash
 
-    {
-         "name": "testname",
-         "type": "other",
-         "properties" : {
-              "p1" : "v11"
-         }
-    }
+     yorc locations add --data '{"name": "testname", "type": "other", "properties" : { "p1" : "v111" }}'
+
 
 Delete a location
 ~~~~~~~~~~~~~~~~~

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -338,6 +338,18 @@ Add a location defininition in JSON format.
 Flags:
   * ``--data`` or ``-d`` :  Specify a JSON format for location definition to add.
 
+Example of location definition named "testname", having type "t" and two properties "p1" and "p2":
+
+.. code-block:: JSON
+
+    {
+         "name": "testname",
+         "type": "t",
+         "properties" : {
+              "p1" : "v1",
+              "p2" : "v2"
+         }
+    }
 
 Update a location
 ~~~~~~~~~~~~~~~~~
@@ -350,6 +362,19 @@ Update a given location's definition.
 
 Flags:
   * ``--data`` or ``-d`` :  Specify a JSON format for the location definition to update.
+
+
+Example:
+
+.. code-block:: JSON
+
+    {
+         "name": "testname",
+         "type": "other",
+         "properties" : {
+              "p1" : "v11"
+         }
+    }
 
 Delete a location
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Pull Request description
Correction to allow applying a locations config file even when no locations are configured

## Description of the change

### What I did
The _list_ and _appy_ location management commands use a function that gets the already configured locations using the locations REST API.
This function is now able to make a different treatement in the situation when no locations definition exist, depending on the caller's needs. In the case of the list command, the need is to return and print out status. In the case of the apply commnad, an appropriate result must be returned (nill) and the execution of the commands needs to continue

### How I did it

### How to verify it
Start a new Yorc without setting locations_file_path config property.
Define locations using apply command.
List the defined locations.

### Description for the changelog

## Applicable Issues
https://github.com/ystia/yorc/issues/574