### PR TITLE
Fix public_ip_address setting fro hostspool compute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Tosca public_ip_address attribute is wrongly set with private address for hosts pool computes ([GH-593](https://github.com/ystia/yorc/issues/593))
+
 ## 4.0.0-M8 (January 24, 2020)
 
 ### BREAKING CHANGES

--- a/prov/hostspool/executor.go
+++ b/prov/hostspool/executor.go
@@ -290,14 +290,8 @@ func (e *defaultExecutor) updateConnectionSettings(
 	if publicAddress, ok := host.Labels[tosca.ComputeNodePublicAddressAttributeName]; ok {
 		// For compatibility with components referencing a host public_ip_address,
 		// defining an attribute public_ip_address as well
-		err = setInstanceAttributesValue(ctx, op, instance, privateAddress,
+		err = setInstanceAttributesValue(ctx, op, instance, publicAddress,
 			[]string{tosca.ComputeNodePublicAddressAttributeName, "public_ip_address"})
-		if err != nil {
-			return err
-		}
-
-		err = deployments.SetInstanceAttribute(ctx, op.deploymentID, op.nodeName,
-			instance, tosca.ComputeNodePublicAddressAttributeName, publicAddress)
 		if err != nil {
 			return err
 		}

--- a/prov/hostspool/executor_test.go
+++ b/prov/hostspool/executor_test.go
@@ -198,9 +198,9 @@ func testExecDelegateForNodes(ctx context.Context, t *testing.T, testExecutor *d
 
 	// Check compute ip_address attributes
 	expected := map[string]string{
-		"public_address":          "1.2.3.4", // to cover some code using this resource
-		"public_ip_address":       "1.2.3.4",
-		"private_address":       "5.6.7.8",
+		"public_address":    "1.2.3.4", // to cover some code using this resource
+		"public_ip_address": "1.2.3.4",
+		"private_address":   "5.6.7.8",
 	}
 
 	for attribute, expectedValue := range expected {
@@ -211,8 +211,6 @@ func testExecDelegateForNodes(ctx context.Context, t *testing.T, testExecutor *d
 			assert.Equal(t, expectedValue, val.RawString(), "unexpected value %s for attribute %q instead of %s", val, expectedValue)
 		}
 	}
-
-
 
 }
 
@@ -286,7 +284,7 @@ func prepareTestEnv(t *testing.T, srv *testutil.TestServer, cc *api.Client, loca
 		"label1":                  "stringvalue1",
 		"public_address":          "1.2.3.4", // to cover some code using this resource
 		"public_ip_address":       "1.2.3.4",
-		"private_address":       "5.6.7.8",
+		"private_address":         "5.6.7.8",
 		"networks.0.network_name": "mynetwork",
 		"networks.0.network_id":   "123",
 		"networks.0.addresses":    "1.2.3.4,1.2.3.5",

--- a/prov/hostspool/executor_test.go
+++ b/prov/hostspool/executor_test.go
@@ -195,6 +195,25 @@ func testExecDelegateForNodes(ctx context.Context, t *testing.T, testExecutor *d
 				label, delegateOperation, k)
 		}
 	}
+
+	// Check compute ip_address attributes
+	expected := map[string]string{
+		"public_address":          "1.2.3.4", // to cover some code using this resource
+		"public_ip_address":       "1.2.3.4",
+		"private_address":       "5.6.7.8",
+	}
+
+	for attribute, expectedValue := range expected {
+		for _, nodeName := range nodeNames {
+			val, err := deployments.GetInstanceAttributeValue(ctx, deploymentID, nodeName, "0", attribute)
+			require.NoError(t, err, "Could not get instance attribute value for deploymentID:%s, node name:%s, attribute:%s", deploymentID, nodeName, attribute)
+			assert.NotNil(t, val, "Unexpected nil value for deploymentID:%s, node name:%s, attribute:%s", deploymentID, nodeName, attribute)
+			assert.Equal(t, expectedValue, val.RawString(), "unexpected value %s for attribute %q instead of %s", val, expectedValue)
+		}
+	}
+
+
+
 }
 
 func routineExecDelegate(ctx context.Context, e *defaultExecutor, cc *api.Client,
@@ -266,6 +285,8 @@ func prepareTestEnv(t *testing.T, srv *testutil.TestServer, cc *api.Client, loca
 		"os.type":                 "linux",
 		"label1":                  "stringvalue1",
 		"public_address":          "1.2.3.4", // to cover some code using this resource
+		"public_ip_address":       "1.2.3.4",
+		"private_address":       "5.6.7.8",
 		"networks.0.network_name": "mynetwork",
 		"networks.0.network_id":   "123",
 		"networks.0.addresses":    "1.2.3.4,1.2.3.5",


### PR DESCRIPTION
# Pull Request description

### Description for the changelog
Tosca public_ip_address attribute is wrongly set with private address for hosts pool computes ([GH-593](https://github.com/ystia/yorc/issues/593))
## Applicable Issues

fixes #593 
