### PR TITLE
Support TOSCA 1.3 to separate capability Compute from capability Container

### DIFF
--- a/commands/bootstrap/resources/topology/topology_ha.tmpl
+++ b/commands/bootstrap/resources/topology/topology_ha.tmpl
@@ -66,7 +66,7 @@ topology_template:
         - hostedOnComputeConsulHost:
             type_requirement: host
             node: ConsulCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
       capabilities:
         consul_server:
@@ -92,7 +92,7 @@ topology_template:
         - hostedOnComputeYorcHost:
             type_requirement: host
             node: YorcCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     JDK:
       type: org.alien4cloud.java.jdk.linux.nodes.OracleJDK
@@ -104,7 +104,7 @@ topology_template:
         - hostedOnAlien4CloudComputeHost:
             type_requirement: host
             node: Alien4CloudCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     Alien4Cloud:
       type: org.alien4cloud.alien4cloud.webapp.nodes.Alien4Cloud
@@ -193,7 +193,7 @@ topology_template:
         - hostedOnComputeNfsHost:
             type_requirement: host
             node: NFSCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
       capabilities:
         nfs_server:
@@ -211,7 +211,7 @@ topology_template:
         - hostedOnComputeYorcHost:
             type_requirement: host
             node: YorcCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     NFSClient:
       type: org.ystia.nfs.linux.ansible.nodes.NFSClient
@@ -227,7 +227,7 @@ topology_template:
         - hostedOnComputeYorcHost:
             type_requirement: host
             node: YorcCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     ConsulAgentA4C:
       type: org.ystia.yorc.experimental.consul.linux.ansible.nodes.ConsulAgent
@@ -256,7 +256,7 @@ topology_template:
         - hostedOnAlien4CloudComputeHost:
             type_requirement: host
             node: Alien4CloudCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
       capabilities:
         consul_agent:
@@ -293,7 +293,7 @@ topology_template:
         - hostedOnComputeYorcHost:
             type_requirement: host
             node: YorcCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
       capabilities:
         consul_agent:
@@ -332,7 +332,7 @@ topology_template:
         - hostedOnComputeYorcHost:
             type_requirement: host
             node: VaultCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
       capabilities:
         consul_agent:
@@ -361,7 +361,7 @@ topology_template:
             relationship: org.alien4cloud.vault.relationships.ConnectToConsulAgent
         - host:
             node: VaultCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     {{end}}
     YorcServer:
@@ -380,7 +380,7 @@ topology_template:
         - hostedOnComputeYorcHost:
             type_requirement: host
             node: YorcCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
         - joinConsulAgentConsulAgentConsul_agent:
             type_requirement: consul

--- a/commands/bootstrap/resources/topology/topology_single_node.tmpl
+++ b/commands/bootstrap/resources/topology/topology_single_node.tmpl
@@ -51,7 +51,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: YorcCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     Alien4Cloud:
       type: org.alien4cloud.alien4cloud.webapp.nodes.Alien4Cloud
@@ -142,7 +142,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: YorcCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     YorcServer:
       type: org.ystia.yorc.linux.ansible.nodes.YorcServer
@@ -160,7 +160,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: YorcCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
         - joinConsulAgentConsulServerConsul_agent:
             type_requirement: consul
@@ -214,7 +214,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: YorcCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
       capabilities:
         consul_server:
@@ -251,7 +251,7 @@ topology_template:
             relationship: org.alien4cloud.vault.relationships.ConnectToConsulAgent
         - host:
             node: YorcCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     {{end}}
     TerraformRuntime:
@@ -263,7 +263,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: YorcCompute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     Infrastructure: {{block "Infrastructure" .}} {{end}}
     YorcAnsibleConfig:

--- a/data/tosca/normative-types.yml
+++ b/data/tosca/normative-types.yml
@@ -183,10 +183,15 @@ capability_types:
     description: The Node capability indicates the base capabilities of a TOSCA Node Type.
 
   tosca.capabilities.Container:
-    derived_from: tosca.capabilities.Root
     description: >
-      The Container capability, when included on a Node Type or Template definition, indicates that the node can act as a container for
-      (or a host for) one or more other declared Node Types.
+      The Container capability, when included on a Node Type or Template definition, indicates that the node can act as a container for (or a host for)
+      one or more other declared Node Types.
+    derived_from: tosca.capabilities.Root
+
+  tosca.capabilities.Compute:
+    derived_from: tosca.capabilities.Container
+    description: >
+      The Compute capability, when included on a Node Type or Template definition, indicates that the node can provide hosting on a named compute resource.
     properties:
       num_cpus:
         type: integer
@@ -583,7 +588,7 @@ node_types:
           occurrences: [ 0, UNBOUNDED ]
     capabilities:
       host:
-        type: tosca.capabilities.Container
+        type: tosca.capabilities.Compute
         valid_source_types: [tosca.nodes.SoftwareComponent]
       endpoint:
         type: tosca.capabilities.Endpoint.Admin
@@ -610,7 +615,7 @@ node_types:
         required: false
     requirements:
       - host:
-          capability: tosca.capabilities.Container
+          capability: tosca.capabilities.Compute
           node: tosca.nodes.Compute
           relationship: tosca.relationships.HostedOn
 
@@ -624,7 +629,7 @@ node_types:
       data_endpoint: tosca.capabilities.Endpoint
       admin_endpoint: tosca.capabilities.Endpoint.Admin
       host:
-        type: tosca.capabilities.Container
+        type: tosca.capabilities.Compute
         valid_source_types: [ tosca.nodes.WebApplication ]
 
   tosca.nodes.WebApplication:
@@ -641,7 +646,7 @@ node_types:
         type: tosca.capabilities.Endpoint
     requirements:
       - host:
-          capability: tosca.capabilities.Container
+          capability: tosca.capabilities.Compute
           node: tosca.nodes.WebServer
           relationship: tosca.relationships.HostedOn
 
@@ -659,7 +664,7 @@ node_types:
         description: the port the DBMS service will listen to for data and requests
     capabilities:
       host:
-        type: tosca.capabilities.Container
+        type: tosca.capabilities.Compute
         valid_source_types: [ tosca.nodes.Database ]
 
   tosca.nodes.Database:
@@ -682,7 +687,7 @@ node_types:
         required: false
     requirements:
       - host:
-          capability: tosca.capabilities.Container
+          capability: tosca.capabilities.Compute
           node: tosca.nodes.DBMS
           relationship: tosca.relationships.HostedOn
     capabilities:
@@ -747,7 +752,7 @@ node_types:
       services on a single Compute host.
     capabilities:
       host:
-        type: tosca.capabilities.Container
+        type: tosca.capabilities.Compute
       scalable:
         type: tosca.capabilities.Scalable
 
@@ -756,7 +761,7 @@ node_types:
     description: The TOSCA Container Application node represents an application that requires Container-level virtualization technology.
     requirements:
       - host:
-          capability: tosca.capabilities.Container
+          capability: tosca.capabilities.Compute
           node: tosca.nodes.Container
           relationship: tosca.relationships.HostedOn
 

--- a/deployments/testdata/capabilities.yaml
+++ b/deployments/testdata/capabilities.yaml
@@ -123,7 +123,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: Compute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     EPCapNodePrivate:
       type: yorc.type.TypeWithEndpointCap
@@ -135,7 +135,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: Compute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     EPCapNodeNamedNet:
       type: yorc.type.TypeWithEndpointCap
@@ -149,5 +149,5 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: Compute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn

--- a/deployments/testdata/capabilities_properties.yaml
+++ b/deployments/testdata/capabilities_properties.yaml
@@ -19,7 +19,7 @@ topology_template:
       requirements:
         - host:
             node: Front
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     Tomcat:
       type: org.alien4cloud.nodes.Tomcat
@@ -235,6 +235,6 @@ capability_types:
   org.alien4cloud.lang.java.pub.capabilities.JDK:
     derived_from: tosca.capabilities.Container
   org.alien4cloud.capabilities.WarContainer:
-    derived_from: tosca.capabilities.Container
+    derived_from: tosca.capabilities.Compute
   org.alien4cloud.java.pub.capabilities.JDK:
     derived_from: tosca.capabilities.Container

--- a/deployments/testdata/get_op_output.yaml
+++ b/deployments/testdata/get_op_output.yaml
@@ -72,14 +72,14 @@ topology_template:
             relationship: yorc.tests.relationships.GetOPOutputsRel
         - host:
             node: Compute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     GetOPOutputsNodeSecondReq:
       type: yorc.tests.nodes.GetOPOutputs
       requirements:
         - host:
             node: Compute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
         - partition:
             node: BS

--- a/deployments/testdata/get_op_output_real.yaml
+++ b/deployments/testdata/get_op_output_real.yaml
@@ -149,7 +149,7 @@ node_types:
         type: starlings.capabilities.DockerVolume
     requirements:
       - hosted_on:
-          capability: tosca.capabilities.Container
+          capability: tosca.capabilities.Compute
           relationship: tosca.relationships.HostedOn
           occurrences: [1,1]
       - filesystem_endpoint:
@@ -229,7 +229,7 @@ topology_template:
       requirements:
         - host:
             node: Compute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     Compute:
       type: tosca.nodes.Compute
@@ -253,7 +253,7 @@ topology_template:
       requirements:
         - hosted_on:
             node: Compute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
         - filesystem_endpoint:
             node: DockerContainer
@@ -267,7 +267,7 @@ topology_template:
       requirements:
         - hosted_on:
             node: Compute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
         - filesystem_endpoint:
             node: DockerContainer

--- a/deployments/testdata/get_secrets.yaml
+++ b/deployments/testdata/get_secrets.yaml
@@ -19,7 +19,7 @@ topology_template:
       requirements:
         - host:
             node: Front
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     Tomcat:
       type: org.alien4cloud.nodes.Tomcat
@@ -243,6 +243,6 @@ capability_types:
   org.alien4cloud.lang.java.pub.capabilities.JDK:
     derived_from: tosca.capabilities.Container
   org.alien4cloud.capabilities.WarContainer:
-    derived_from: tosca.capabilities.Container
+    derived_from: tosca.capabilities.Compute
   org.alien4cloud.java.pub.capabilities.JDK:
     derived_from: tosca.capabilities.Container

--- a/deployments/testdata/global_interfaces_inputs.yaml
+++ b/deployments/testdata/global_interfaces_inputs.yaml
@@ -57,6 +57,6 @@ topology_template:
       requirements:
         - host:
             node: Compute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
 

--- a/deployments/testdata/issue_get_empty_prop_rel.yaml
+++ b/deployments/testdata/issue_get_empty_prop_rel.yaml
@@ -80,7 +80,7 @@ node_types:
         type: yorc.tests.capabilities.ValueAssignmentEndpoint
     requirements:
       - host:
-          capability: tosca.capabilities.Container
+          capability: tosca.capabilities.Compute
           relationship: tosca.relationships.HostedOn
       - server:
           capability: yorc.tests.capabilities.ValueAssignmentEndpoint
@@ -319,7 +319,7 @@ topology_template:
       requirements:
         - host:
             node: Compute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     ValueAssignmentNode2:
           type: yorc.tests.nodes.ValueAssignmentNode
@@ -371,7 +371,7 @@ topology_template:
           requirements:
             - host:
                 node: Compute
-                capability: tosca.capabilities.Container
+                capability: tosca.capabilities.Compute
                 relationship: tosca.relationships.HostedOn
             - server:
                 capability: yorc.tests.capabilities.ValueAssignmentEndpoint

--- a/deployments/testdata/relationship_workflow.yaml
+++ b/deployments/testdata/relationship_workflow.yaml
@@ -22,7 +22,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: Compute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     Compute:
       type: tosca.nodes.Compute

--- a/deployments/testdata/test_client_service_generated_topology.yml
+++ b/deployments/testdata/test_client_service_generated_topology.yml
@@ -43,7 +43,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: Compute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
       capabilities:
         appA_capA:

--- a/deployments/testdata/test_component.yml
+++ b/deployments/testdata/test_component.yml
@@ -82,7 +82,7 @@ topology_template:
       type: yorc.test.nodes.TestContainer
       properties: {component_version: 1.0, port: 80, document_root: /var/www}
       requirements:
-      - host: {node: TestCompute, capability: tosca.capabilities.Container, relationship: tosca.relationships.HostedOn}
+      - host: {node: TestCompute, capability: tosca.capabilities.Compute, relationship: tosca.relationships.HostedOn}
     Network:
       type: tosca.nodes.Network
       properties: {ip_version: 4}
@@ -90,7 +90,7 @@ topology_template:
       type: yorc.test.nodes.TestModule
       properties: {component_version: 1.0}
       requirements:
-      - host: {node: TestCompute, capability: tosca.capabilities.Container, relationship: tosca.relationships.HostedOn}
+      - host: {node: TestCompute, capability: tosca.capabilities.Compute, relationship: tosca.relationships.HostedOn}
   outputs:
     TestComponent_url:
       description: The URL

--- a/deployments/testdata/test_container.yml
+++ b/deployments/testdata/test_container.yml
@@ -47,4 +47,4 @@ node_types:
           implementation: scripts/install_testcontainer.sh
         start: scripts/start_testcontainer.sh
 capability_types:
-  yorc.test.capabilities.TestContainerCapability: {derived_from: tosca.capabilities.Container}
+  yorc.test.capabilities.TestContainerCapability: {derived_from: tosca.capabilities.Compute}

--- a/deployments/testdata/test_module.yml
+++ b/deployments/testdata/test_module.yml
@@ -17,7 +17,7 @@ node_types:
       attachWebsite: {type: yorc.test.capabilities.TestModuleCapability}
     requirements:
     - host:
-        capability: tosca.capabilities.Container
+        capability: tosca.capabilities.Compute
         node: tosca.nodes.Compute
         relationship: tosca.relationships.HostedOn
         occurrences: [1, 1]

--- a/deployments/testdata/test_topology.yml
+++ b/deployments/testdata/test_topology.yml
@@ -40,7 +40,7 @@ topology_template:
       type: yorc.test.nodes.TestContainer
       properties: {component_version: 1.0, port: 80, document_root: /var/www}
       requirements:
-      - host: {node: TestCompute, capability: tosca.capabilities.Container, relationship: tosca.relationships.HostedOn}
+      - host: {node: TestCompute, capability: tosca.capabilities.Compute, relationship: tosca.relationships.HostedOn}
       capabilities:
         data_endpoint:
           properties: {protocol: tcp, secure: false, network_name: PRIVATE, initiator: source}
@@ -53,7 +53,7 @@ topology_template:
       type: yorc.test.nodes.TestModule
       properties: {component_version: 1.0}
       requirements:
-      - host: {node: TestCompute, capability: tosca.capabilities.Container, relationship: tosca.relationships.HostedOn}
+      - host: {node: TestCompute, capability: tosca.capabilities.Compute, relationship: tosca.relationships.HostedOn}
   outputs:
     TestComponent_url:
       value:

--- a/deployments/testdata/test_topology_client_service.yml
+++ b/deployments/testdata/test_topology_client_service.yml
@@ -40,7 +40,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: ComputeInstance
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
         - joinServiceAppACapA:
             type_requirement: appA_capA

--- a/deployments/testdata/test_topology_service.yml
+++ b/deployments/testdata/test_topology_service.yml
@@ -56,7 +56,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: Compute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
       capabilities:
         appA_capA:

--- a/deployments/testdata/test_topology_substitution.yml
+++ b/deployments/testdata/test_topology_substitution.yml
@@ -65,7 +65,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: Compute
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     SrvImpl2Instance:
       type: yorc.tests.nodes.SrvImpl2

--- a/deployments/testdata/test_topology_updated.yml
+++ b/deployments/testdata/test_topology_updated.yml
@@ -40,7 +40,7 @@ topology_template:
       type: yorc.test.nodes.TestContainer
       properties: {component_version: 1.0, port: 80, document_root: /var/www}
       requirements:
-      - host: {node: TestCompute, capability: tosca.capabilities.Container, relationship: tosca.relationships.HostedOn}
+      - host: {node: TestCompute, capability: tosca.capabilities.Compute, relationship: tosca.relationships.HostedOn}
       capabilities:
         data_endpoint:
           properties: {protocol: tcp, secure: false, network_name: PRIVATE, initiator: source}
@@ -53,7 +53,7 @@ topology_template:
       type: yorc.test.nodes.TestModule
       properties: {component_version: 1.0}
       requirements:
-      - host: {node: TestCompute, capability: tosca.capabilities.Container, relationship: tosca.relationships.HostedOn}
+      - host: {node: TestCompute, capability: tosca.capabilities.Compute, relationship: tosca.relationships.HostedOn}
   outputs:
     TestComponent_url:
       value:

--- a/helper/provutil/testdata/BastionEndpointPriority.yaml
+++ b/helper/provutil/testdata/BastionEndpointPriority.yaml
@@ -13,7 +13,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: Bastion
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
       capabilities:
     Bastion:

--- a/helper/provutil/testdata/BastionRelationship.yaml
+++ b/helper/provutil/testdata/BastionRelationship.yaml
@@ -13,7 +13,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: BastionKey
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
       capabilities:
     BastionKey:
@@ -68,7 +68,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: BastionPassword
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     BastionPassword:
       type: yorc.nodes.Compute
@@ -102,7 +102,7 @@ topology_template:
         - hostedOnComputeHost:
             type_requirement: host
             node: BastionCapabilityCredentials
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     BastionCapabilityCredentials:
       type: yorc.nodes.Compute

--- a/prov/ansible/testdata/execTemplate.yml
+++ b/prov/ansible/testdata/execTemplate.yml
@@ -86,7 +86,7 @@ topology_template:
       requirements:
         - host:
             node: ComputeA
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
         - connect:
             node: NodeB
@@ -102,7 +102,7 @@ topology_template:
       requirements:
         - host:
             node: ComputeB
-            capability: tosca.capabilities.Container
+            capability: tosca.capabilities.Compute
             relationship: tosca.relationships.HostedOn
     ComputeA:
       type: tosca.nodes.Compute

--- a/tasks/workflow/testdata/workflow.yaml
+++ b/tasks/workflow/testdata/workflow.yaml
@@ -35,7 +35,7 @@ topology_template:
       - hostedOnComputeHost:
           type_requirement: host
           node: Compute
-          capability: tosca.capabilities.Container
+          capability: tosca.capabilities.Compute
           relationship: tosca.relationships.HostedOn
 
     Compute:


### PR DESCRIPTION
# Pull Request description

This PR supports the TOSCA profile v1.3 which introduces the new capability `tosca.capabilities.Compute` from `tosca.capabilities.Container` as described in GH-589

## Description of the change

### What I did

* Add new capability type `tosca.capabilities.Compute` in normative-types.yml.
* Adapt tests to use the new capability type as follows:
- Update all nodes hosting on a `tosca.nodes.Compute` and `tosca.nodes.WebServer` node to have a requirement from type `tosca.capabilities.Compute` (instead of `tosca.capabilities.Container`) as in TOSCA profile v1.3.
- For other nodes, they continue to have the requirement `tosca.capabilities.Container` as they are hosted on a `tosca.nodes.SoftwareComponent`.

### How to verify it

* Run unit test: OK
* Run integration test:
1. Update the repo `tosca-normative-types` from a4c with the new tosca definitions in this commit (49aa8c6).
2. Use a4c to boot a Compute node with a software component on it.

### Description for the changelog

Support TOSCA 1.3 to separate capability Compute from capability Container

## Applicable Issues

No issues if you have a new setup. But for existing ones, upgrade existing tosca types in a4c is difficult and I do not know how to do it properly.