### PR TITLE
Failure running workflow with inline activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Tosca public_ip_address attribute is wrongly set with private address for hosts pool computes ([GH-593](https://github.com/ystia/yorc/issues/593))
 * REQ_TARGET keyword on TOSCA doesn't work with requirement type ([GH-598](https://github.com/ystia/yorc/issues/598))
+* Failure running workflow with inline activity ([GH-592](https://github.com/ystia/yorc/issues/592))
 
 ## 4.0.0-M8 (January 24, 2020)
 

--- a/tasks/workflow/consul_test.go
+++ b/tasks/workflow/consul_test.go
@@ -45,8 +45,8 @@ func TestRunConsulWorkflowPackageTests(t *testing.T) {
 		t.Run("testRunStep", func(t *testing.T) {
 			testRunStep(t, srv, client)
 		})
-		t.Run("testRegisterInlineWorkflow", func(t *testing.T) {
-			testRegisterInlineWorkflow(t, srv, client)
+		t.Run("testInlineWorkflow", func(t *testing.T) {
+			testInlineWorkflow(t, srv, client)
 		})
 		t.Run("testDeleteExecutionTreeSamePrefix", func(t *testing.T) {
 			testDeleteExecutionTreeSamePrefix(t, client)

--- a/tasks/workflow/step.go
+++ b/tasks/workflow/step.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ystia/yorc/v4/prov/scheduling"
 	"github.com/ystia/yorc/v4/registry"
 	"github.com/ystia/yorc/v4/tasks"
+	"github.com/ystia/yorc/v4/tasks/collector"
 	"github.com/ystia/yorc/v4/tasks/workflow/builder"
 	"github.com/ystia/yorc/v4/tosca"
 )
@@ -371,22 +372,48 @@ func (s *step) runActivity(wfCtx context.Context, cfg config.Configuration, depl
 		}
 	case builder.ActivityTypeInline:
 		// Register inline workflow associated to the original task
-		return s.registerInlineWorkflow(wfCtx, activity.Value())
+		return s.registerInlineWorkflow(wfCtx, deploymentID, activity.Value())
 	}
 	return nil
 }
 
-func (s *step) registerInlineWorkflow(ctx context.Context, workflowName string) error {
+func (s *step) registerInlineWorkflow(ctx context.Context, deploymentID, workflowName string) error {
 	events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelINFO, s.t.targetID).RegisterAsString(fmt.Sprintf("Register workflow %q from taskID:%q, deploymentID:%q", workflowName, s.t.taskID, s.t.targetID))
-	wfOps, err := builder.BuildInitExecutionOperations(ctx, s.t.targetID, s.t.taskID, workflowName, true)
+
+	// Preparing a new task with its own data referencing the parent workflow step
+	parentData, err := tasks.GetAllTaskData(s.t.taskID)
 	if err != nil {
 		return err
 	}
-	err = tasks.StoreOperations(s.t.taskID, wfOps)
+	data := make(map[string]string)
+	for k, v := range parentData {
+		data[k] = v
+	}
+	data[taskDataParentWorkflowName] = s.WorkflowName
+	data[taskDataParentStepName] = s.Name
+	data[taskDataParentTaskID] = s.t.taskID
+	data[taskDataDeploymentID] = deploymentID
+	data[taskDataWorkflowName] = workflowName
+
+	taskID, err := collector.NewCollector(s.cc).RegisterTaskWithData(deploymentID, tasks.TaskTypeCustomWorkflow, data)
 	if err != nil {
-		err = errors.Wrapf(err, "Failed to register workflow init operations with workflow:%q, targetID:%q, taskID:%q", workflowName, s.t.targetID, s.t.taskID)
+		err = errors.Wrapf(err, "Failed to register inline workflow %s in parent workflow %s step %s, targetID %s, taskID:%q",
+			workflowName, s.WorkflowName, s.Name, s.t.targetID, s.t.taskID)
+	} else {
+		log.Debugf("Registered task %s for inline workflow %s in parent workflow %s step %s",
+			taskID, workflowName, s.WorkflowName, s.Name)
+		err = s.setStatus(tasks.TaskStepStatusRUNNING)
 	}
 
+	if err != nil {
+		err = s.setStatus(tasks.TaskStepStatusERROR)
+
+	}
+	// Marking this step as asynchronous as it should not be considered as
+	// done by the caller
+	s.Async = true
+	// No final function as here the workflow is not done
+	s.t.finalFunction = nil
 	return err
 }
 

--- a/tasks/workflow/step.go
+++ b/tasks/workflow/step.go
@@ -399,16 +399,14 @@ func (s *step) registerInlineWorkflow(ctx context.Context, deploymentID, workflo
 	if err != nil {
 		err = errors.Wrapf(err, "Failed to register inline workflow %s in parent workflow %s step %s, targetID %s, taskID %s",
 			workflowName, s.WorkflowName, s.Name, s.t.targetID, s.t.taskID)
-	} else {
-		log.Debugf("Registered task %s for inline workflow %s in parent workflow %s step %s",
-			taskID, workflowName, s.WorkflowName, s.Name)
-		err = s.setStatus(tasks.TaskStepStatusRUNNING)
+		_ = s.setStatus(tasks.TaskStepStatusERROR)
+		return err
 	}
 
-	if err != nil {
-		err = s.setStatus(tasks.TaskStepStatusERROR)
+	log.Debugf("Registered task %s for inline workflow %s in parent workflow %s step %s",
+		taskID, workflowName, s.WorkflowName, s.Name)
+	_ = s.setStatus(tasks.TaskStepStatusRUNNING)
 
-	}
 	// Marking this step as asynchronous as it should not be considered as
 	// done by the caller
 	s.Async = true

--- a/tasks/workflow/step.go
+++ b/tasks/workflow/step.go
@@ -397,7 +397,7 @@ func (s *step) registerInlineWorkflow(ctx context.Context, deploymentID, workflo
 
 	taskID, err := collector.NewCollector(s.cc).RegisterTaskWithData(deploymentID, tasks.TaskTypeCustomWorkflow, data)
 	if err != nil {
-		err = errors.Wrapf(err, "Failed to register inline workflow %s in parent workflow %s step %s, targetID %s, taskID:%q",
+		err = errors.Wrapf(err, "Failed to register inline workflow %s in parent workflow %s step %s, targetID %s, taskID %s",
 			workflowName, s.WorkflowName, s.Name, s.t.targetID, s.t.taskID)
 	} else {
 		log.Debugf("Registered task %s for inline workflow %s in parent workflow %s step %s",

--- a/tasks/workflow/testdata/workflow.yaml
+++ b/tasks/workflow/testdata/workflow.yaml
@@ -26,6 +26,15 @@ node_types:
           implementation:
             type: ystia.yorc.tests.artifacts.Implementation.Custom
             file: whatever
+      custom:
+        operation1:
+          implementation:
+            type: ystia.yorc.tests.artifacts.Implementation.Custom
+            file: whatever
+        operation2:
+          implementation:
+            type: ystia.yorc.tests.artifacts.Implementation.Custom
+            file: whatever
 
 topology_template:
   node_templates:
@@ -53,6 +62,24 @@ topology_template:
             network_name: PRIVATE
             initiator: source
   workflows:
+    custom_wf1:
+      steps:
+        step_wf1:
+          target: WFNode
+          activities:
+          - call_operation: custom.operation1
+    custom_wf2:
+      steps:
+        first_step_wf2:
+          target: WFNode
+          activities:
+          - inline: custom_wf1
+          on_success:
+          - second_step_wf2
+        second_step_wf2:
+          target: WFNode
+          activities:
+          - call_operation: custom.operation1
     install:
       steps:
         Compute_install:

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -769,7 +769,7 @@ func (w *worker) runWorkflowStep(ctx context.Context, t *taskExecution, workflow
 	if err != nil {
 		return errors.Wrapf(err, "Failed to build step:%q for workflow:%q", t.step, workflowName)
 	}
-	if wfSteps == nil || len(wfSteps) == 0 {
+	if len(wfSteps) == 0 {
 		// Nothing to do
 		return nil
 	}

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -747,7 +747,7 @@ func (w *worker) runCustomWorkflow(ctx context.Context, t *taskExecution, wfName
 		}
 
 		// Check if this workflow was launched as an inline workflow by a parent workflow
-		parentWorkflow, err := getParentWorfklow(ctx, t, wfName)
+		parentWorkflow, err := getParentWorkflow(ctx, t, wfName)
 		if err != nil {
 			return err
 		}

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -588,7 +588,7 @@ func (w *worker) runUndeploy(ctx context.Context, t *taskExecution) error {
 			}
 			return nil
 		}
-		bypassErrors, err := w.checkByPassErrors(t, "uninstall")
+		bypassErrors, err := checkByPassErrors(t, "uninstall")
 		if err != nil {
 			return err
 		}
@@ -736,28 +736,30 @@ func (w *worker) runCustomWorkflow(ctx context.Context, t *taskExecution, wfName
 	if wfName == "" {
 		return errors.New("workflow name missing")
 	}
-	bypassErrors, err := w.checkByPassErrors(t, wfName)
+	bypassErrors, err := checkByPassErrors(t, wfName)
 	if err != nil {
 		return err
 	}
 	t.finalFunction = func() error {
-		_, err := updateTaskStatusAccordingToWorkflowStatus(ctx, t.targetID, t.taskID, wfName)
+		taskStatus, err := updateTaskStatusAccordingToWorkflowStatus(ctx, t.targetID, t.taskID, wfName)
+		if err != nil {
+			return err
+		}
+
+		// Check if this workflow was launched as an inline workflow by a parent workflow
+		parentWorkflow, err := getParentWorfklow(ctx, t, wfName)
+		if err != nil {
+			return err
+		}
+
+		if parentWorkflow != "" {
+			err = updateParentWorkflowStepAndRegisterNextSteps(ctx, t, parentWorkflow, taskStatus)
+		}
+
 		return err
 	}
 
 	return w.runWorkflowStep(ctx, t, wfName, bypassErrors)
-}
-
-func (w *worker) checkByPassErrors(t *taskExecution, wfName string) (bool, error) {
-	continueOnError, err := tasks.GetTaskData(t.taskID, "continueOnError")
-	if err != nil {
-		return false, err
-	}
-	bypassErrors, err := strconv.ParseBool(continueOnError)
-	if err != nil {
-		return false, errors.Wrapf(err, "failed to parse \"continueOnError\" flag for workflow:%q", wfName)
-	}
-	return bypassErrors, nil
 }
 
 // bool return indicates if the workflow is done

--- a/tasks/workflow/workflow.go
+++ b/tasks/workflow/workflow.go
@@ -135,8 +135,7 @@ func getParentWorfklow(ctx context.Context, t *taskExecution, wfName string) (st
 
 // Update a parent workflow step for which an inline workflow just finished with
 // the status in argument.
-// Register next steps of a parent workflow for which an inline workflow step
-// just finished with the status in argument
+// Register next steps depending on the status of the workflow execution
 func updateParentWorkflowStepAndRegisterNextSteps(ctx context.Context, t *taskExecution, wfName string, taskStatus tasks.TaskStatus) error {
 
 	// Get the parent step to update

--- a/tasks/workflow/workflow.go
+++ b/tasks/workflow/workflow.go
@@ -18,16 +18,30 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strconv"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/ystia/yorc/v4/events"
 	"github.com/ystia/yorc/v4/helper/consulutil"
 	"github.com/ystia/yorc/v4/log"
 	"github.com/ystia/yorc/v4/tasks"
 	"github.com/ystia/yorc/v4/tasks/workflow/builder"
+)
+
+const (
+	// Task data providing the parent worflow name for an inline workflow
+	taskDataParentWorkflowName = "parentWorkflowName"
+	// Task data providing the parent step name for an inline workflow
+	taskDataParentStepName = "parentStepName"
+	// Task data providing the parent task ID
+	taskDataParentTaskID = "parentTaskID"
+	// Task data providing the deployment ID
+	taskDataDeploymentID = "deploymentID"
+	// Task data providing the current workflow name
+	taskDataWorkflowName = "workflowName"
 )
 
 // createWorkflowStepsOperations returns Consul transactional KV operations for initiating workflow execution
@@ -106,4 +120,109 @@ func updateTaskStatusAccordingToWorkflowStatus(ctx context.Context, deploymentID
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelINFO, deploymentID).Registerf("Workflow %q ended without error", workflowName)
 	}
 	return status, errors.Wrapf(checkAndSetTaskStatus(ctx, deploymentID, taskID, status), "Failed to update task status to %q with TaskID: %q", status, taskID)
+}
+
+// Get the parent workflow of an inline workflow, returns an empty string if there
+// is no parent workflow
+func getParentWorfklow(ctx context.Context, t *taskExecution, wfName string) (string, error) {
+	parentWorkflow, err := tasks.GetTaskData(t.taskID, taskDataParentWorkflowName)
+	if err != nil && !tasks.IsTaskDataNotFoundError(err) {
+		return parentWorkflow, err
+	}
+
+	return parentWorkflow, nil
+}
+
+// Update a parent workflow step for which an inline workflow just finished with
+// the status in argument.
+// Register next steps of a parent workflow for which an inline workflow step
+// just finished with the status in argument
+func updateParentWorkflowStepAndRegisterNextSteps(ctx context.Context, t *taskExecution, wfName string, taskStatus tasks.TaskStatus) error {
+
+	// Get the parent step to update
+	parentStepName, err := tasks.GetTaskData(t.taskID, taskDataParentStepName)
+	if err != nil && !tasks.IsTaskDataNotFoundError(err) {
+		return err
+	}
+
+	if parentStepName == "" {
+		return errors.Wrapf(err, "Found no inline step name in task %s data for parent workflow %s", t.taskID, wfName)
+	}
+
+	// Get the parent task ID
+	parentTaskID, err := tasks.GetTaskData(t.taskID, taskDataParentTaskID)
+	if err != nil && !tasks.IsTaskDataNotFoundError(err) {
+		return err
+	}
+
+	if parentTaskID == "" {
+		return errors.Wrapf(err, "Found no parent task ID in task %s data for parent workflow %s", t.taskID, wfName)
+	}
+
+	stepStatus := tasks.TaskStepStatusDONE
+	if taskStatus == tasks.TaskStatusFAILED {
+		stepStatus = tasks.TaskStepStatusERROR
+	} else if taskStatus == tasks.TaskStatusCANCELED {
+		stepStatus = tasks.TaskStepStatusCANCELED
+	}
+	err = tasks.UpdateTaskStepWithStatus(parentTaskID, parentStepName, stepStatus)
+	if err != nil {
+		return err
+	}
+
+	if stepStatus == tasks.TaskStepStatusCANCELED {
+		return err
+	}
+
+	if stepStatus == tasks.TaskStepStatusERROR {
+		// Check the option continue on error
+		continueOnError, err := checkByPassErrors(t, wfName)
+		if err != nil || !continueOnError {
+			return err
+		}
+	}
+
+	// Add next steps
+	err = registerParentStepNextSteps(ctx, t, parentTaskID, wfName, parentStepName)
+	return err
+
+}
+
+func registerParentStepNextSteps(ctx context.Context, t *taskExecution, parentTaskID, wfName, stepName string) error {
+
+	// Get the deployment ID
+	deploymentID, err := tasks.GetTaskData(t.taskID, taskDataDeploymentID)
+	if err != nil {
+		return err
+	}
+
+	wfSteps, err := builder.BuildWorkFlow(ctx, deploymentID, wfName)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to build steps for workflow:%q", wfName)
+	}
+	if len(wfSteps) == 0 {
+		// Nothing to do
+		return nil
+	}
+
+	bs, ok := wfSteps[stepName]
+	if !ok {
+		return errors.Errorf("Failed to build step: %q for workflow: %q, unknown step", stepName, wfName)
+	}
+	t.taskID = parentTaskID
+	s := wrapBuilderStep(bs, t.cc, t)
+	return s.registerNextSteps(ctx, wfName)
+
+}
+
+func checkByPassErrors(t *taskExecution, wfName string) (bool, error) {
+	continueOnError, err := tasks.GetTaskData(t.taskID, "continueOnError")
+	if err != nil {
+		return false, err
+	}
+	bypassErrors, err := strconv.ParseBool(continueOnError)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to parse \"continueOnError\" flag for workflow:%q", wfName)
+	}
+	return bypassErrors, nil
 }

--- a/tasks/workflow/workflow.go
+++ b/tasks/workflow/workflow.go
@@ -124,7 +124,7 @@ func updateTaskStatusAccordingToWorkflowStatus(ctx context.Context, deploymentID
 
 // Get the parent workflow of an inline workflow, returns an empty string if there
 // is no parent workflow
-func getParentWorfklow(ctx context.Context, t *taskExecution, wfName string) (string, error) {
+func getParentWorkflow(ctx context.Context, t *taskExecution, wfName string) (string, error) {
 	parentWorkflow, err := tasks.GetTaskData(t.taskID, taskDataParentWorkflowName)
 	if err != nil && !tasks.IsTaskDataNotFoundError(err) {
 		return parentWorkflow, err

--- a/tasks/workflow/workflow.go
+++ b/tasks/workflow/workflow.go
@@ -145,7 +145,7 @@ func updateParentWorkflowStepAndRegisterNextSteps(ctx context.Context, t *taskEx
 	}
 
 	if parentStepName == "" {
-		return errors.Wrapf(err, "Found no inline step name in task %s data for parent workflow %s", t.taskID, wfName)
+		return errors.Errorf("Found no inline step name in task %s data for parent workflow %s", t.taskID, wfName)
 	}
 
 	// Get the parent task ID
@@ -155,7 +155,7 @@ func updateParentWorkflowStepAndRegisterNextSteps(ctx context.Context, t *taskEx
 	}
 
 	if parentTaskID == "" {
-		return errors.Wrapf(err, "Found no parent task ID in task %s data for parent workflow %s", t.taskID, wfName)
+		return errors.Errorf("Found no parent task ID in task %s data for parent workflow %s", t.taskID, wfName)
 	}
 
 	stepStatus := tasks.TaskStepStatusDONE

--- a/tasks/workflow/workflow_test.go
+++ b/tasks/workflow/workflow_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testutil"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ystia/yorc/v4/config"
@@ -31,6 +32,7 @@ import (
 	"github.com/ystia/yorc/v4/helper/consulutil"
 	"github.com/ystia/yorc/v4/prov"
 	"github.com/ystia/yorc/v4/registry"
+	"github.com/ystia/yorc/v4/tasks"
 	"github.com/ystia/yorc/v4/tasks/workflow/builder"
 )
 
@@ -184,13 +186,84 @@ func clearActivityHooks() {
 	postActivityHooks = make([]ActivityHook, 0)
 }
 
-func testRegisterInlineWorkflow(t *testing.T, srv1 *testutil.TestServer, cc *api.Client) {
+func testInlineWorkflow(t *testing.T, srv1 *testutil.TestServer, cc *api.Client) {
 	deploymentID := strings.Replace(t.Name(), "/", "_", -1)
-	topologyPath := "../../deployments/testdata/inline_workflow.yaml"
-	err := deployments.StoreDeploymentDefinition(context.Background(), deploymentID, topologyPath)
+	topologyPath := "testdata/workflow.yaml"
+	ctx := context.Background()
+	err := deployments.StoreDeploymentDefinition(ctx, deploymentID, topologyPath)
 	require.NoError(t, err, "Unexpected error storing %s", topologyPath)
 
-	_, err = builder.BuildWorkFlow(context.Background(), deploymentID, "install")
-	require.NoError(t, err, "Unexpected error building workflow for %s", topologyPath)
+	wfName := "custom_wf2"
+	inlineWfName := "custom_wf1"
+	stepName := "first_step_wf2"
+	taskID := "task" + "TestInline"
+	mockExecutor := &mockExecutor{}
+	registry.GetRegistry().RegisterDelegates([]string{"ystia.yorc.tests.nodes.WFCompute"}, mockExecutor, "tests")
+	registry.GetRegistry().RegisterOperationExecutor([]string{"ystia.yorc.tests.artifacts.Implementation.Custom"}, mockExecutor, "tests")
+
+	wfSteps, err := builder.BuildWorkFlow(ctx, deploymentID, wfName)
+	require.NoError(t, err, "Failed to build workflow %s", wfName)
+	bs := wfSteps[stepName]
+	require.NotNil(t, bs, "Failed to find step %s in workflow %s", stepName, wfName)
+
+	te := &taskExecution{id: "taskExec" + "TestInline", taskID: taskID, targetID: deploymentID, cc: cc}
+	s := wrapBuilderStep(bs, cc, te)
+	srv1.SetKV(t, path.Join(consulutil.WorkflowsPrefix, s.t.taskID, stepName), []byte("initial"))
+
+	// Preparing task data
+	err = tasks.SetTaskData(taskID, taskDataWorkflowName, wfName)
+	require.NoError(t, err, "Failed to prepare workflow task data for workflow %s", wfName)
+	err = tasks.SetTaskData(taskID, "continueOnError", "false")
+	require.NoError(t, err, "Failed to prepare task data for workflow %s", wfName)
+
+	err = s.run(ctx, config.Configuration{}, deploymentID, false, wfName, &worker{})
+	require.NoError(t, err, "Failed running step %s in workflow %s", stepName, wfName)
+	stepStatus, err := tasks.GetTaskStepStatus(taskID, s.Name)
+	require.NoError(t, err, "Failed to get task step %s status for workflow %s", s.Name, wfName)
+	require.Equal(t, tasks.TaskStepStatusRUNNING.String(), stepStatus.String(), "Expected step %s to be running for workflow %s", s.Name, wfName)
+
+	// Check a new task was created for the inline step
+	tasksIDs, err := tasks.GetQueryTaskIDs(tasks.TaskTypeCustomWorkflow, "", "")
+	require.NoError(t, err, "Failed to get tasks of type custom workflow")
+	var childTaskID string
+	for _, tid := range tasksIDs {
+		if tid != taskID {
+			childTaskID = tid
+			break
+		}
+	}
+	require.True(t, childTaskID != "", "Found no child task for inline workflow step")
+
+	// Checking this child task data
+	data, err := tasks.GetAllTaskData(childTaskID)
+	require.NoError(t, err, "Failed to get child task data")
+	assert.Equal(t, wfName, data[taskDataParentWorkflowName], "Bad value for parent workflow in child task data")
+	assert.Equal(t, stepName, data[taskDataParentStepName], "Bad value for parent step in child task data")
+	assert.Equal(t, taskID, data[taskDataParentTaskID], "Bad value for parent task ID in child task data")
+	assert.Equal(t, inlineWfName, data[taskDataWorkflowName], "Bad value for workflow name in child task data")
+
+	childTaskExec := &taskExecution{id: "taskExec" + "TestChild", taskID: childTaskID, targetID: deploymentID, cc: cc}
+	testWorker := &worker{
+		consulClient: cc,
+		cfg: config.Configuration{
+			WorkingDirectory: "./testdata/work/",
+		},
+	}
+
+	childTaskExec.step = "step_wf1"
+	srv1.SetKV(t, path.Join(consulutil.WorkflowsPrefix, childTaskExec.taskID, childTaskExec.step), []byte("initial"))
+	err = testWorker.runCustomWorkflow(ctx, childTaskExec, inlineWfName)
+	require.NoError(t, err, "Failed to run inline workflow %s", s.Name, inlineWfName)
+	require.True(t, mockExecutor.callOpsCalled, "Expected an operation to be executed, when running workflow %s")
+	err = childTaskExec.finalFunction()
+	require.NoError(t, err, "Failed to execute final function of child task execution for workflow %s", inlineWfName)
+	childTaskStatus, err := tasks.GetTaskStatus(childTaskID)
+	require.NoError(t, err, "Failed to get child task status")
+	require.Equal(t, tasks.TaskStatusDONE.String(), childTaskStatus.String(), "Wrong status for child task")
+
+	// Check the parent workflow step
+	stepStatus, err = tasks.GetTaskStepStatus(taskID, stepName)
+	require.NoError(t, err, "Failed to get task step %s status for workflow %s", stepName, wfName)
+	require.Equal(t, tasks.TaskStepStatusDONE.String(), stepStatus.String(), "Expected step %s to be done for workflow %s", stepName, wfName)
 
 }

--- a/tasks/workflow/workflow_test.go
+++ b/tasks/workflow/workflow_test.go
@@ -269,7 +269,7 @@ func testInlineWorkflow(t *testing.T, srv1 *testutil.TestServer, cc *api.Client)
 	// Error cases
 	// Using a task not related to a custon workflow
 	childTaskExec.taskID = "anotherTask"
-	parentWf, err := getParentWorfklow(ctx, childTaskExec, inlineWfName)
+	parentWf, err := getParentWorkflow(ctx, childTaskExec, inlineWfName)
 	require.NoError(t, err, "Did not expect an error getting the name of a workflow with wrong task")
 	require.Equal(t, "", parentWf, "Unexpected parent workflow found")
 	err = updateParentWorkflowStepAndRegisterNextSteps(ctx, childTaskExec, inlineWfName, tasks.TaskStatusDONE)


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Executing an inline workflow step in a new task, as this is really a new workflow made of steps itself, and running it in a separate task avoids potential step names collisions between the parent workflow and the child workflow that could occur if both were run in the same task.

### How I did it

Changes done:

`tasks/workflow/step.go`
Function registerInlineWorkflow():
Preparing a new task with its own data referencing the parent workflow step and parent task.
This task will take care of executing the inline workflow.

`tasks/workflow/worker.go`
Function runCustomWorkflow():
Modified the final function called when the workflow has finished, to do additional actions if this workflow is an inline workflow launched by a parent workflow step:
* update the parent workflow step status according to the status of this inline workflow execution
* register the parent workflow next steps

`tasks/workflow/workflow.go`:
Added functions to get the name of parent workflow from task data, update a parent workflow step state and register parent workflow next steps

### How to verify it

Using yorc as A4C UI doesn't work very well to follow the execution of a workflow with inline steps.
Deploy this zip file in attachment:
[deployment.zip](https://github.com/ystia/yorc/files/4171059/deployment.zip)
describing an OpenStack application with these custom workflows wf1, and wf2 for which the first step is the inline workflow wf1:
```yaml
    wf1:
      steps:
        Component_say_hello:
          target: Component
          activities:
            - call_operation: custom.say_hello
          on_success:
            - Component_say_goodbye
        Component_say_goodbye:
          target: Component
          activities:
            - call_operation: custom.say_goodbye
    wf2:
      steps:
        inline_wf1:
          activities:
            - inline: wf1
          on_success:
            - Component_say_hello
        Component_say_hello:
          target: Component
          activities:
            - call_operation: custom.say_hello
```

Run this command to deploy the application:

```bash
yorc deployments deploy deployment.zip --id test --stream-logs
```

Once done, run the workflow and follow the events, using this command:

```bash
yorc deployments workflows execute test --workflow-name wf2 --stream-events
```

Check these events occur showing workflow wf2 is running, this triggers the execution of workflow wf1 steps custom.say_hello and custom.say_goobye,
then the execution of workflow wf2 last step custom.say_hello :

```
Deployment: test Task "6d1bd3b6-9bd0-4c4f-8ac4-bf91eb87ea3e" (workflow) Workflow: wf2	 Status: running
[...] (workflow)	 Workflow: wf1	 Status: initial
[...] (workflow)	 Workflow: wf1	 Status: running
[...] (workflowStep)	 Workflow: wf1	 Instance: 0	 Step: Component_say_hello Node: Component	 Operation: custom.say_hello	 Status: initial
[...] (Execution)	 Execution: "5605e565-bbbe-4b77-a48b-b96d84f98281-0"	 Workflow: wf1	 Instance: 0	 Step: Component_say_hello	 Node: Component	 Operation: custom.say_hello	 Status: initial
[...] (workflowStep)	 Workflow: wf1	 Instance: 0	 Step: Component_say_hello Node: Component	 Operation: custom.say_hello	 Status: running
[...] (Execution)	 Execution: "5605e565-bbbe-4b77-a48b-b96d84f98281-0"	 Workflow: wf1	 Instance: 0	 Step: Component_say_hello	 Node: Component	 Operation: custom.say_hello	 Status: running
[...] (workflowStep)	 Workflow: wf1	 Instance: 0	 Step: Component_say_hello Node: Component	 Operation: custom.say_hello	 Status: done
[...] (Execution)	 Execution: "5605e565-bbbe-4b77-a48b-b96d84f98281-0"	 Workflow: wf1	 Instance: 0	 Step: Component_say_hello	 Node: Component	 Operation: custom.say_hello	 Status: done
[...] (workflowStep)	 Workflow: wf1	 Instance: 0	 Step: Component_say_goodbye	 Node: Component	 Operation: custom.say_goodbye	 Status: initial
[...] (Execution)	 Execution: "57005bf3-b671-4e90-9fe5-8cdc6edc3ca0-0"	 Workflow: wf1	 Instance: 0	 Step: Component_say_goodbye	 Node: Component	 Operation: custom.say_goodbye	 Status: initial
[...] (workflowStep)	 Workflow: wf1	 Instance: 0	 Step: Component_say_goodbye	 Node: Component	 Operation: custom.say_goodbye	 Status: running
[...] (Execution)	 Execution: "57005bf3-b671-4e90-9fe5-8cdc6edc3ca0-0"	 Workflow: wf1	 Instance: 0	 Step: Component_say_goodbye	 Node: Component	 Operation: custom.say_goodbye	 Status: running
[...] (workflowStep)	 Workflow: wf1	 Instance: 0	 Step: Component_say_goodbye	 Node: Component	 Operation: custom.say_goodbye	 Status: done
[...] (Execution)	 Execution: "57005bf3-b671-4e90-9fe5-8cdc6edc3ca0-0"	 Workflow: wf1	 Instance: 0	 Step: Component_say_goodbye	 Node: Component	 Operation: custom.say_goodbye	 Status: done
[...] (workflow)	 Workflow: wf1	 Status: done
[...] (workflowStep)	 Workflow: wf2	 Instance: 0	 Step: Component_say_hello Node: Component	 Operation: custom.say_hello	 Status: initial
[...] (Execution)	 Execution: "0d00bc24-fb5b-4399-acf2-340c8e3e6c05-0"	 Workflow: wf2	 Instance: 0	 Step: Component_say_hello	 Node: Component	 Operation: custom.say_hello	 Status: initial
[...] (workflowStep)	 Workflow: wf2	 Instance: 0	 Step: Component_say_hello Node: Component	 Operation: custom.say_hello	 Status: running
[...] (Execution)	 Execution: "0d00bc24-fb5b-4399-acf2-340c8e3e6c05-0"	 Workflow: wf2	 Instance: 0	 Step: Component_say_hello	 Node: Component	 Operation: custom.say_hello	 Status: running
[...] (workflowStep)	 Workflow: wf2	 Instance: 0	 Step: Component_say_hello Node: Component	 Operation: custom.say_hello	 Status: done
[...] (Execution)	 Execution: "0d00bc24-fb5b-4399-acf2-340c8e3e6c05-0"	 Workflow: wf2	 Instance: 0	 Step: Component_say_hello	 Node: Component	 Operation: custom.say_hello	 Status: done
[...] (workflow)	 Workflow: wf2	 Status: done

```
Check workflow wf2 task info (task id provided in the first event of the workflow execution above) :

```
yorc deployments tasks info --steps test 6d1bd3b6-9bd0-4c4f-8ac4-bf91eb87ea3e

Task:  6d1bd3b6-9bd0-4c4f-8ac4-bf91eb87ea3e
Task status: DONE
Task type: CustomWorkflow
Steps:
+---------------------+--------+
| Name                | Status |
+---------------------+--------+
| Component_say_hello | DONE   |
| inline_wf1          | DONE   |
+---------------------+--------+
```

### Description for the changelog

Failure running workflow with inline activity ([GH-592](https://github.com/ystia/yorc/issues/592))

## Applicable Issues

Closes #592 