### PR TITLE
Feature/gh 83 hostpool placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### FEATURES
+
+* Host pool election for compute allocation can be more relevant ([GH-83](https://github.com/ystia/yorc/issues/83))
+
 ## 4.0.0-M8 (January 24, 2020)
 
 ### BREAKING CHANGES

--- a/data/tosca/yorc-hostspool-types.yml
+++ b/data/tosca/yorc-hostspool-types.yml
@@ -44,12 +44,12 @@ policy_types:
     derived_from: yorc.policies.hostspool.Placement
     description: >
       The yorc hostpool TOSCA Policy placement which allows to allocate a host with a round robin algorithm.
-      It means the host with the less related allocations will be elect preferentially.
+      It means the host with the least related allocations will be elect preferentially.
     targets: [ tosca.nodes.Compute ]
 
   yorc.policies.hostspool.BinPackingPlacement:
     derived_from: yorc.policies.hostspool.Placement
     description: >
       The yorc hostpool TOSCA Policy placement which allows to allocate a host with a bin packing algorithm.
-      It means the host with the more related allocations will be elect preferentially.
+      It means the host with the most related allocations will be elect preferentially.
     targets: [ tosca.nodes.Compute ]

--- a/data/tosca/yorc-hostspool-types.yml
+++ b/data/tosca/yorc-hostspool-types.yml
@@ -3,7 +3,7 @@ tosca_definitions_version: yorc_tosca_simple_yaml_1_0
 metadata:
   template_name: yorc-hostspool-types
   template_author: yorc
-  template_version: 1.0.0
+  template_version: 1.1.0
 
 imports:
   - yorc: <yorc-types.yml>
@@ -33,3 +33,23 @@ node_types:
         properties:
           credentials:
             user: "not significant, will be set by yorc itself"
+
+policy_types:
+  yorc.policies.hostspool.Placement:
+    abstract: true
+    derived_from: tosca.policies.Placement
+    description: The yorc hostpool TOSCA Policy Placement.
+
+  yorc.policies.hostspool.RoundRobinPlacement:
+    derived_from: yorc.policies.hostspool.Placement
+    description: >
+      The yorc hostpool TOSCA Policy placement which allows to allocate a host with a round robin algorithm.
+      It means the host with the less related allocations will be elect preferentially.
+    targets: [ tosca.nodes.Compute ]
+
+  yorc.policies.hostspool.BinPackingPlacement:
+    derived_from: yorc.policies.hostspool.Placement
+    description: >
+      The yorc hostpool TOSCA Policy placement which allows to allocate a host with a bin packing algorithm.
+      It means the host with the more related allocations will be elect preferentially.
+    targets: [ tosca.nodes.Compute ]

--- a/data/tosca/yorc-hostspool-types.yml
+++ b/data/tosca/yorc-hostspool-types.yml
@@ -40,16 +40,16 @@ policy_types:
     derived_from: tosca.policies.Placement
     description: The yorc hostpool TOSCA Policy Placement.
 
-  yorc.policies.hostspool.RoundRobinPlacement:
+  yorc.policies.hostspool.WeightBalancedPlacement:
     derived_from: yorc.policies.hostspool.Placement
     description: >
-      The yorc hostpool TOSCA Policy placement which allows to allocate a host with a round robin algorithm.
-      It means the host with the least related allocations will be elect preferentially.
+      The yorc hostpool TOSCA Policy placement which allows to allocate a host with a weight-balanced algorithm.
+      It means the host the less allocated will be elect preferentially.
     targets: [ tosca.nodes.Compute ]
 
   yorc.policies.hostspool.BinPackingPlacement:
     derived_from: yorc.policies.hostspool.Placement
     description: >
       The yorc hostpool TOSCA Policy placement which allows to allocate a host with a bin packing algorithm.
-      It means the host with the most related allocations will be elect preferentially.
+      It means the host the more allocated will be elect preferentially.
     targets: [ tosca.nodes.Compute ]

--- a/helper/stringutil/stringutil_test.go
+++ b/helper/stringutil/stringutil_test.go
@@ -36,6 +36,7 @@ func TestGetLastElement(t *testing.T) {
 	}{
 		{name: "TestWithSeparator", args: args{str: "tosca.interfaces.node.lifecycle.standard.create", separator: "."}, expected: "create"},
 		{name: "TestWithoutSeparator", args: args{str: "tosca.interfaces.node.lifecycle.standard.create", separator: "_"}, expected: ""},
+		{name: "TestEmptyString", args: args{str: "", separator: "_"}, expected: ""},
 	}
 
 	for _, tt := range tests {

--- a/prov/hostspool/consul_test.go
+++ b/prov/hostspool/consul_test.go
@@ -104,8 +104,8 @@ func TestRunConsulHostsPoolPackageTests(t *testing.T) {
 	t.Run("testConsulManagerAllocateShareableCompute", func(t *testing.T) {
 		testConsulManagerAllocateShareableCompute(t, client)
 	})
-	t.Run("testConsulManagerAllocateWithRoundRobinPlacement", func(t *testing.T) {
-		testConsulManagerAllocateWithRoundRobinPlacement(t, client)
+	t.Run("testConsulManagerAllocateWithWeightBalancedPlacement", func(t *testing.T) {
+		testConsulManagerAllocateWithWeightBalancedPlacement(t, client)
 	})
 	t.Run("testConsulManagerAllocateShareableComputeWithSameAllocationPrefix", func(t *testing.T) {
 		testConsulManagerAllocateShareableComputeWithSameAllocationPrefix(t, client)

--- a/prov/hostspool/consul_test.go
+++ b/prov/hostspool/consul_test.go
@@ -104,6 +104,9 @@ func TestRunConsulHostsPoolPackageTests(t *testing.T) {
 	t.Run("testConsulManagerAllocateShareableCompute", func(t *testing.T) {
 		testConsulManagerAllocateShareableCompute(t, client)
 	})
+	t.Run("testConsulManagerAllocateWithRoundRobinPlacement", func(t *testing.T) {
+		testConsulManagerAllocateWithRoundRobinPlacement(t, client)
+	})
 	t.Run("testConsulManagerAllocateShareableComputeWithSameAllocationPrefix", func(t *testing.T) {
 		testConsulManagerAllocateShareableComputeWithSameAllocationPrefix(t, client)
 	})

--- a/prov/hostspool/executor.go
+++ b/prov/hostspool/executor.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/dustin/go-humanize"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-multierror"
 	"github.com/mitchellh/mapstructure"
@@ -138,13 +137,6 @@ func (e *defaultExecutor) execDelegateHostsPool(
 	return nil
 }
 
-func setInstancesStateWithContextualLogs(ctx context.Context, op operationParameters, instances []string, state tosca.NodeState) {
-
-	for _, instance := range instances {
-		deployments.SetInstanceStateWithContextualLogs(events.AddLogOptionalFields(ctx, events.LogOptionalFields{events.InstanceID: instance}), op.deploymentID, op.nodeName, instance, state)
-	}
-}
-
 func (e *defaultExecutor) hostsPoolCreate(ctx context.Context,
 	cc *api.Client, cfg config.Configuration,
 	op operationParameters, allocatedResources map[string]string) error {
@@ -182,7 +174,7 @@ func (e *defaultExecutor) hostsPoolCreate(ctx context.Context,
 		}
 	}
 
-	placement, err := e.getPlacementPolicy(ctx, op.deploymentID, op.nodeName)
+	placement, err := e.getPlacementPolicy(ctx, op, op.nodeName)
 	if err != nil {
 		return err
 	}
@@ -195,22 +187,29 @@ func (e *defaultExecutor) hostsPoolCreate(ctx context.Context,
 	return e.allocateHostsToInstances(ctx, instances, shareable, filters, op, allocatedResources, placement)
 }
 
-func (e *defaultExecutor) getPlacementPolicy(ctx context.Context, deploymentID, target string) (string, error) {
-	placementPolicies, err := deployments.GetPoliciesForTypeAndNode(ctx, deploymentID, placementPolicy, target)
+func (e *defaultExecutor) getPlacementPolicy(ctx context.Context, op operationParameters, target string) (string, error) {
+	placementPolicies, err := deployments.GetPoliciesForTypeAndNode(ctx, op.deploymentID, placementPolicy, target)
 	if err != nil {
 		return "", err
 	}
 
 	if len(placementPolicies) == 0 {
-		// Default placement policy
-		return binPackingPlacement, nil
+		return "", nil
 	}
 
 	if len(placementPolicies) > 1 {
 		return "", errors.Errorf("Found more than one placement policy to apply to node name:%q", target)
 	}
 
-	policyType, err := deployments.GetPolicyType(ctx, deploymentID, placementPolicies[0])
+	policyType, err := deployments.GetPolicyType(ctx, op.deploymentID, placementPolicies[0])
+	if err != nil {
+		return "", err
+	}
+
+	if err = op.hpManager.CheckPlacementPolicy(policyType); err != nil {
+		return "", err
+	}
+
 	return policyType, nil
 }
 
@@ -341,40 +340,6 @@ func (e *defaultExecutor) updateConnectionSettings(
 	return setInstanceAttributesFromLabels(ctx, op, instance, host.Labels)
 }
 
-func setInstanceAttributesValue(ctx context.Context, op operationParameters, instance, value string, attributes []string) error {
-	for _, attr := range attributes {
-		err := deployments.SetInstanceAttribute(ctx, op.deploymentID, op.nodeName, instance,
-			attr, value)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func setInstanceAttributesFromLabels(ctx context.Context, op operationParameters, instance string, labels map[string]string) error {
-	for label, value := range labels {
-		err := setAttributeFromLabel(ctx, op.deploymentID, op.nodeName, instance,
-			label, value, tosca.ComputeNodeNetworksAttributeName, tosca.NetworkNameProperty)
-		if err != nil {
-			return err
-		}
-		err = setAttributeFromLabel(ctx, op.deploymentID, op.nodeName, instance,
-			label, value, tosca.ComputeNodeNetworksAttributeName, tosca.NetworkIDProperty)
-		if err != nil {
-			return err
-		}
-		// This is bad as we split value even if we are not sure that it matches
-		err = setAttributeFromLabel(ctx, op.deploymentID, op.nodeName, instance,
-			label, strings.Split(value, ","), tosca.ComputeNodeNetworksAttributeName,
-			tosca.NetworkAddressesProperty)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (e *defaultExecutor) getAllocatedResourcesFromHostCapabilities(ctx context.Context, deploymentID, nodeName string) (map[string]string, error) {
 	res := make(map[string]string, 0)
 	p, err := deployments.GetCapabilityPropertyValue(ctx, deploymentID, nodeName, "host", "num_cpus")
@@ -401,82 +366,6 @@ func (e *defaultExecutor) getAllocatedResourcesFromHostCapabilities(ctx context.
 		res["host.disk_size"] = p.RawString()
 	}
 	return res, nil
-}
-
-func appendCapabilityFilter(ctx context.Context, deploymentID, nodeName, capName, propName, op string, filters []labelsutil.Filter) ([]labelsutil.Filter, error) {
-	p, err := deployments.GetCapabilityPropertyValue(ctx, deploymentID, nodeName, capName, propName)
-	if err != nil {
-		return filters, err
-	}
-
-	hasProp, propDataType, err := deployments.GetCapabilityPropertyType(ctx, deploymentID, nodeName, capName, propName)
-	if err != nil {
-		return filters, err
-	}
-
-	if p != nil && p.RawString() != "" {
-		var sb strings.Builder
-		sb.WriteString(capName)
-		sb.WriteString(".")
-		sb.WriteString(propName)
-		sb.WriteString(" ")
-		sb.WriteString(op)
-		sb.WriteString(" ")
-		if hasProp && propDataType == "string" {
-			// Strings need to be quoted in filters
-			sb.WriteString("'")
-			sb.WriteString(p.RawString())
-			sb.WriteString("'")
-
-		} else {
-			sb.WriteString(p.RawString())
-		}
-
-		f, err := labelsutil.CreateFilter(sb.String())
-		if err != nil {
-			return filters, err
-		}
-		return append(filters, f), nil
-	}
-	return filters, nil
-}
-
-func createFiltersFromComputeCapabilities(ctx context.Context, deploymentID, nodeName string) ([]labelsutil.Filter, error) {
-	var err error
-	filters := make([]labelsutil.Filter, 0)
-	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "host", "num_cpus", ">=", filters)
-	if err != nil {
-		return nil, err
-	}
-	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "host", "cpu_frequency", ">=", filters)
-	if err != nil {
-		return nil, err
-	}
-	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "host", "disk_size", ">=", filters)
-	if err != nil {
-		return nil, err
-	}
-	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "host", "mem_size", ">=", filters)
-	if err != nil {
-		return nil, err
-	}
-	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "os", "architecture", "=", filters)
-	if err != nil {
-		return nil, err
-	}
-	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "os", "type", "=", filters)
-	if err != nil {
-		return nil, err
-	}
-	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "os", "distribution", "=", filters)
-	if err != nil {
-		return nil, err
-	}
-	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "os", "version", "=", filters)
-	if err != nil {
-		return nil, err
-	}
-	return filters, nil
 }
 
 func (e *defaultExecutor) hostsPoolDelete(originalCtx context.Context, cc *api.Client,
@@ -509,92 +398,4 @@ func (e *defaultExecutor) hostsPoolDelete(originalCtx context.Context, cc *api.C
 		}
 	}
 	return errors.Wrap(errs, "errors encountered during hosts pool node release. Some hosts maybe not properly released.")
-}
-
-func setAttributeFromLabel(ctx context.Context, deploymentID, nodeName, instance, label string, value interface{}, prefix, suffix string) error {
-	if strings.HasPrefix(label, prefix+".") && strings.HasSuffix(label, "."+suffix) {
-		attrName := strings.Replace(strings.Replace(label, prefix+".", prefix+"/", -1), "."+suffix, "/"+suffix, -1)
-		err := deployments.SetInstanceAttributeComplex(ctx, deploymentID, nodeName, instance, attrName, value)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func updateResourcesLabels(origin map[string]string, diff map[string]string, operation func(a int64, b int64) int64) (map[string]string, error) {
-	labels := make(map[string]string)
-
-	// Host Resources Labels can only be updated when deployment resources requirement is described
-	if cpusDiffStr, ok := diff["host.num_cpus"]; ok {
-		if cpusOriginStr, ok := origin["host.num_cpus"]; ok {
-			cpusOrigin, err := strconv.Atoi(cpusOriginStr)
-			if err != nil {
-				return nil, err
-			}
-			cpusDiff, err := strconv.Atoi(cpusDiffStr)
-			if err != nil {
-				return nil, err
-			}
-
-			res := operation(int64(cpusOrigin), int64(cpusDiff))
-			labels["host.num_cpus"] = strconv.Itoa(int(res))
-		}
-	}
-
-	if memDiffStr, ok := diff["host.mem_size"]; ok {
-		if memOriginStr, ok := origin["host.mem_size"]; ok {
-			memOrigin, err := humanize.ParseBytes(memOriginStr)
-			if err != nil {
-				return nil, err
-			}
-			memDiff, err := humanize.ParseBytes(memDiffStr)
-			if err != nil {
-				return nil, err
-			}
-
-			res := operation(int64(memOrigin), int64(memDiff))
-			labels["host.mem_size"] = formatBytes(res, isIECformat(memOriginStr))
-		}
-	}
-
-	if diskDiffStr, ok := diff["host.disk_size"]; ok {
-		if diskOriginStr, ok := origin["host.disk_size"]; ok {
-			diskOrigin, err := humanize.ParseBytes(diskOriginStr)
-			if err != nil {
-				return nil, err
-			}
-			diskDiff, err := humanize.ParseBytes(diskDiffStr)
-			if err != nil {
-				return nil, err
-			}
-
-			res := operation(int64(diskOrigin), int64(diskDiff))
-			labels["host.disk_size"] = formatBytes(res, isIECformat(diskOriginStr))
-		}
-	}
-
-	return labels, nil
-}
-
-func add(valA int64, valB int64) int64 {
-	return valA + valB
-}
-
-func subtract(valA int64, valB int64) int64 {
-	return valA - valB
-}
-
-func formatBytes(value int64, isIEC bool) string {
-	if isIEC {
-		return humanize.IBytes(uint64(value))
-	}
-	return humanize.Bytes(uint64(value))
-}
-
-func isIECformat(value string) bool {
-	if value != "" && strings.HasSuffix(value, "iB") {
-		return true
-	}
-	return false
 }

--- a/prov/hostspool/executor_test.go
+++ b/prov/hostspool/executor_test.go
@@ -214,6 +214,7 @@ func routineExecDelegate(ctx context.Context, e *defaultExecutor, cc *api.Client
 		delegateOperation: delegateOperation,
 		hpManager:         hpManager,
 	}
+
 	err := e.execDelegateHostsPool(ctx, cc, cfg, operationParams)
 	if err != nil {
 		fmt.Printf("Error executing operation %s on node %s: %s\n", delegateOperation, nodeName, err.Error())

--- a/prov/hostspool/hostspool_mgr.go
+++ b/prov/hostspool/hostspool_mgr.go
@@ -59,6 +59,7 @@ type Manager interface {
 	Release(locationName, hostname string, allocation *Allocation) error
 	ListLocations() ([]string, error)
 	RemoveLocation(locationName string) error
+	CheckPlacementPolicy(placementPolicy string) error
 }
 
 // SSHClientFactory is a that could be called to customize the client used to check the connection.

--- a/prov/hostspool/hostspool_mgr_allocation.go
+++ b/prov/hostspool/hostspool_mgr_allocation.go
@@ -215,7 +215,7 @@ func getAddAllocationsOperation(locationName, hostname string, allocations []All
 				getKVTxnOp(api.KVSet, path.Join(allocKVPrefix, "node_name"), []byte(alloc.NodeName)),
 				getKVTxnOp(api.KVSet, path.Join(allocKVPrefix, "instance"), []byte(alloc.Instance)),
 				getKVTxnOp(api.KVSet, path.Join(allocKVPrefix, "deployment_id"), []byte(alloc.DeploymentID)),
-				getKVTxnOp(api.KVSet, path.Join(allocKVPrefix, "shareable"),  []byte(strconv.FormatBool(alloc.Shareable))),
+				getKVTxnOp(api.KVSet, path.Join(allocKVPrefix, "shareable"), []byte(strconv.FormatBool(alloc.Shareable))),
 				getKVTxnOp(api.KVSet, path.Join(allocKVPrefix, "placement_policy"), []byte(alloc.PlacementPolicy)),
 			}
 
@@ -293,8 +293,7 @@ func (cm *consulManager) GetAllocations(locationName, hostname string) ([]Alloca
 		alloc := Allocation{}
 		alloc.ID = id
 
-
-		stringFields := []struct{
+		stringFields := []struct {
 			name string
 			attr *string
 		}{
@@ -313,7 +312,6 @@ func (cm *consulManager) GetAllocations(locationName, hostname string) ([]Alloca
 				*field.attr = string(kvp.Value)
 			}
 		}
-
 
 		kvp, _, err := cm.cc.KV().Get(path.Join(key, "shareable"), nil)
 		if err != nil {

--- a/prov/hostspool/hostspool_mgr_allocation.go
+++ b/prov/hostspool/hostspool_mgr_allocation.go
@@ -30,9 +30,9 @@ import (
 )
 
 const (
-	binPackingPlacement = "yorc.policies.hostspool.BinPackingPlacement"
-	roundRobinPlacement = "yorc.policies.hostspool.RoundRobinPlacement"
-	placementPolicy     = "yorc.policies.hostspool.Placement"
+	binPackingPlacement     = "yorc.policies.hostspool.BinPackingPlacement"
+	weightBalancedPlacement = "yorc.policies.hostspool.WeightBalancedPlacement"
+	placementPolicy         = "yorc.policies.hostspool.Placement"
 )
 
 type hostCandidate struct {
@@ -123,9 +123,9 @@ func (cm *consulManager) allocateWait(locationName string, maxWaitTime time.Dura
 }
 func (cm *consulManager) electHostFromCandidates(locationName string, allocation *Allocation, candidates []hostCandidate) string {
 	switch allocation.PlacementPolicy {
-	case roundRobinPlacement:
-		log.Printf("Applying round-robin placement policy for location:%s, deployment:%s, node name:%s, instance:%s", locationName, allocation.DeploymentID, allocation.NodeName, allocation.Instance)
-		return roundRobin(candidates)
+	case weightBalancedPlacement:
+		log.Printf("Applying weight-balanced placement policy for location:%s, deployment:%s, node name:%s, instance:%s", locationName, allocation.DeploymentID, allocation.NodeName, allocation.Instance)
+		return weightBalanced(candidates)
 	case binPackingPlacement:
 		log.Printf("Applying bin packing placement policy for location:%s, deployment:%s, node name:%s, instance:%s", locationName, allocation.DeploymentID, allocation.NodeName, allocation.Instance)
 		return binPacking(candidates)
@@ -135,7 +135,7 @@ func (cm *consulManager) electHostFromCandidates(locationName string, allocation
 	}
 }
 
-func roundRobin(candidates []hostCandidate) string {
+func weightBalanced(candidates []hostCandidate) string {
 	hostname := candidates[0].name
 	minAllocations := candidates[0].allocations
 	for _, candidate := range candidates {
@@ -346,7 +346,7 @@ func (cm *consulManager) CheckPlacementPolicy(placementPolicy string) error {
 	}
 
 	switch placementPolicy {
-	case roundRobinPlacement, binPackingPlacement:
+	case weightBalancedPlacement, binPackingPlacement:
 		return nil
 	default:
 		return errors.Errorf("placement policy:%q is not actually supported", placementPolicy)

--- a/prov/hostspool/hostspool_mgr_allocation.go
+++ b/prov/hostspool/hostspool_mgr_allocation.go
@@ -345,6 +345,14 @@ func (cm *consulManager) GetAllocations(locationName, hostname string) ([]Alloca
 		}
 		alloc.Resources = resources
 
+		kvp, _, err = cm.cc.KV().Get(path.Join(key, "placement_policy"), nil)
+		if err != nil {
+			return nil, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+		}
+		if kvp != nil && len(kvp.Value) > 0 {
+			alloc.PlacementPolicy = string(kvp.Value)
+		}
+
 		allocations = append(allocations, alloc)
 	}
 	return allocations, nil

--- a/prov/hostspool/hostspool_mgr_test.go
+++ b/prov/hostspool/hostspool_mgr_test.go
@@ -1166,7 +1166,7 @@ func testConsulManagerAllocateShareableCompute(t *testing.T, cc *api.Client) {
 	require.Equal(t, HostStatusFree, allocatedHost.Status)
 }
 
-func testConsulManagerAllocateWithRoundRobinPlacement(t *testing.T, cc *api.Client) {
+func testConsulManagerAllocateWithWeightBalancedPlacement(t *testing.T, cc *api.Client) {
 	location := "myLocation1"
 	cleanupHostsPool(t, cc)
 	cm := &consulManager{cc, mockSSHClientFactory}
@@ -1189,7 +1189,7 @@ func testConsulManagerAllocateWithRoundRobinPlacement(t *testing.T, cc *api.Clie
 	assert.Equal(t, checkpoint, newCkpt, "Unexpected checkpoint in list")
 
 	// Allocate host1: first allocation
-	alloc1 := &Allocation{NodeName: "node_test1", Instance: "instance_test1", DeploymentID: "test1", Shareable: true, Resources: resources, PlacementPolicy: roundRobinPlacement}
+	alloc1 := &Allocation{NodeName: "node_test1", Instance: "instance_test1", DeploymentID: "test1", Shareable: true, Resources: resources, PlacementPolicy: weightBalancedPlacement}
 	require.NoError(t, err, "Unexpected error creating a filter")
 	allocatedName, warnings, err := cm.Allocate(location, alloc1, noFilters...)
 	assert.Equal(t, hostpool[0].Name, allocatedName,
@@ -1205,7 +1205,7 @@ func testConsulManagerAllocateWithRoundRobinPlacement(t *testing.T, cc *api.Clie
 	require.Equal(t, resources, allocatedHost.Allocations[0].Resources)
 
 	// Allocate host1: 2nd allocation
-	alloc2 := &Allocation{NodeName: "node_test2", Instance: "instance_test2", DeploymentID: "test2", Shareable: true, Resources: resources, PlacementPolicy: roundRobinPlacement}
+	alloc2 := &Allocation{NodeName: "node_test2", Instance: "instance_test2", DeploymentID: "test2", Shareable: true, Resources: resources, PlacementPolicy: weightBalancedPlacement}
 	allocatedName, warnings, err = cm.Allocate(location, alloc2, noFilters...)
 	assert.Equal(t, hostpool[1].Name, allocatedName,
 		"Unexpected host allocated")

--- a/prov/hostspool/hostspool_structs.go
+++ b/prov/hostspool/hostspool_structs.go
@@ -19,12 +19,14 @@ package hostspool
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 
-	"fmt"
 	"github.com/pkg/errors"
-	"net/url"
+
+	"github.com/ystia/yorc/v4/helper/stringutil"
 )
 
 // HostStatus x ENUM(
@@ -123,7 +125,7 @@ type Allocation struct {
 }
 
 func (alloc *Allocation) String() string {
-	allocStr := fmt.Sprintf("deployment: %s,node-instance: %s-%s,shareable: %t, placement policy:%s", alloc.DeploymentID, alloc.NodeName, alloc.Instance, alloc.Shareable, alloc.PlacementPolicy)
+	allocStr := fmt.Sprintf("deployment: %s,node-instance: %s-%s,shareable: %t, placement:%s", alloc.DeploymentID, alloc.NodeName, alloc.Instance, alloc.Shareable, stringutil.GetLastElement(alloc.PlacementPolicy, "."))
 	if alloc.Resources != nil && len(alloc.Resources) > 0 {
 		for k, v := range alloc.Resources {
 			allocStr += "," + k + ": " + v

--- a/prov/hostspool/hostspool_structs.go
+++ b/prov/hostspool/hostspool_structs.go
@@ -113,16 +113,17 @@ type HostConfig struct {
 
 // An Allocation describes the related allocation associated to a host pool
 type Allocation struct {
-	ID           string            `json:"id"`
-	NodeName     string            `json:"node_name"`
-	Instance     string            `json:"instance"`
-	DeploymentID string            `json:"deployment_id"`
-	Shareable    bool              `json:"shareable"`
-	Resources    map[string]string `json:"resource_labels,omitempty"`
+	ID              string            `json:"id"`
+	NodeName        string            `json:"node_name"`
+	Instance        string            `json:"instance"`
+	DeploymentID    string            `json:"deployment_id"`
+	Shareable       bool              `json:"shareable"`
+	Resources       map[string]string `json:"resource_labels,omitempty"`
+	PlacementPolicy string            `json:"placement_policy"`
 }
 
 func (alloc *Allocation) String() string {
-	allocStr := fmt.Sprintf("deployment: %s,node-instance: %s-%s,shareable: %t", alloc.DeploymentID, alloc.NodeName, alloc.Instance, alloc.Shareable)
+	allocStr := fmt.Sprintf("deployment: %s,node-instance: %s-%s,shareable: %t, placement policy:%s", alloc.DeploymentID, alloc.NodeName, alloc.Instance, alloc.Shareable, alloc.PlacementPolicy)
 	if alloc.Resources != nil && len(alloc.Resources) > 0 {
 		for k, v := range alloc.Resources {
 			allocStr += "," + k + ": " + v

--- a/prov/hostspool/testdata/topology_hp_compute.yaml
+++ b/prov/hostspool/testdata/topology_hp_compute.yaml
@@ -120,6 +120,10 @@ topology_template:
             min_instances: 1
             max_instances: 1
             default_instances: 1
+  policies:
+    - BinPackingPlacementPolicy:
+        type: yorc.policies.hostspool.BinPackingPlacement
+        targets: [ Compute,Compute2]
   workflows:
     install:
       steps:

--- a/prov/hostspool/utils.go
+++ b/prov/hostspool/utils.go
@@ -181,7 +181,7 @@ func updateNumberResourcesLabels(origin map[string]string, diff map[string]strin
 	return nil
 }
 
-func updateSizeResourcesLabels(origin map[string]string, diff map[string]string, operation func(a int64, b int64) int64, labels map[string]string) error  {
+func updateSizeResourcesLabels(origin map[string]string, diff map[string]string, operation func(a int64, b int64) int64, labels map[string]string) error {
 	sizeResourcesLabels := []struct {
 		name string
 	}{

--- a/prov/hostspool/utils.go
+++ b/prov/hostspool/utils.go
@@ -110,10 +110,10 @@ func createFiltersFromComputeCapabilities(ctx context.Context, deploymentID, nod
 	var err error
 	filters := make([]labelsutil.Filter, 0)
 
-	filtersParams := []struct{
+	filtersParams := []struct {
 		capabilityName string
-		propertyName string
-		operator string
+		propertyName   string
+		operator       string
 	}{
 		{"host", "num_cpus", ">="},
 		{"host", "cpu_frequency", ">="},
@@ -166,7 +166,7 @@ func updateResourcesLabels(origin map[string]string, diff map[string]string, ope
 		}
 	}
 
-	sizeResourcesLabels := []struct{
+	sizeResourcesLabels := []struct {
 		name string
 	}{
 		{"host.mem_size"},

--- a/prov/hostspool/utils.go
+++ b/prov/hostspool/utils.go
@@ -1,0 +1,233 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostspool
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/dustin/go-humanize"
+
+	"github.com/ystia/yorc/v4/deployments"
+	"github.com/ystia/yorc/v4/events"
+	"github.com/ystia/yorc/v4/helper/labelsutil"
+	"github.com/ystia/yorc/v4/tosca"
+)
+
+func setInstancesStateWithContextualLogs(ctx context.Context, op operationParameters, instances []string, state tosca.NodeState) {
+
+	for _, instance := range instances {
+		deployments.SetInstanceStateWithContextualLogs(events.AddLogOptionalFields(ctx, events.LogOptionalFields{events.InstanceID: instance}), op.deploymentID, op.nodeName, instance, state)
+	}
+}
+
+func setInstanceAttributesValue(ctx context.Context, op operationParameters, instance, value string, attributes []string) error {
+	for _, attr := range attributes {
+		err := deployments.SetInstanceAttribute(ctx, op.deploymentID, op.nodeName, instance,
+			attr, value)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setInstanceAttributesFromLabels(ctx context.Context, op operationParameters, instance string, labels map[string]string) error {
+	for label, value := range labels {
+		err := setAttributeFromLabel(ctx, op.deploymentID, op.nodeName, instance,
+			label, value, tosca.ComputeNodeNetworksAttributeName, tosca.NetworkNameProperty)
+		if err != nil {
+			return err
+		}
+		err = setAttributeFromLabel(ctx, op.deploymentID, op.nodeName, instance,
+			label, value, tosca.ComputeNodeNetworksAttributeName, tosca.NetworkIDProperty)
+		if err != nil {
+			return err
+		}
+		// This is bad as we split value even if we are not sure that it matches
+		err = setAttributeFromLabel(ctx, op.deploymentID, op.nodeName, instance,
+			label, strings.Split(value, ","), tosca.ComputeNodeNetworksAttributeName,
+			tosca.NetworkAddressesProperty)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func appendCapabilityFilter(ctx context.Context, deploymentID, nodeName, capName, propName, op string, filters []labelsutil.Filter) ([]labelsutil.Filter, error) {
+	p, err := deployments.GetCapabilityPropertyValue(ctx, deploymentID, nodeName, capName, propName)
+	if err != nil {
+		return filters, err
+	}
+
+	hasProp, propDataType, err := deployments.GetCapabilityPropertyType(ctx, deploymentID, nodeName, capName, propName)
+	if err != nil {
+		return filters, err
+	}
+
+	if p != nil && p.RawString() != "" {
+		var sb strings.Builder
+		sb.WriteString(capName)
+		sb.WriteString(".")
+		sb.WriteString(propName)
+		sb.WriteString(" ")
+		sb.WriteString(op)
+		sb.WriteString(" ")
+		if hasProp && propDataType == "string" {
+			// Strings need to be quoted in filters
+			sb.WriteString("'")
+			sb.WriteString(p.RawString())
+			sb.WriteString("'")
+
+		} else {
+			sb.WriteString(p.RawString())
+		}
+
+		f, err := labelsutil.CreateFilter(sb.String())
+		if err != nil {
+			return filters, err
+		}
+		return append(filters, f), nil
+	}
+	return filters, nil
+}
+
+func createFiltersFromComputeCapabilities(ctx context.Context, deploymentID, nodeName string) ([]labelsutil.Filter, error) {
+	var err error
+	filters := make([]labelsutil.Filter, 0)
+	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "host", "num_cpus", ">=", filters)
+	if err != nil {
+		return nil, err
+	}
+	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "host", "cpu_frequency", ">=", filters)
+	if err != nil {
+		return nil, err
+	}
+	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "host", "disk_size", ">=", filters)
+	if err != nil {
+		return nil, err
+	}
+	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "host", "mem_size", ">=", filters)
+	if err != nil {
+		return nil, err
+	}
+	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "os", "architecture", "=", filters)
+	if err != nil {
+		return nil, err
+	}
+	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "os", "type", "=", filters)
+	if err != nil {
+		return nil, err
+	}
+	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "os", "distribution", "=", filters)
+	if err != nil {
+		return nil, err
+	}
+	filters, err = appendCapabilityFilter(ctx, deploymentID, nodeName, "os", "version", "=", filters)
+	if err != nil {
+		return nil, err
+	}
+	return filters, nil
+}
+
+func setAttributeFromLabel(ctx context.Context, deploymentID, nodeName, instance, label string, value interface{}, prefix, suffix string) error {
+	if strings.HasPrefix(label, prefix+".") && strings.HasSuffix(label, "."+suffix) {
+		attrName := strings.Replace(strings.Replace(label, prefix+".", prefix+"/", -1), "."+suffix, "/"+suffix, -1)
+		err := deployments.SetInstanceAttributeComplex(ctx, deploymentID, nodeName, instance, attrName, value)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func updateResourcesLabels(origin map[string]string, diff map[string]string, operation func(a int64, b int64) int64) (map[string]string, error) {
+	labels := make(map[string]string)
+
+	// Host Resources Labels can only be updated when deployment resources requirement is described
+	if cpusDiffStr, ok := diff["host.num_cpus"]; ok {
+		if cpusOriginStr, ok := origin["host.num_cpus"]; ok {
+			cpusOrigin, err := strconv.Atoi(cpusOriginStr)
+			if err != nil {
+				return nil, err
+			}
+			cpusDiff, err := strconv.Atoi(cpusDiffStr)
+			if err != nil {
+				return nil, err
+			}
+
+			res := operation(int64(cpusOrigin), int64(cpusDiff))
+			labels["host.num_cpus"] = strconv.Itoa(int(res))
+		}
+	}
+
+	if memDiffStr, ok := diff["host.mem_size"]; ok {
+		if memOriginStr, ok := origin["host.mem_size"]; ok {
+			memOrigin, err := humanize.ParseBytes(memOriginStr)
+			if err != nil {
+				return nil, err
+			}
+			memDiff, err := humanize.ParseBytes(memDiffStr)
+			if err != nil {
+				return nil, err
+			}
+
+			res := operation(int64(memOrigin), int64(memDiff))
+			labels["host.mem_size"] = formatBytes(res, isIECformat(memOriginStr))
+		}
+	}
+
+	if diskDiffStr, ok := diff["host.disk_size"]; ok {
+		if diskOriginStr, ok := origin["host.disk_size"]; ok {
+			diskOrigin, err := humanize.ParseBytes(diskOriginStr)
+			if err != nil {
+				return nil, err
+			}
+			diskDiff, err := humanize.ParseBytes(diskDiffStr)
+			if err != nil {
+				return nil, err
+			}
+
+			res := operation(int64(diskOrigin), int64(diskDiff))
+			labels["host.disk_size"] = formatBytes(res, isIECformat(diskOriginStr))
+		}
+	}
+
+	return labels, nil
+}
+
+func add(valA int64, valB int64) int64 {
+	return valA + valB
+}
+
+func subtract(valA int64, valB int64) int64 {
+	return valA - valB
+}
+
+func formatBytes(value int64, isIEC bool) string {
+	if isIEC {
+		return humanize.IBytes(uint64(value))
+	}
+	return humanize.Bytes(uint64(value))
+}
+
+func isIECformat(value string) bool {
+	if value != "" && strings.HasSuffix(value, "iB") {
+		return true
+	}
+	return false
+}

--- a/prov/hostspool/utils.go
+++ b/prov/hostspool/utils.go
@@ -149,28 +149,20 @@ func updateResourcesLabels(origin map[string]string, diff map[string]string, ope
 	labels := make(map[string]string)
 
 	// Host Resources Labels can only be updated when deployment resources requirement is described
-
-	intResourcesLabels := []struct{
-		name string
-	}{
-		{"host.num_cpus"},
-	}
-
-	for _, resource := range intResourcesLabels {
-		if resourceDiffStr, ok := diff[resource.name]; ok {
-			if resourceOriginStr, ok := origin[resource.name]; ok {
-				resourceOrigin, err := strconv.Atoi(resourceOriginStr)
-				if err != nil {
-					return nil, err
-				}
-				resourceDiff, err := strconv.Atoi(resourceDiffStr)
-				if err != nil {
-					return nil, err
-				}
-
-				res := operation(int64(resourceOrigin), int64(resourceDiff))
-				labels[resource.name] = strconv.Itoa(int(res))
+	cpuResourcesLabel := "host.num_cpus"
+	if resourceDiffStr, ok := diff[cpuResourcesLabel]; ok {
+		if resourceOriginStr, ok := origin[cpuResourcesLabel]; ok {
+			resourceOrigin, err := strconv.Atoi(resourceOriginStr)
+			if err != nil {
+				return nil, err
 			}
+			resourceDiff, err := strconv.Atoi(resourceDiffStr)
+			if err != nil {
+				return nil, err
+			}
+
+			res := operation(int64(resourceOrigin), int64(resourceDiff))
+			labels[cpuResourcesLabel] = strconv.Itoa(int(res))
 		}
 	}
 


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Add policy types for hostspool:
- yorc.policies.hostspool.Placement (abstract policy)
- yorc.policies.hostspool.BinPackingPlacement (default placement policy)
- yorc.policies.hostspool.RoundRobinPlacement

Add PlacementPolicy field to struct hostspool.Allocation struct
Add electHostFromCandidates method to hostspool manager to apply placement policies

See related A4C-yorc-provider PR: https://github.com/alien4cloud/alien4cloud-yorc-provider/pull/17
See A4C documentation : http://alien4cloud.github.io/#applying-hosts-pool-placement-policies
See CI tests: https://github.com/ystia/yorc/blob/feature/godog-ci/testdata/ci/features/Placement.feature
### How to verify it
Create a hosts pool with 2 shareable nodes
Create an app with a 2-instances compute and deploy it with RoundRobin placement then BinPacking Placement then no placement.

You can see the hostpool placement with:
`yorc hp list -l myHpLocation`

### Description for the changelog

## Applicable Issues
#83 