### PR TITLE
Allow CLI locations to list all locations including hosts pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Yorc Bootstrap doesn't uninstall yorc binary ([GH-605](https://github.com/ystia/yorc/issues/605))
 * Document server info REST API endpoint and change returned JSON to comply to our standards ([GH-609](https://github.com/ystia/yorc/issues/609))
 * Default cache size for file storage is too large ([GH-612](https://github.com/ystia/yorc/issues/612))
+* CLI yorc locations list doesn't return HostsPool information ([GH-615](https://github.com/ystia/yorc/issues/615))
 
 ## 4.0.0-M9 (February 14, 2020)
 

--- a/commands/hostspool/hosts_pool_add.go
+++ b/commands/hostspool/hosts_pool_add.go
@@ -111,6 +111,9 @@ func addHost(client httputil.HTTPClient, args []string, location, jsonParam, pri
 	defer response.Body.Close()
 
 	httputil.HandleHTTPStatusCode(response, args[0], "host pool", http.StatusCreated)
+	if response.Header.Get("Warning") != "" {
+		fmt.Println("Warning :", response.Header.Get("Warning"))
+	}
 	fmt.Println("Command submitted. path :", response.Header.Get("Location"))
 	return nil
 }

--- a/commands/hostspool/hosts_pool_apply.go
+++ b/commands/hostspool/hosts_pool_apply.go
@@ -310,7 +310,7 @@ func applyHostsPoolConfig(client httputil.HTTPClient, args []string, location st
 	}
 	fmt.Println("New hosts pool configuration applied successfully.")
 	if connectionFailure {
-		fmt.Println("Connection failures occured for the following hosts:")
+		fmt.Println("Connection failures occurred for the following hosts:")
 		fmt.Println("")
 		fmt.Println(hostsTable.Render())
 	}

--- a/commands/hostspool/hosts_pool_update.go
+++ b/commands/hostspool/hosts_pool_update.go
@@ -17,6 +17,7 @@ package hostspool
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -112,5 +113,8 @@ func updateHost(client httputil.HTTPClient, args []string, location, jsonParam, 
 	defer response.Body.Close()
 
 	httputil.HandleHTTPStatusCode(response, args[0], "host pool", http.StatusOK)
+	if response.Header.Get("Warning") != "" {
+		fmt.Println("Warning :", response.Header.Get("Warning"))
+	}
 	return nil
 }

--- a/commands/locations/locations.go
+++ b/commands/locations/locations.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ystia/yorc/v4/commands"
 	"github.com/ystia/yorc/v4/commands/httputil"
 	"github.com/ystia/yorc/v4/config"
-	"github.com/ystia/yorc/v4/helper/tabutil"
 	"github.com/ystia/yorc/v4/rest"
 )
 
@@ -104,32 +103,6 @@ func getColoredText(colorize bool, text string, operation int) string {
 		return color.New(color.FgHiRed, color.Bold).SprintFunc()(text)
 	default:
 		return text
-	}
-}
-
-// AddRow adds a row to a table, with text colored according to the operation
-// longTable specifies table with all headers
-func addRow(table tabutil.Table, colorize bool, operation int, lConfig rest.LocationConfiguration) {
-	colNumber := 3
-
-	coloredColumns := make([]interface{}, colNumber)
-	locProps := lConfig.Properties
-	propKeys := locProps.Keys()
-	for i := 0; i < len(propKeys); i++ {
-		propValue := locProps.Get(propKeys[i])
-		value := fmt.Sprintf("%v", propValue)
-		prop := propKeys[i] + ": " + value
-		if i == 0 {
-			coloredColumns[0] = getColoredText(colorize, lConfig.Name, operation)
-			coloredColumns[1] = getColoredText(colorize, lConfig.Type, operation)
-			coloredColumns[2] = getColoredText(colorize, prop, operation)
-		} else {
-			coloredColumns[0] = getColoredText(colorize, "", operation)
-			coloredColumns[1] = getColoredText(colorize, "", operation)
-			coloredColumns[2] = getColoredText(colorize, prop, operation)
-
-		}
-		table.AddRow(coloredColumns...)
 	}
 }
 

--- a/commands/locations/locations_apply.go
+++ b/commands/locations/locations_apply.go
@@ -223,10 +223,10 @@ func amendLocationsMap(newLocationsMap, updateLocationsMap, deleteLocationsMap m
 func presentLocationsMap(locationsMap map[string]rest.LocationConfiguration, colorize bool, op int) {
 	if len(locationsMap) > 0 {
 		locationsTable := tabutil.NewTable()
-		locationsTable.AddHeaders("Name", "Type", "Properties")
 		for _, locConfig := range locationsMap {
-			addRow(locationsTable, colorize, op, locConfig)
+			displayLocationInfo(locationsTable, locConfig.Name, locConfig.Type, locConfig.Properties, colorize, op)
 		}
+
 		fmt.Printf("\n- Locations to %s:", opNames[op])
 		fmt.Println("")
 		fmt.Println(locationsTable.Render())

--- a/commands/locations/locations_info.go
+++ b/commands/locations/locations_info.go
@@ -50,7 +50,7 @@ func getLocationInfo(client httputil.HTTPClient, args []string) error {
 
 	locationTable := tabutil.NewTable()
 	locationTable.AddHeaders("Name", "Type", "Properties")
-	displayLocationInfo(locationTable, locConfig.Name, locConfig.Type, locConfig.Properties)
+	displayLocationInfo(locationTable, locConfig.Name, locConfig.Type, locConfig.Properties, false, 0)
 	fmt.Println(locationTable.Render())
 	return nil
 }

--- a/commands/locations/locations_info.go
+++ b/commands/locations/locations_info.go
@@ -50,7 +50,7 @@ func getLocationInfo(client httputil.HTTPClient, args []string) error {
 
 	locationTable := tabutil.NewTable()
 	locationTable.AddHeaders("Name", "Type", "Properties")
-	addRow(locationTable, false, locationShow, locConfig)
+	displayLocationInfo(locationTable, locConfig.Name, locConfig.Type, locConfig.Properties)
 	fmt.Println(locationTable.Render())
 	return nil
 }

--- a/commands/locations/locations_list.go
+++ b/commands/locations/locations_list.go
@@ -53,22 +53,22 @@ func listLocations(client httputil.HTTPClient) error {
 	locationsTable := tabutil.NewTable()
 	locationsTable.AddHeaders("Name", "Type", "Properties")
 	for _, locConfig := range locsConfig.Locations {
-		displayLocationInfo(locationsTable, locConfig.Name, locConfig.Type, locConfig.Properties)
+		displayLocationInfo(locationsTable, locConfig.Name, locConfig.Type, locConfig.Properties, false, 0)
 	}
 	fmt.Println("Locations:")
 	fmt.Println(locationsTable.Render())
 	return nil
 }
 
-func displayLocationInfo(table tabutil.Table, locationName, locationType string, properties config.DynamicMap) {
+func displayLocationInfo(table tabutil.Table, locationName, locationType string, properties config.DynamicMap, colorize bool, operation int) {
 	propKeys := properties.Keys()
 	for i := 0; i < len(propKeys); i++ {
 		propValue := properties.Get(propKeys[i])
-		displayProperties(table, locationName, locationType, i, propKeys[i], propValue, 0)
+		displayProperties(table, locationName, locationType, i, propKeys[i], propValue, 0, colorize, operation)
 	}
 }
 
-func displayRow(table tabutil.Table, locationName, locationType string, index int, propKey string, propValue interface{}, nbTabs int) {
+func displayRow(table tabutil.Table, locationName, locationType string, index int, propKey string, propValue interface{}, nbTabs int, colorize bool, operation int) {
 	value := fmt.Sprintf("%v", propValue)
 	var str string
 
@@ -84,33 +84,33 @@ func displayRow(table tabutil.Table, locationName, locationType string, index in
 	}
 
 	if index == 0 {
-		table.AddRow(locationName, locationType, str)
+		table.AddRow(getColoredText(colorize, locationName, operation), getColoredText(colorize, locationType, operation), getColoredText(colorize, str, operation))
 	} else {
-		table.AddRow("", "", str)
+		table.AddRow("", "", getColoredText(colorize, str, operation))
 	}
 }
 
-func displayProperties(table tabutil.Table, locationName, locationType string, index int, propKey string, propValue interface{}, nbTabs int) {
+func displayProperties(table tabutil.Table, locationName, locationType string, index int, propKey string, propValue interface{}, nbTabs int, colorize bool, operation int) {
 	switch v := propValue.(type) {
 	case []interface{}:
-		displayRow(table, locationName, locationType, index, propKey, "", nbTabs)
+		displayRow(table, locationName, locationType, index, propKey, "", nbTabs, colorize, operation)
 		index++
 		nbTabs++
 		for i := 0; i < len(v); i++ {
-			displayProperties(table, locationName, locationType, index, "", v[i], nbTabs)
+			displayProperties(table, locationName, locationType, index, "", v[i], nbTabs, colorize, operation)
 		}
 	case map[string]interface{}:
 		if propKey != "" {
-			displayRow(table, locationName, locationType, index, propKey, "", nbTabs)
+			displayRow(table, locationName, locationType, index, propKey, "", nbTabs, colorize, operation)
 			nbTabs++
 		}
 		index++
 
 		for k, val := range v {
-			displayProperties(table, locationName, locationType, index, k, val, nbTabs)
+			displayProperties(table, locationName, locationType, index, k, val, nbTabs, colorize, operation)
 		}
 	default:
-		displayRow(table, locationName, locationType, index, propKey, propValue, nbTabs)
+		displayRow(table, locationName, locationType, index, propKey, propValue, nbTabs, colorize, operation)
 	}
 }
 

--- a/commands/locations/locations_list.go
+++ b/commands/locations/locations_list.go
@@ -17,14 +17,13 @@ package locations
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-
 	"github.com/spf13/cobra"
 	"github.com/ystia/yorc/v4/commands/httputil"
+	"github.com/ystia/yorc/v4/config"
 	"github.com/ystia/yorc/v4/helper/tabutil"
-	"github.com/ystia/yorc/v4/locations/adapter"
 	"github.com/ystia/yorc/v4/rest"
+	"io/ioutil"
+	"net/http"
 )
 
 func init() {
@@ -40,36 +39,79 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			httputil.ErrExit(err)
 		}
-		return listLocations(client, args)
+		return listLocations(client)
 	},
 }
 
-func listLocations(client httputil.HTTPClient, args []string) error {
+func listLocations(client httputil.HTTPClient) error {
 	// Get locations definitions
 	locsConfig, err := getLocationsConfig(client, true)
 	if err != nil {
 		httputil.ErrExit(err)
 	}
 	// Print out locations definitions in a table
-	locsTable := tabutil.NewTable()
-	locsTable.AddHeaders("Name", "Type", "Properties")
+	locationsTable := tabutil.NewTable()
+	locationsTable.AddHeaders("Name", "Type", "Properties")
 	for _, locConfig := range locsConfig.Locations {
-		locProps := locConfig.Properties
-		propKeys := locProps.Keys()
-		for i := 0; i < len(propKeys); i++ {
-			propValue := locProps.Get(propKeys[i])
-			value := fmt.Sprintf("%v", propValue)
-			prop := propKeys[i] + ": " + value
-			if i == 0 {
-				locsTable.AddRow(locConfig.Name, locConfig.Type, prop)
-			} else {
-				locsTable.AddRow("", "", prop)
-			}
-		}
+		displayLocationInfo(locationsTable, locConfig.Name, locConfig.Type, locConfig.Properties)
 	}
 	fmt.Println("Locations:")
-	fmt.Println(locsTable.Render())
+	fmt.Println(locationsTable.Render())
 	return nil
+}
+
+func displayLocationInfo(table tabutil.Table, locationName, locationType string, properties config.DynamicMap) {
+	propKeys := properties.Keys()
+	for i := 0; i < len(propKeys); i++ {
+		propValue := properties.Get(propKeys[i])
+		displayProperties(table, locationName, locationType, i, propKeys[i], propValue, 0)
+	}
+}
+
+func displayRow(table tabutil.Table, locationName, locationType string, index int, propKey string, propValue interface{}, nbTabs int) {
+	value := fmt.Sprintf("%v", propValue)
+	var str string
+
+	// Add tabulations
+	for i := 0; i <= nbTabs; i++ {
+		str += "  "
+	}
+
+	if propKey != "" {
+		str += propKey + ": " + value
+	} else {
+		str += value
+	}
+
+	if index == 0 {
+		table.AddRow(locationName, locationType, str)
+	} else {
+		table.AddRow("", "", str)
+	}
+}
+
+func displayProperties(table tabutil.Table, locationName, locationType string, index int, propKey string, propValue interface{}, nbTabs int) {
+	switch v := propValue.(type) {
+	case []interface{}:
+		displayRow(table, locationName, locationType, index, propKey, "", nbTabs)
+		index++
+		nbTabs++
+		for i := 0; i < len(v); i++ {
+			displayProperties(table, locationName, locationType, index, "", v[i], nbTabs)
+		}
+	case map[string]interface{}:
+		if propKey != "" {
+			displayRow(table, locationName, locationType, index, propKey, "", nbTabs)
+			nbTabs++
+		}
+		index++
+
+		for k, val := range v {
+			displayProperties(table, locationName, locationType, index, k, val, nbTabs)
+		}
+	default:
+		displayRow(table, locationName, locationType, index, propKey, propValue, nbTabs)
+	}
 }
 
 // getLocationsConfig uses the HTTP client to make a request to locations API.
@@ -115,9 +157,7 @@ func getLocationsConfig(client httputil.HTTPClient, retOnError bool) (*rest.Loca
 		if err != nil {
 			return nil, err
 		}
-		if locConfig.Type != adapter.AdaptedLocationType {
-			locs.Locations = append(locs.Locations, locConfig)
-		}
+		locs.Locations = append(locs.Locations, locConfig)
 	}
 
 	return &locs, nil

--- a/commands/locations/locations_list_test.go
+++ b/commands/locations/locations_list_test.go
@@ -52,6 +52,29 @@ func (c *httpClientMockList) Do(req *http.Request) (*http.Response, error) {
 		locationConfigProps := make(map[string]interface{})
 		locationConfigProps["region"] = "us-east-2"
 		locationConfigProps["regionbis"] = "us-east-3"
+
+		locationConfigProps["security_groups"] = []string{"sg1", "sg2"}
+
+		locationConfigProps["hosts"] = []map[string]interface{}{
+			{
+				"name": "host1",
+				"connection": map[string]interface{}{
+					"user": "john",
+					"key":  "mykey.pem",
+					"host": "1.2.3.4",
+					"port": 22,
+				},
+			},
+			{
+				"name": "host2",
+				"connection": map[string]interface{}{
+					"user": "john",
+					"key":  "mykey.pem",
+					"host": "1.2.3.4",
+					"port": 22,
+				},
+			},
+		}
 		locationConfig := &rest.LocationConfiguration{Name: "location3", Type: "aws", Properties: locationConfigProps}
 		b, err := json.Marshal(locationConfig)
 		if err != nil {
@@ -80,6 +103,6 @@ func (c *httpClientMockList) PostForm(path string, data url.Values) (*http.Respo
 }
 
 func TestListLocations(t *testing.T) {
-	err := listLocations(&httpClientMockList{}, nil)
+	err := listLocations(&httpClientMockList{})
 	require.NoError(t, err, "Failed to get locations")
 }

--- a/commands/server.go
+++ b/commands/server.go
@@ -255,6 +255,7 @@ func setConfig() {
 	serverCmd.PersistentFlags().Bool("disable_ssh_agent", false, "Allow disabling ssh-agent use for SSH authentication on provisioned computes. Default is false. If true, compute credentials must provide a path to a private key file instead of key content.")
 	serverCmd.PersistentFlags().String("locations_file_path", "", "File path to locations configuration. This configuration is taken in account for the first time the server starts.")
 	serverCmd.PersistentFlags().Int("concurrency_limit_for_upgrades", config.DefaultUpgradesConcurrencyLimit, "Limit of concurrency used in Upgrade processes. If not set the default value will be used")
+	serverCmd.PersistentFlags().Duration("ssh_connection_timeout", config.DefaultSSHConnectionTimeout, "Timeout to establish SSH connection from Yorc SSH client. If not set the default value will be used")
 
 	serverCmd.PersistentFlags().Duration("tasks_dispatcher_long_poll_wait_time", config.DefaultTasksDispatcherLongPollWaitTime, "Wait time when long polling for executions tasks to dispatch to workers")
 	serverCmd.PersistentFlags().Duration("tasks_dispatcher_lock_wait_time", config.DefaultTasksDispatcherLockWaitTime, "Wait time for acquiring a lock for an execution task")
@@ -319,6 +320,7 @@ func setConfig() {
 	viper.BindPFlag("disable_ssh_agent", serverCmd.PersistentFlags().Lookup("disable_ssh_agent"))
 	viper.BindPFlag("locations_file_path", serverCmd.PersistentFlags().Lookup("locations_file_path"))
 	viper.BindPFlag("concurrency_limit_for_upgrades", serverCmd.PersistentFlags().Lookup("concurrency_limit_for_upgrades"))
+	viper.BindPFlag("ssh_connection_timeout", serverCmd.PersistentFlags().Lookup("ssh_connection_timeout"))
 
 	viper.BindPFlag("tasks.dispatcher.long_poll_wait_time", serverCmd.PersistentFlags().Lookup("tasks_dispatcher_long_poll_wait_time"))
 	viper.BindPFlag("tasks.dispatcher.lock_wait_time", serverCmd.PersistentFlags().Lookup("tasks_dispatcher_lock_wait_time"))
@@ -361,6 +363,7 @@ func setConfig() {
 	viper.BindEnv("disable_ssh_agent")
 	viper.BindEnv("locations_file_path")
 	viper.BindEnv("concurrency_limit_for_upgrades")
+	viper.BindEnv("ssh_connection_timeout")
 
 	//Bind Consul environment variables flags
 	for key := range consulConfiguration {
@@ -395,6 +398,7 @@ func setConfig() {
 	viper.SetDefault("server_id", host)
 	viper.SetDefault("disable_ssh_agent", false)
 	viper.SetDefault("concurrency_limit_for_upgrades", config.DefaultUpgradesConcurrencyLimit)
+	viper.SetDefault("ssh_connection_timeout", config.DefaultSSHConnectionTimeout)
 
 	viper.SetDefault("tasks.dispatcher.long_poll_wait_time", config.DefaultTasksDispatcherLongPollWaitTime)
 	viper.SetDefault("tasks.dispatcher.lock_wait_time", config.DefaultTasksDispatcherLockWaitTime)

--- a/commands/server_test.go
+++ b/commands/server_test.go
@@ -59,6 +59,7 @@ func TestServerConfigWithEnvVars(t *testing.T) {
 		PluginsDirectory        string
 		WorkersNumber           int
 		UpgradeConcurrencyLimit int
+		SSHConnectionTimeout    time.Duration
 	}{
 		LocationsFilePath:       "/path/to/locations/file",
 		ResourcesPrefix:         "pref-",
@@ -66,6 +67,7 @@ func TestServerConfigWithEnvVars(t *testing.T) {
 		PluginsDirectory:        "plugdir",
 		WorkersNumber:           42,
 		UpgradeConcurrencyLimit: 100,
+		SSHConnectionTimeout:    30 * time.Second,
 	}
 
 	// Set server env variables
@@ -75,6 +77,7 @@ func TestServerConfigWithEnvVars(t *testing.T) {
 	os.Setenv("YORC_PLUGINS_DIRECTORY", expectedConfig.PluginsDirectory)
 	os.Setenv("YORC_WORKERS_NUMBER", strconv.Itoa(expectedConfig.WorkersNumber))
 	os.Setenv("YORC_CONCURRENCY_LIMIT_FOR_UPGRADES", strconv.Itoa(expectedConfig.UpgradeConcurrencyLimit))
+	os.Setenv("YORC_SSH_CONNECTION_TIMEOUT", expectedConfig.SSHConnectionTimeout.String())
 
 	testResetConfig()
 	setConfig()
@@ -87,6 +90,7 @@ func TestServerConfigWithEnvVars(t *testing.T) {
 	assert.Equal(t, expectedConfig.PluginsDirectory, testConfig.PluginsDirectory, "Plugins Directory configuration differs from expected environment configuration")
 	assert.Equal(t, expectedConfig.WorkersNumber, testConfig.WorkersNumber, "Workers Number configuration differs from expected environment configuration")
 	assert.Equal(t, expectedConfig.UpgradeConcurrencyLimit, testConfig.UpgradeConcurrencyLimit, "Upgrade concurrency limit configuration differs from expected environment configuration")
+	assert.Equal(t, expectedConfig.SSHConnectionTimeout, testConfig.SSHConnectionTimeout, "SSH connection timeout configuration differs from expected environment configuration")
 
 	// cleanup env
 	os.Unsetenv("YORC_LOCATIONS_FILE_PATH")

--- a/config/config.go
+++ b/config/config.go
@@ -81,6 +81,9 @@ const DefaultTasksDispatcherLockWaitTime = 50 * time.Millisecond
 // DefaultUpgradesConcurrencyLimit is the default limit of concurrency used in Upgrade processes
 const DefaultUpgradesConcurrencyLimit = 1000
 
+// DefaultSSHConnectionTimeout is the default timeout for SSH connections
+const DefaultSSHConnectionTimeout = 10 * time.Second
+
 // Configuration holds config information filled by Cobra and Viper (see commands package for more information)
 type Configuration struct {
 	Ansible                          Ansible       `yaml:"ansible,omitempty" mapstructure:"ansible"`
@@ -108,6 +111,7 @@ type Configuration struct {
 	Tasks                            Tasks         `yaml:"tasks,omitempty" mapstructure:"tasks"`
 	Storage                          Storage       `yaml:"storage,omitempty" mapstructure:"storage"`
 	UpgradeConcurrencyLimit          int           `yaml:"concurrency_limit_for_upgrades,omitempty" mapstructure:"concurrency_limit_for_upgrades"`
+	SSHConnectionTimeout             time.Duration `yaml:"ssh_connection_timeout,omitempty" mapstructure:"ssh_connection_timeout"`
 }
 
 // DockerSandbox holds the configuration for a docker sandbox

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -210,6 +210,11 @@ Globals Command-line options
 
   * ``--concurrency_limit_for_upgrades``: Limit of concurrency used in Upgrade processes. If not set the default value of `1000` will be used.
 
+.. _option_ssh_connection_timeout_cmd:
+
+  * ``--ssh_connection_timeout``: Timeout to establish SSH connection from Yorc SSH client, especially used for Slurm and HostsPool locations. If not set the default value of `10 s` will be used.
+
+
 .. _yorc_config_file_section:
 
 Configuration files
@@ -307,6 +312,10 @@ Below is an example of configuration file with TLS enabled.
 .. _option_upgrades_concurrency_cfg:
 
   * ``concurrency_limit_for_upgrades``: Equivalent to :ref:`--concurrency_limit_for_upgrades <option_upgrades_concurrency_cmd>` command-line flag.
+
+.. _option_ssh_connection_timeout_cfg:
+
+  * ``ssh_connection_timeout``: Equivalent to :ref:`--ssh_connection_timeout <option_ssh_connection_timeout_cmd>` command-line flag.
 
 .. _yorc_config_file_ansible_section:
 
@@ -861,6 +870,10 @@ Environment variables
 .. _option_upgrades_concurrency_env:
 
   * ``YORC_CONCURRENCY_LIMIT_FOR_UPGRADES``: Equivalent to :ref:`--concurrency_limit_for_upgrades <option_upgrades_concurrency_cmd>` command-line flag.
+
+.. _option_ssh_connection_timeout_env:
+
+  * ``YORC_SSH_CONNECTION_TIMEOUT``: Equivalent to :ref:`--ssh_connection_timeout <option_ssh_connection_timeout_cmd>` command-line flag.
 
 .. _option_log_env:
 

--- a/locations/adapter/hostspool_adapter.go
+++ b/locations/adapter/hostspool_adapter.go
@@ -42,15 +42,15 @@ type hostsPoolLocationAdapter struct {
 }
 
 // NewHostsPoolLocationAdapter allows to create a new hostsPool location adapter
-func NewHostsPoolLocationAdapter(client *api.Client) LocationAdapter {
-	return &hostsPoolLocationAdapter{hostspool.NewManager(client)}
+func NewHostsPoolLocationAdapter(client *api.Client, cfg config.Configuration) LocationAdapter {
+	return &hostsPoolLocationAdapter{hostspool.NewManager(client, cfg)}
 }
 
 // NewHostsPoolLocationAdapterWithSSHFactory creates a Location Adapter with a given ssh factory
 //
 // Currently this is used for testing purpose to mock the ssh connection.
-func NewHostsPoolLocationAdapterWithSSHFactory(client *api.Client, sshClientFactory hostspool.SSHClientFactory) LocationAdapter {
-	return &hostsPoolLocationAdapter{hostspool.NewManagerWithSSHFactory(client, sshClientFactory)}
+func NewHostsPoolLocationAdapterWithSSHFactory(client *api.Client, cfg config.Configuration, sshClientFactory hostspool.SSHClientFactory) LocationAdapter {
+	return &hostsPoolLocationAdapter{hostspool.NewManagerWithSSHFactory(client, cfg, sshClientFactory)}
 }
 
 // CreateLocationConfiguration allows to create a location configuration of hosts pool type

--- a/locations/location_mgr.go
+++ b/locations/location_mgr.go
@@ -76,16 +76,16 @@ func GetManager(cfg config.Configuration) (Manager, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewManager(client), nil
+	return NewManager(client, cfg), nil
 }
 
 // NewManager creates a Location Manager for the http server
 // The http server has already a Consul client instance that was
 // provided to it as a constructor input parameter (see rest.NewServer function).
-func NewManager(client *api.Client) Manager {
+func NewManager(client *api.Client, cfg config.Configuration) Manager {
 	locMgrInitOnce.Do(func() {
 		locationMgr = &locationManager{cc: client}
-		locationMgr.hpAdapter = adapter.NewHostsPoolLocationAdapter(client)
+		locationMgr.hpAdapter = adapter.NewHostsPoolLocationAdapter(client, cfg)
 	})
 	return locationMgr
 }

--- a/locations/location_mgr_test.go
+++ b/locations/location_mgr_test.go
@@ -53,7 +53,7 @@ func GetManagerWithSSHFactory(cfg config.Configuration, sshClientFactory hostspo
 			return nil, nil, err
 		}
 		locationMgr = &locationManager{cc: client}
-		locationMgr.hpAdapter = adapter.NewHostsPoolLocationAdapterWithSSHFactory(client, sshClientFactory)
+		locationMgr.hpAdapter = adapter.NewHostsPoolLocationAdapterWithSSHFactory(client, cfg, sshClientFactory)
 	}
 
 	return locationMgr, mgr, nil

--- a/prov/hostspool/consul_test.go
+++ b/prov/hostspool/consul_test.go
@@ -51,81 +51,81 @@ func TestRunConsulHostsPoolPackageTests(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("TestConsulManagerAdd", func(t *testing.T) {
-		testConsulManagerAdd(t, client)
+		testConsulManagerAdd(t, client, cfg)
 	})
 	t.Run("TestConsulManagerRemove", func(t *testing.T) {
-		testConsulManagerRemove(t, client)
+		testConsulManagerRemove(t, client, cfg)
 	})
 	t.Run("TestConsulManagerRemoveHostWithSamePrefix", func(t *testing.T) {
-		testConsulManagerRemoveHostWithSamePrefix(t, client)
+		testConsulManagerRemoveHostWithSamePrefix(t, client, cfg)
 	})
 	t.Run("TestConsulManagerAddLabels", func(t *testing.T) {
-		testConsulManagerAddLabels(t, client)
+		testConsulManagerAddLabels(t, client, cfg)
 	})
 	t.Run("TestConsulManagerRemoveLabels", func(t *testing.T) {
-		testConsulManagerRemoveLabels(t, client)
+		testConsulManagerRemoveLabels(t, client, cfg)
 	})
 	t.Run("TestConsulManagerConcurrency", func(t *testing.T) {
-		testConsulManagerConcurrency(t, client)
+		testConsulManagerConcurrency(t, client, cfg)
 	})
 	t.Run("TestConsulManagerUpdateConnection", func(t *testing.T) {
-		testConsulManagerUpdateConnection(t, client)
+		testConsulManagerUpdateConnection(t, client, cfg)
 	})
 	t.Run("TestConsulManagerList", func(t *testing.T) {
-		testConsulManagerList(t, client)
+		testConsulManagerList(t, client, cfg)
 	})
 	t.Run("TestConsulManagerGetHost", func(t *testing.T) {
-		testConsulManagerGetHost(t, client)
+		testConsulManagerGetHost(t, client, cfg)
 	})
 	t.Run("TestConsulManagerApply", func(t *testing.T) {
-		testConsulManagerApply(t, client)
+		testConsulManagerApply(t, client, cfg)
 	})
 	t.Run("testConsulManagerApplyErrorNoName", func(t *testing.T) {
-		testConsulManagerApplyErrorNoName(t, client)
+		testConsulManagerApplyErrorNoName(t, client, cfg)
 	})
 	t.Run("testConsulManagerApplyErrorDuplicateName", func(t *testing.T) {
-		testConsulManagerApplyErrorDuplicateName(t, client)
+		testConsulManagerApplyErrorDuplicateName(t, client, cfg)
 	})
 	t.Run("testConsulManagerApplyErrorDeleteAllocatedHost", func(t *testing.T) {
-		testConsulManagerApplyErrorDeleteAllocatedHost(t, client)
+		testConsulManagerApplyErrorDeleteAllocatedHost(t, client, cfg)
 	})
 	t.Run("testConsulManagerApplyErrorOutdatedCheckpoint", func(t *testing.T) {
-		testConsulManagerApplyErrorOutdatedCheckpoint(t, client)
+		testConsulManagerApplyErrorOutdatedCheckpoint(t, client, cfg)
 	})
 	t.Run("testConsulManagerApplyBadConnection", func(t *testing.T) {
-		testConsulManagerApplyBadConnection(t, client)
+		testConsulManagerApplyBadConnection(t, client, cfg)
 	})
 	t.Run("testConsulManagerApplyBadConnectionAndRestoreHostStatus", func(t *testing.T) {
-		testConsulManagerApplyBadConnectionAndRestoreHostStatus(t, client)
+		testConsulManagerApplyBadConnectionAndRestoreHostStatus(t, client, cfg)
 	})
 	t.Run("testConsulManagerAllocateConcurrency", func(t *testing.T) {
-		testConsulManagerAllocateConcurrency(t, client)
+		testConsulManagerAllocateConcurrency(t, client, cfg)
 	})
 	t.Run("testConsulManagerAllocateShareableCompute", func(t *testing.T) {
-		testConsulManagerAllocateShareableCompute(t, client)
+		testConsulManagerAllocateShareableCompute(t, client, cfg)
 	})
 	t.Run("testConsulManagerAllocateWithWeightBalancedPlacement", func(t *testing.T) {
-		testConsulManagerAllocateWithWeightBalancedPlacement(t, client)
+		testConsulManagerAllocateWithWeightBalancedPlacement(t, client, cfg)
 	})
 	t.Run("testConsulManagerAllocateShareableComputeWithSameAllocationPrefix", func(t *testing.T) {
-		testConsulManagerAllocateShareableComputeWithSameAllocationPrefix(t, client)
+		testConsulManagerAllocateShareableComputeWithSameAllocationPrefix(t, client, cfg)
 	})
 	t.Run("testConsulManagerApplyWithAllocation", func(t *testing.T) {
-		testConsulManagerApplyWithAllocation(t, client)
+		testConsulManagerApplyWithAllocation(t, client, cfg)
 	})
 	t.Run("testConsulManagerAddLabelsWithAllocation", func(t *testing.T) {
-		testConsulManagerAddLabelsWithAllocation(t, client)
+		testConsulManagerAddLabelsWithAllocation(t, client, cfg)
 	})
 	t.Run("testCreateFiltersFromComputeCapabilities", func(t *testing.T) {
 		testCreateFiltersFromComputeCapabilities(t, deploymentID)
 	})
 	t.Run("testConcurrentExecDelegateShareableHost", func(t *testing.T) {
-		testConcurrentExecDelegateShareableHost(t, srv, client, deploymentID, location)
+		testConcurrentExecDelegateShareableHost(t, srv, client, cfg, deploymentID, location)
 	})
 	t.Run("testFailureExecDelegateShareableHost", func(t *testing.T) {
-		testFailureExecDelegateShareableHost(t, srv, client, deploymentID, location)
+		testFailureExecDelegateShareableHost(t, srv, client, cfg, deploymentID, location)
 	})
 	t.Run("testExecDelegateFailure", func(t *testing.T) {
-		testExecDelegateFailure(t, srv, client, deploymentID, location)
+		testExecDelegateFailure(t, srv, client, cfg, deploymentID, location)
 	})
 }

--- a/prov/hostspool/errors.go
+++ b/prov/hostspool/errors.go
@@ -67,3 +67,17 @@ func IsNoMatchingHostFoundError(err error) bool {
 	_, ok := errors.Cause(err).(noMatchingHostFoundError)
 	return ok
 }
+
+type hostConnectionError struct {
+	message string
+}
+
+func (e hostConnectionError) Error() string {
+	return e.message
+}
+
+// IsHostConnectionError checks if an error is an error due to host connection error
+func IsHostConnectionError(err error) bool {
+	_, ok := errors.Cause(err).(hostConnectionError)
+	return ok
+}

--- a/prov/hostspool/executor.go
+++ b/prov/hostspool/executor.go
@@ -59,7 +59,7 @@ func (e *defaultExecutor) ExecDelegate(ctx context.Context, cfg config.Configura
 		return err
 	}
 
-	locationName, err := e.getLocationForNode(ctx, cc, deploymentID, nodeName)
+	locationName, err := e.getLocationForNode(ctx, cfg, cc, deploymentID, nodeName)
 	if err != nil {
 		return err
 	}
@@ -70,15 +70,15 @@ func (e *defaultExecutor) ExecDelegate(ctx context.Context, cfg config.Configura
 		deploymentID:      deploymentID,
 		nodeName:          nodeName,
 		delegateOperation: delegateOperation,
-		hpManager:         NewManager(cc),
+		hpManager:         NewManager(cc, cfg),
 	}
 	return e.execDelegateHostsPool(ctx, cc, cfg, operationParams)
 }
 
-func (e *defaultExecutor) getLocationForNode(ctx context.Context, cc *api.Client, deploymentID, nodeName string) (string, error) {
+func (e *defaultExecutor) getLocationForNode(ctx context.Context, cfg config.Configuration, cc *api.Client, deploymentID, nodeName string) (string, error) {
 
 	// Get current locations
-	hpManager := NewManager(cc)
+	hpManager := NewManager(cc, cfg)
 	locations, err := hpManager.ListLocations()
 	if err != nil {
 		return "", err

--- a/prov/hostspool/hostspool_mgr.go
+++ b/prov/hostspool/hostspool_mgr.go
@@ -134,7 +134,7 @@ func (cm *consulManager) addWait(locationName, hostname string, conn Connection,
 
 	err = cm.checkConnection(locationName, hostname)
 	if err != nil {
-		cm.setHostStatusWithMessage(locationName, hostname, HostStatusError, "can't connect to host")
+		cm.setHostStatusWithMessage(locationName, hostname, HostStatusError, hostConnectionErrorMessage)
 	}
 	return err
 }

--- a/prov/hostspool/hostspool_mgr.go
+++ b/prov/hostspool/hostspool_mgr.go
@@ -135,8 +135,9 @@ func (cm *consulManager) addWait(locationName, hostname string, conn Connection,
 	err = cm.checkConnection(locationName, hostname)
 	if err != nil {
 		cm.setHostStatusWithMessage(locationName, hostname, HostStatusError, hostConnectionErrorMessage)
+		return errors.WithStack(hostConnectionError{message: err.Error()})
 	}
-	return err
+	return nil
 }
 
 func (cm *consulManager) getAddOperations(

--- a/prov/hostspool/hostspool_mgr_allocation.go
+++ b/prov/hostspool/hostspool_mgr_allocation.go
@@ -195,7 +195,7 @@ func (cm *consulManager) releaseWait(locationName, hostname, deploymentID, nodeN
 	err = cm.checkConnection(locationName, hostname)
 	if err != nil {
 		cm.backupHostStatus(locationName, hostname)
-		cm.setHostStatusWithMessage(locationName, hostname, HostStatusError, "failed to connect to host")
+		cm.setHostStatusWithMessage(locationName, hostname, HostStatusError, hostConnectionErrorMessage)
 	}
 	return allocation, nil
 }

--- a/prov/hostspool/hostspool_mgr_connection.go
+++ b/prov/hostspool/hostspool_mgr_connection.go
@@ -130,7 +130,7 @@ func (cm *consulManager) updateConnectionWait(locationName, hostname string, con
 			cm.backupHostStatus(locationName, hostname)
 			cm.setHostStatusWithMessage(locationName, hostname, HostStatusError, hostConnectionErrorMessage)
 		}
-		return err
+		return errors.WithStack(hostConnectionError{message: err.Error()})
 	}
 	if status == HostStatusError {
 		cm.restoreHostStatus(locationName, hostname)

--- a/prov/hostspool/hostspool_mgr_connection.go
+++ b/prov/hostspool/hostspool_mgr_connection.go
@@ -28,6 +28,8 @@ import (
 	"github.com/ystia/yorc/v4/helper/consulutil"
 )
 
+const hostConnectionErrorMessage = "failed to connect to host"
+
 func (cm *consulManager) UpdateConnection(locationName, hostname string, conn Connection) error {
 	return cm.updateConnectionWait(locationName, hostname, conn, maxWaitTimeSeconds*time.Second)
 }
@@ -126,7 +128,7 @@ func (cm *consulManager) updateConnectionWait(locationName, hostname string, con
 	if err != nil {
 		if status != HostStatusError {
 			cm.backupHostStatus(locationName, hostname)
-			cm.setHostStatusWithMessage(locationName, hostname, HostStatusError, "failed to connect to host")
+			cm.setHostStatusWithMessage(locationName, hostname, HostStatusError, hostConnectionErrorMessage)
 		}
 		return err
 	}
@@ -238,7 +240,7 @@ func (cm *consulManager) updateConnectionStatus(locationName, name string, waitG
 	if err != nil {
 		if status != HostStatusError {
 			cm.backupHostStatus(locationName, name)
-			cm.setHostStatusWithMessage(locationName, name, HostStatusError, "failed to connect to host")
+			cm.setHostStatusWithMessage(locationName, name, HostStatusError, hostConnectionErrorMessage)
 		}
 		return
 	}

--- a/prov/hostspool/hostspool_mgr_connection.go
+++ b/prov/hostspool/hostspool_mgr_connection.go
@@ -211,28 +211,18 @@ func (cm *consulManager) GetHostConnection(locationName, hostname string) (Conne
 
 // Check if we can log into an host given a connection
 func (cm *consulManager) checkConnection(locationName, hostname string) error {
-
 	conn, err := cm.GetHostConnection(locationName, hostname)
 	if err != nil {
 		return errors.Wrapf(err, "failed to connect to host %q", hostname)
 	}
-	conf, err := getSSHConfig(conn)
+	conf, err := getSSHConfig(cm.cfg, conn)
 	if err != nil {
 		return errors.Wrapf(err, "failed to connect to host %q", hostname)
 	}
 
-	c := make(chan struct{})
-	go func() {
-		defer close(c)
-		client := cm.getSSHClient(conf, conn)
-		_, err = client.RunCommand(`echo "Connected!"`)
-	}()
-	select {
-	case <-c:
-		return errors.Wrapf(err, "failed to connect to host %q", hostname)
-	case <-time.After(10 * time.Second):
-		return errors.Errorf("timeout exceeded to connect to host %q", hostname)
-	}
+	client := cm.getSSHClient(conf, conn)
+	_, err = client.RunCommand(`echo "Connected!"`)
+	return errors.Wrapf(err, "failed to connect to host %q", hostname)
 }
 
 // Go routine checking a Host connection and updating the Host status

--- a/prov/slurm/execution.go
+++ b/prov/slurm/execution.go
@@ -127,7 +127,7 @@ func newExecution(ctx context.Context, cfg config.Configuration, taskID, deploym
 		return nil, err
 	}
 	// Create sshClient using user credentials from credentials property if the are provided, or from yorc config otherwise
-	execCommon.client, err = getSSHClient(creds, locationProps)
+	execCommon.client, err = getSSHClient(cfg, creds, locationProps)
 	if err != nil {
 		return nil, err
 	}

--- a/prov/slurm/helper.go
+++ b/prov/slurm/helper.go
@@ -41,7 +41,7 @@ const invalidJob = "Invalid job id specified"
 
 // getSSHClient returns a SSH client with slurm credentials from node or job configuration provided by the deployment,
 // or by the yorc slurm configuration
-func getSSHClient(credentials *types.Credential, locationProps config.DynamicMap) (*sshutil.SSHClient, error) {
+func getSSHClient(cfg config.Configuration, credentials *types.Credential, locationProps config.DynamicMap) (*sshutil.SSHClient, error) {
 	// Check manadatory slurm configuration
 	if err := checkLocationConfig(locationProps); err != nil {
 		log.Printf("Unable to provide SSH client due to:%+v", err)
@@ -59,6 +59,7 @@ func getSSHClient(credentials *types.Credential, locationProps config.DynamicMap
 	SSHConfig := &ssh.ClientConfig{
 		User:            credentials.User,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         cfg.SSHConnectionTimeout,
 	}
 
 	// Set an authentication method. At least one authentication method

--- a/prov/slurm/helper_test.go
+++ b/prov/slurm/helper_test.go
@@ -243,10 +243,12 @@ func TestPrivateKey(t *testing.T) {
 		"port":        22,
 		"private_key": privateKeyContent,
 	}
-
+	cfg := config.Configuration{
+		SSHConnectionTimeout: 10 * time.Second,
+	}
 	err = checkLocationUserConfig(locationProps)
 	assert.NoError(t, err, "Unexpected error parsing a configuration with private key")
-	_, err = getSSHClient(&types.Credential{User: "jdoe", Keys: map[string]string{"0": privateKeyContent}}, locationProps)
+	_, err = getSSHClient(cfg, &types.Credential{User: "jdoe", Keys: map[string]string{"0": privateKeyContent}}, locationProps)
 	assert.NoError(t, err, "Unexpected error getting a ssh client using provided properties with private key")
 
 	// Remove the private key.
@@ -254,9 +256,9 @@ func TestPrivateKey(t *testing.T) {
 	locationProps.Set("private_key", "")
 	err = checkLocationUserConfig(locationProps)
 	assert.Error(t, err, "Expected an error parsing a wrong configuration with no private key and no password defined")
-	_, err = getSSHClient(&types.Credential{}, locationProps)
+	_, err = getSSHClient(cfg, &types.Credential{}, locationProps)
 	assert.Error(t, err, "Expected an error getting a ssh client using a configuration with no private key and no password defined")
-	_, err = getSSHClient(&types.Credential{User: "jdoe"}, locationProps)
+	_, err = getSSHClient(cfg, &types.Credential{User: "jdoe"}, locationProps)
 	assert.Error(t, err, "Expected an error getting a ssh client using a provided user name property but no private key and no password provided")
 
 	// Setting a wrong private key path
@@ -264,9 +266,9 @@ func TestPrivateKey(t *testing.T) {
 	locationProps.Set("private_key", "invalid_path_to_key.pem")
 	err = checkLocationUserConfig(locationProps)
 	assert.NoError(t, err, "Unexpected error parsing a configuration with private key")
-	_, err = getSSHClient(&types.Credential{}, locationProps)
+	_, err = getSSHClient(cfg, &types.Credential{}, locationProps)
 	assert.Error(t, err, "Expected an error getting a ssh client using a configuration with bad private key and no password defined")
-	_, err = getSSHClient(&types.Credential{User: "jdoe", Keys: map[string]string{"0": "invalid_path_to_key.pem"}}, locationProps)
+	_, err = getSSHClient(cfg, &types.Credential{User: "jdoe", Keys: map[string]string{"0": "invalid_path_to_key.pem"}}, locationProps)
 	assert.Error(t, err, "Expected an error getting a ssh client using provided credentials with bad private key and no password defined")
 
 	// Slurm Configuration with no private key but a password, the config should be valid
@@ -279,7 +281,7 @@ func TestPrivateKey(t *testing.T) {
 
 	err = checkLocationUserConfig(locationProps)
 	assert.NoError(t, err, "Unexpected error parsing a configuration with password")
-	_, err = getSSHClient(&types.Credential{User: "jdoe", Token: "test"}, locationProps)
+	_, err = getSSHClient(cfg, &types.Credential{User: "jdoe", Token: "test"}, locationProps)
 	assert.NoError(t, err, "Unexpected error getting a ssh client using provided credentials with password")
 }
 

--- a/prov/slurm/monitoring_jobs.go
+++ b/prov/slurm/monitoring_jobs.go
@@ -116,7 +116,7 @@ func (o *actionOperator) monitorJob(ctx context.Context, cfg config.Configuratio
 		return true, err
 	}
 	// Get a sshClient to connect to slurm client node, and execute slurm commands such as squeue, or system commands such as cp, mv, mkdir, etc.
-	sshClient, err := getSSHClient(credentials, locationProps)
+	sshClient, err := getSSHClient(cfg, credentials, locationProps)
 	if err != nil {
 		return true, err
 	}

--- a/rest/consul_test.go
+++ b/rest/consul_test.go
@@ -44,14 +44,14 @@ var mockSSHClientFactory = func(config *ssh.ClientConfig, conn hostspool.Connect
 	}
 }
 
-func newTestHTTPRouter(client *api.Client, req *http.Request) *http.Response {
+func newTestHTTPRouter(client *api.Client, cfg config.Configuration, req *http.Request) *http.Response {
 	router := newRouter()
 
 	httpSrv := &Server{
 		router:         router,
 		consulClient:   client,
-		hostsPoolMgr:   hostspool.NewManagerWithSSHFactory(client, mockSSHClientFactory),
-		locationMgr:    locations.NewManager(client),
+		hostsPoolMgr:   hostspool.NewManagerWithSSHFactory(client, cfg, mockSSHClientFactory),
+		locationMgr:    locations.NewManager(client, cfg),
 		tasksCollector: collector.NewCollector(client),
 		config:         config.Configuration{WorkingDirectory: "../work"},
 	}
@@ -71,22 +71,22 @@ func TestRunConsulRestPackageTests(t *testing.T) {
 
 	t.Run("groupRest", func(t *testing.T) {
 		t.Run("testHostsPoolHandlers", func(t *testing.T) {
-			testHostsPoolHandlers(t, client, srv)
+			testHostsPoolHandlers(t, client, cfg, srv)
 		})
 		t.Run("testLocationsHandlers", func(t *testing.T) {
-			testLocationsHandlers(t, client, srv)
+			testLocationsHandlers(t, client, cfg, srv)
 		})
 		t.Run("testSSLRest", func(t *testing.T) {
 			testSSLREST(t, client, srv)
 		})
 		t.Run("testDeploymentHandlers", func(t *testing.T) {
-			testDeploymentHandlers(t, client, srv)
+			testDeploymentHandlers(t, client, cfg, srv)
 		})
 		t.Run("testPostInfraUsageHandler", func(t *testing.T) {
-			testPostInfraUsageHandler(t, client, srv)
+			testPostInfraUsageHandler(t, client, cfg, srv)
 		})
 		t.Run("testTaskQueryHandlers", func(t *testing.T) {
-			testTaskQueryHandlers(t, client, srv)
+			testTaskQueryHandlers(t, client, cfg, srv)
 		})
 	})
 }

--- a/rest/deployments_oss_test.go
+++ b/rest/deployments_oss_test.go
@@ -19,6 +19,7 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/ystia/yorc/v4/config"
 	"reflect"
 
 	"io/ioutil"
@@ -33,7 +34,7 @@ import (
 	ytestutil "github.com/ystia/yorc/v4/testutil"
 )
 
-func testUpdateDeployments(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testUpdateDeployments(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	depID := ytestutil.BuildDeploymentID(t)
 
 	type result struct {
@@ -56,7 +57,7 @@ func testUpdateDeployments(t *testing.T, client *api.Client, srv *testutil.TestS
 
 			req := httptest.NewRequest("PATCH", "/deployments/"+tt.deploymentID, nil)
 			req.Header.Set("Content-Type", mimeTypeApplicationZip)
-			resp := newTestHTTPRouter(client, req)
+			resp := newTestHTTPRouter(client, cfg, req)
 			require.NotNil(t, resp, "unexpected nil response")
 			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)
 

--- a/rest/deployments_test.go
+++ b/rest/deployments_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/ystia/yorc/v4/config"
 	"github.com/ystia/yorc/v4/helper/ziputil"
 	"io"
 	"io/ioutil"
@@ -42,24 +43,24 @@ import (
 	ytestutil "github.com/ystia/yorc/v4/testutil"
 )
 
-func testDeploymentHandlers(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testDeploymentHandlers(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	t.Run("testDeleteDeploymentHandlerWithStopOnErrorParam", func(t *testing.T) {
-		testDeleteDeploymentHandlerWithStopOnErrorParam(t, client, srv)
+		testDeleteDeploymentHandlerWithStopOnErrorParam(t, client, cfg, srv)
 	})
 	t.Run("testDeleteDeploymentHandlerWithPurgeParam", func(t *testing.T) {
-		testDeleteDeploymentHandlerWithPurgeParam(t, client, srv)
+		testDeleteDeploymentHandlerWithPurgeParam(t, client, cfg, srv)
 	})
 	t.Run("testGetDeploymentHandler", func(t *testing.T) {
-		testGetDeploymentHandler(t, client, srv)
+		testGetDeploymentHandler(t, client, cfg, srv)
 	})
 	t.Run("testListDeploymentHandler", func(t *testing.T) {
-		testListDeploymentHandler(t, client, srv)
+		testListDeploymentHandler(t, client, cfg, srv)
 	})
 	t.Run("testUpdateDeployments", func(t *testing.T) {
-		testUpdateDeployments(t, client, srv)
+		testUpdateDeployments(t, client, cfg, srv)
 	})
 	t.Run("testNewDeployments", func(t *testing.T) {
-		testNewDeployments(t, client, srv)
+		testNewDeployments(t, client, cfg, srv)
 	})
 
 	// Cleanup work
@@ -91,7 +92,7 @@ func prepareTest(t *testing.T, deploymentID string, client *api.Client, srv *tes
 	}
 }
 
-func testDeleteDeploymentHandlerWithStopOnErrorParam(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testDeleteDeploymentHandlerWithStopOnErrorParam(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	t.Parallel()
 	type result struct {
 		statusCode      int
@@ -118,7 +119,7 @@ func testDeleteDeploymentHandlerWithStopOnErrorParam(t *testing.T, client *api.C
 			params := url.Values{}
 			params.Add("stopOnError", tt.stopOnErrorParam)
 			req.URL.RawQuery = params.Encode()
-			resp := newTestHTTPRouter(client, req)
+			resp := newTestHTTPRouter(client, cfg, req)
 			require.NotNil(t, resp, "unexpected nil response")
 			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)
 
@@ -156,7 +157,7 @@ func testDeleteDeploymentHandlerWithStopOnErrorParam(t *testing.T, client *api.C
 	}
 }
 
-func testDeleteDeploymentHandlerWithPurgeParam(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testDeleteDeploymentHandlerWithPurgeParam(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	t.Parallel()
 
 	type result struct {
@@ -184,7 +185,7 @@ func testDeleteDeploymentHandlerWithPurgeParam(t *testing.T, client *api.Client,
 			params := url.Values{}
 			params.Add("purge", tt.purgeParam)
 			req.URL.RawQuery = params.Encode()
-			resp := newTestHTTPRouter(client, req)
+			resp := newTestHTTPRouter(client, cfg, req)
 			require.NotNil(t, resp, "unexpected nil response")
 			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)
 
@@ -220,7 +221,7 @@ func testDeleteDeploymentHandlerWithPurgeParam(t *testing.T, client *api.Client,
 	}
 }
 
-func testGetDeploymentHandler(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testGetDeploymentHandler(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	t.Parallel()
 
 	type result struct {
@@ -245,7 +246,7 @@ func testGetDeploymentHandler(t *testing.T, client *api.Client, srv *testutil.Te
 			prepareTest(t, tt.name, client, srv)
 			req := httptest.NewRequest("GET", "/deployments/"+tt.deploymentID, nil)
 			req.Header.Set("Accept", mimeTypeApplicationJSON)
-			resp := newTestHTTPRouter(client, req)
+			resp := newTestHTTPRouter(client, cfg, req)
 			require.NotNil(t, resp, "unexpected nil response")
 			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)
 
@@ -274,7 +275,7 @@ func testGetDeploymentHandler(t *testing.T, client *api.Client, srv *testutil.Te
 	}
 }
 
-func testListDeploymentHandler(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testListDeploymentHandler(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	//t.Parallel() because conflicts can occurs with other tests
 
 	type result struct {
@@ -298,7 +299,7 @@ func testListDeploymentHandler(t *testing.T, client *api.Client, srv *testutil.T
 			prepareTest(t, tt.name, client, srv)
 			req := httptest.NewRequest("GET", "/deployments", nil)
 			req.Header.Set("Accept", mimeTypeApplicationJSON)
-			resp := newTestHTTPRouter(client, req)
+			resp := newTestHTTPRouter(client, cfg, req)
 			require.NotNil(t, resp, "unexpected nil response")
 			require.Equal(t, tt.want.statusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.want.statusCode)
 
@@ -327,7 +328,7 @@ func testListDeploymentHandler(t *testing.T, client *api.Client, srv *testutil.T
 	}
 }
 
-func testNewDeployments(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testNewDeployments(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 
 	tests := []struct {
 		name           string
@@ -376,7 +377,7 @@ func testNewDeployments(t *testing.T, client *api.Client, srv *testutil.TestServ
 			req := httptest.NewRequest("PUT", "/deployments/"+depID, reqBody)
 			req.Header.Set("Content-Type", mimeTypeApplicationZip)
 
-			resp := newTestHTTPRouter(client, req)
+			resp := newTestHTTPRouter(client, cfg, req)
 			require.NotNil(t, resp, "unexpected nil response")
 			require.Equal(t, tt.wantStatusCode, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, tt.wantStatusCode)
 

--- a/rest/hosts_pool_test.go
+++ b/rest/hosts_pool_test.go
@@ -51,6 +51,9 @@ func testHostsPoolHandlers(t *testing.T, client *api.Client, cfg config.Configur
 	t.Run("testNewHostInPool", func(t *testing.T) {
 		testNewHostInPool(t, client, cfg, srv)
 	})
+	t.Run("testNewHostInPoolWithConnectionError", func(t *testing.T) {
+		testNewHostInPoolWithConnectionError(t, client, cfg, srv)
+	})
 	t.Run("testNewHostInPoolWithoutConnectionInfo", func(t *testing.T) {
 		testNewHostInPoolWithoutConnectionInfo(t, client, cfg, srv)
 	})
@@ -191,6 +194,32 @@ func testNewHostInPool(t *testing.T, client *api.Client, cfg config.Configuratio
 	require.Equal(t, []string{"/hosts_pool/myHostsPoolLocationTest/host11"}, resp.Header["Location"])
 
 	client.KV().DeleteTree(consulutil.HostsPoolPrefix+"/myHostsPoolLocationTest/host11", nil)
+}
+
+func testNewHostInPoolWithConnectionError(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
+	t.Parallel()
+
+	var hostRequest HostRequest
+	hostRequest.Connection = &hostspool.Connection{
+		User:       "fail",
+		Host:       "1.2.3.4",
+		Port:       22,
+		PrivateKey: "../prov/hostspool/testdata/new_key.pem",
+	}
+	hostRequest.Labels = append(hostRequest.Labels, MapEntry{MapEntryOperationAdd, "key1", "val1"})
+
+	tmp, err := json.Marshal(hostRequest)
+	require.Nil(t, err, "unexpected error marshalling data to provide body request")
+	req := httptest.NewRequest("PUT", "/hosts_pool/myHostsPoolLocationTest/host111", bytes.NewBuffer([]byte(string(tmp))))
+	req.Header.Add("Content-Type", mimeTypeApplicationJSON)
+	resp := newTestHTTPRouter(client, cfg, req)
+	_, err = ioutil.ReadAll(resp.Body)
+	require.NotNil(t, resp, "unexpected nil response")
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusCreated)
+	require.Equal(t, []string{"/hosts_pool/myHostsPoolLocationTest/host111"}, resp.Header["Location"])
+	require.Equal(t, []string{"failed to connect to host \"host111\": Failed to connect"}, resp.Header["Warning"])
+
+	client.KV().DeleteTree(consulutil.HostsPoolPrefix+"/myHostsPoolLocationTest/host111", nil)
 }
 
 func testNewHostInPoolWithoutConnectionInfo(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {

--- a/rest/http.go
+++ b/rest/http.go
@@ -134,8 +134,8 @@ func NewServer(configuration config.Configuration, client *api.Client, shutdownC
 		consulClient:   client,
 		tasksCollector: collector.NewCollector(client),
 		config:         configuration,
-		hostsPoolMgr:   hostspool.NewManager(client),
-		locationMgr:    locations.NewManager(client),
+		hostsPoolMgr:   hostspool.NewManager(client, configuration),
+		locationMgr:    locations.NewManager(client, configuration),
 	}
 
 	httpServer.registerHandlers()

--- a/rest/infra_usage_test.go
+++ b/rest/infra_usage_test.go
@@ -51,7 +51,7 @@ func (m *mockInfraUsageCollector) GetUsageInfo(ctx context.Context, conf config.
 	return nil, err
 }
 
-func testPostInfraUsageHandler(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testPostInfraUsageHandler(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	t.Parallel()
 
 	mock := new(mockInfraUsageCollector)
@@ -60,7 +60,7 @@ func testPostInfraUsageHandler(t *testing.T, client *api.Client, srv *testutil.T
 
 	req := httptest.NewRequest("POST", "/infra_usage/myInfraName/myLocationName?myparam=success", nil)
 	req.Header.Add("Content-Type", mimeTypeApplicationJSON)
-	resp := newTestHTTPRouter(client, req)
+	resp := newTestHTTPRouter(client, cfg, req)
 
 	require.NotNil(t, resp, "unexpected nil response")
 	require.Equal(t, http.StatusAccepted, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusAccepted)
@@ -69,7 +69,7 @@ func testPostInfraUsageHandler(t *testing.T, client *api.Client, srv *testutil.T
 	require.Equal(t, true, strings.HasPrefix(resp.Header["Location"][0], "/infra_usage/myInfraName/myLocationName/tasks"), "unexpected location header prefix")
 }
 
-func testPostInfraUsageHandlerError(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testPostInfraUsageHandlerError(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	t.Parallel()
 
 	mock := new(mockInfraUsageCollector)
@@ -78,7 +78,7 @@ func testPostInfraUsageHandlerError(t *testing.T, client *api.Client, srv *testu
 
 	req := httptest.NewRequest("POST", "/infra_usage/myInfraError/myLocationName?myparam=failure", nil)
 	req.Header.Add("Content-Type", mimeTypeApplicationJSON)
-	resp := newTestHTTPRouter(client, req)
+	resp := newTestHTTPRouter(client, cfg, req)
 
 	require.NotNil(t, resp, "unexpected nil response")
 	require.Equal(t, http.StatusAccepted, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusAccepted)

--- a/rest/locations_test.go
+++ b/rest/locations_test.go
@@ -30,34 +30,34 @@ import (
 	"github.com/ystia/yorc/v4/log"
 )
 
-func testLocationsHandlers(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testLocationsHandlers(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	populateKV(t, srv)
 	t.Run("testListLocations", func(t *testing.T) {
-		testListLocations(t, client, srv)
+		testListLocations(t, client, cfg, srv)
 	})
 	t.Run("testDeleteLocation", func(t *testing.T) {
-		testDeleteLocation(t, client, srv)
+		testDeleteLocation(t, client, cfg, srv)
 	})
 	t.Run("testDeleteLocation", func(t *testing.T) {
-		testDeleteInexistentLocation(t, client, srv)
+		testDeleteInexistentLocation(t, client, cfg, srv)
 	})
 	t.Run("testGetLocation", func(t *testing.T) {
-		testGetLocationInfo(t, client, srv)
+		testGetLocationInfo(t, client, cfg, srv)
 	})
 	t.Run("testCreateNoDataLocation", func(t *testing.T) {
-		testCreateNoDataLocation(t, client, srv)
+		testCreateNoDataLocation(t, client, cfg, srv)
 	})
 	t.Run("testCreateLocation", func(t *testing.T) {
-		testCreateLocation(t, client, srv)
+		testCreateLocation(t, client, cfg, srv)
 	})
 	t.Run("testCreateAlreadyExistentLocation", func(t *testing.T) {
-		testCreateAlreadyExistentLocation(t, client, srv)
+		testCreateAlreadyExistentLocation(t, client, cfg, srv)
 	})
 	t.Run("testUpdateLocation", func(t *testing.T) {
-		testUpdateLocation(t, client, srv)
+		testUpdateLocation(t, client, cfg, srv)
 	})
 	t.Run("testUpdateNoDataLocation", func(t *testing.T) {
-		testUpdateNoDataLocation(t, client, srv)
+		testUpdateNoDataLocation(t, client, cfg, srv)
 	})
 	cleanUpKV(client)
 }
@@ -78,13 +78,13 @@ func cleanUpKV(client *api.Client) {
 	client.KV().DeleteTree(consulutil.LocationsPrefix+"/loc3", nil)
 }
 
-func testListLocations(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testListLocations(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	log.SetDebug(true)
 
 	// Make a request
 	req := httptest.NewRequest("GET", "/locations", nil)
 	req.Header.Add("Accept", "application/json")
-	resp := newTestHTTPRouter(client, req)
+	resp := newTestHTTPRouter(client, cfg, req)
 	body, err := ioutil.ReadAll(resp.Body)
 
 	require.Nil(t, err, "unexpected error reading body response")
@@ -106,9 +106,9 @@ func testListLocations(t *testing.T, client *api.Client, srv *testutil.TestServe
 
 }
 
-func testDeleteLocation(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testDeleteLocation(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	req := httptest.NewRequest("DELETE", "/locations/loc1", nil)
-	resp := newTestHTTPRouter(client, req)
+	resp := newTestHTTPRouter(client, cfg, req)
 	_, err := ioutil.ReadAll(resp.Body)
 
 	require.Nil(t, err, "unexpected error reading body response")
@@ -116,9 +116,9 @@ func testDeleteLocation(t *testing.T, client *api.Client, srv *testutil.TestServ
 	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusOK)
 }
 
-func testDeleteInexistentLocation(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testDeleteInexistentLocation(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	req := httptest.NewRequest("DELETE", "/locations/loc1", nil)
-	resp := newTestHTTPRouter(client, req)
+	resp := newTestHTTPRouter(client, cfg, req)
 	_, err := ioutil.ReadAll(resp.Body)
 
 	require.Nil(t, err, "unexpected error reading body response")
@@ -127,10 +127,10 @@ func testDeleteInexistentLocation(t *testing.T, client *api.Client, srv *testuti
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusBadRequest)
 }
 
-func testGetLocationInfo(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testGetLocationInfo(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	req := httptest.NewRequest("GET", "/locations/loc2", nil)
 	req.Header.Add("Accept", "application/json")
-	resp := newTestHTTPRouter(client, req)
+	resp := newTestHTTPRouter(client, cfg, req)
 	body, err := ioutil.ReadAll(resp.Body)
 
 	require.Nil(t, err, "unexpected error reading body response")
@@ -139,11 +139,11 @@ func testGetLocationInfo(t *testing.T, client *api.Client, srv *testutil.TestSer
 	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusOK)
 }
 
-func testCreateNoDataLocation(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testCreateNoDataLocation(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	req := httptest.NewRequest("PUT", "/locations/loc1", nil)
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
-	resp := newTestHTTPRouter(client, req)
+	resp := newTestHTTPRouter(client, cfg, req)
 	_, err := ioutil.ReadAll(resp.Body)
 
 	require.Nil(t, err, "unexpected error reading body response")
@@ -151,7 +151,7 @@ func testCreateNoDataLocation(t *testing.T, client *api.Client, srv *testutil.Te
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusBadRequest)
 }
 
-func testCreateLocation(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testCreateLocation(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	locationProps := config.DynamicMap{
 		"p11": "v11",
 		"p12": "v12",
@@ -165,7 +165,7 @@ func testCreateLocation(t *testing.T, client *api.Client, srv *testutil.TestServ
 	req := httptest.NewRequest("PUT", "/locations/loc1", bytes.NewBuffer([]byte(string(tmp))))
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
-	resp := newTestHTTPRouter(client, req)
+	resp := newTestHTTPRouter(client, cfg, req)
 	_, err = ioutil.ReadAll(resp.Body)
 
 	require.Nil(t, err, "unexpected error reading body response")
@@ -173,7 +173,7 @@ func testCreateLocation(t *testing.T, client *api.Client, srv *testutil.TestServ
 	require.Equal(t, http.StatusCreated, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusCreated)
 }
 
-func testCreateAlreadyExistentLocation(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testCreateAlreadyExistentLocation(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	locationProps := config.DynamicMap{
 		"p11": "v11",
 		"p12": "v12",
@@ -187,7 +187,7 @@ func testCreateAlreadyExistentLocation(t *testing.T, client *api.Client, srv *te
 	req := httptest.NewRequest("PUT", "/locations/loc1", bytes.NewBuffer([]byte(string(tmp))))
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
-	resp := newTestHTTPRouter(client, req)
+	resp := newTestHTTPRouter(client, cfg, req)
 	_, err = ioutil.ReadAll(resp.Body)
 
 	require.Nil(t, err, "unexpected error reading body response")
@@ -195,7 +195,7 @@ func testCreateAlreadyExistentLocation(t *testing.T, client *api.Client, srv *te
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusBadRequest)
 }
 
-func testUpdateLocation(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testUpdateLocation(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	locationProps := config.DynamicMap{
 		"p11": "v11",
 		"p12": "v15",
@@ -209,7 +209,7 @@ func testUpdateLocation(t *testing.T, client *api.Client, srv *testutil.TestServ
 	req := httptest.NewRequest("PATCH", "/locations/loc1", bytes.NewBuffer([]byte(string(tmp))))
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
-	resp := newTestHTTPRouter(client, req)
+	resp := newTestHTTPRouter(client, cfg, req)
 	_, err = ioutil.ReadAll(resp.Body)
 
 	require.Nil(t, err, "unexpected error reading body response")
@@ -217,11 +217,11 @@ func testUpdateLocation(t *testing.T, client *api.Client, srv *testutil.TestServ
 	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code %d instead of %d", resp.StatusCode, http.StatusOK)
 }
 
-func testUpdateNoDataLocation(t *testing.T, client *api.Client, srv *testutil.TestServer) {
+func testUpdateNoDataLocation(t *testing.T, client *api.Client, cfg config.Configuration, srv *testutil.TestServer) {
 	req := httptest.NewRequest("PATCH", "/locations/loc1", nil)
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
-	resp := newTestHTTPRouter(client, req)
+	resp := newTestHTTPRouter(client, cfg, req)
 	_, err := ioutil.ReadAll(resp.Body)
 
 	require.Nil(t, err, "unexpected error reading body response")


### PR DESCRIPTION
Change CLI locations properties display for complex types

# Pull Request description

## Description of the change
- Allow CLI locations to list all locations including hosts pool
- Change CLI locations properties display for complex types
- Add timeout for SSH connections
### How to verify it
- Execute CLI commands
```bash
$ yorc locations apply test.json
$ yorc locations list
$ yorc locations info <HP_LOCATION_NAME>
```
with 
[test.json.zip](https://github.com/ystia/yorc/files/4298809/test.json.zip)


### Description for the changelog
* CLI yorc locations list doesn't return HostsPool information ([GH-615](https://github.com/ystia/yorc/issues/615))
## Applicable Issues
fixes #615 