### PR TITLE
Update REST API doc for server info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### BUG FIXES
 
 * Yorc Bootstrap doesn't uninstall yorc binary ([GH-605](https://github.com/ystia/yorc/issues/605))
+* Document server info REST API endpoint and change returned JSON to comply to our standards ([GH-609](https://github.com/ystia/yorc/issues/609))
 
 ## 4.0.0-M9 (February 14, 2020)
 

--- a/rest/http_api.md
+++ b/rest/http_api.md
@@ -755,11 +755,39 @@ Content-Type: application/json
   }
 }
 ```
-## Health
 
-### Get the Yorc service health
+## Server related endpoints
 
-This request si made by Consul to check the Yorc service is alive
+These endpoints are related to the queried Yorc server instance.
+
+### Get the Yorc server info
+
+This request return static information about the server. For now it only contains versions information.
+`yorc_version` field contains a [semantic versioning](https://semver.org/spec/v2.0.0.html) version number,
+while `git_commit` contains the git `sha1` of the server version.
+`yorc_version` may contain an option `build identifier` for specific builds like Yorc premium (see below for a sample).
+
+'Accept' header should be set to 'application/json'.
+
+`GET /server/info`
+
+**Response**:
+
+```HTTP
+HTTP/1.1 200 Created
+Content-Type: application/json
+```
+
+```json
+{
+  "yorc_version": "4.0.0-M10+premium",
+  "git_commit": "4572679f61f102088a8fe431fa88fd7f75dd9c1a"
+}
+```
+
+### Get the Yorc server health
+
+This endpoint is typically used by Consul to check the Yorc service is alive.
 
 'Accept' header should be set to 'application/json'.
 
@@ -1287,7 +1315,7 @@ Content-Type: application/json
 
 ### List locations
 
-List all the existent location definitions. 
+List all the existent location definitions.
 
 'Content-Type' header should be set to 'application/json'.
 
@@ -1314,7 +1342,7 @@ Content-Type: application/json
 
 ### Get location
 
-Get an existent location's definitions. 
+Get an existent location's definitions.
 
 'Content-Type' header should be set to 'application/json'.
 

--- a/rest/info_test.go
+++ b/rest/info_test.go
@@ -34,7 +34,7 @@ func TestGetInfoHandler(t *testing.T) {
 			status, http.StatusOK)
 	}
 
-	expected := "{\"YorcVersion\":\"Must Be defined by MakeFile\",\"GitCommit\":\"Must Be defined by MakeFile\"}\n"
+	expected := "{\"yorc_version\":\"Must Be defined by MakeFile\",\"git_commit\":\"Must Be defined by MakeFile\"}\n"
 	if rr.Body.String() != expected {
 		t.Errorf("handler returned unexpected body: got %q want %q",
 			rr.Body.String(), expected)

--- a/rest/structs.go
+++ b/rest/structs.go
@@ -329,6 +329,6 @@ type RegistryInfraUsageCollectorsCollection struct {
 
 // Info are the infos about the current YORC server
 type Info struct {
-	YorcVersion string
-	GitCommit   string
+	YorcVersion string `json:"yorc_version"`
+	GitCommit   string `json:"git_commit"`
 }


### PR DESCRIPTION
Also change the returned value to follow our standards.

# Pull Request description

## Description of the change

### What I did

Add server info section in REST API documentation.

Also changed returned JSON from:

```json
{
  "YorcVersion": "4.0.0-SNAPSHOT",
  "GitCommit": "528e655e27e3e770e8fb426b624318c31b2925b2"
}
```

to: 

```json
{
  "yorc_version": "4.0.0-SNAPSHOT",
  "git_commit": "528e655e27e3e770e8fb426b624318c31b2925b2"
}
```

to comply to our standards.

### Description for the changelog

* Document server info REST API endpoint and change returned JSON to comply to our standards ([GH-609](https://github.com/ystia/yorc/issues/609))


## Applicable Issues

Fixes #609 