### PR TITLE
Check for location type mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Check for location type mismatch ([GH-550](https://github.com/ystia/yorc/issues/550))
+
 ## 4.0.0-M10 (March 10, 2020)
 
 ### FEATURES

--- a/locations/location_mgr.go
+++ b/locations/location_mgr.go
@@ -194,9 +194,8 @@ func (mgr *locationManager) GetLocationProperties(locationName, locationType str
 	// got configuration for the requested location
 	props = lConfig.Properties
 	// 	check if no mismatch between the type defined in the configuration and the given location type
-	kvLocationType := lConfig.Type
-	if locationType != kvLocationType {
-		return props, errors.Errorf("The location %q has %s type defined and not the requested %s type", locationName, kvLocationType, locationType)
+	if locationType != lConfig.Type {
+		return props, errors.Errorf("The location %q has %s type defined and not the requested %s type", locationName, lConfig.Type, locationType)
 	}
 
 	return props, err

--- a/locations/location_mgr.go
+++ b/locations/location_mgr.go
@@ -190,6 +190,9 @@ func (mgr *locationManager) GetLocationProperties(locationName, locationType str
 	if err != nil {
 		return props, errors.Wrapf(err, "failed to unmarshal configuration for location %s", locationName)
 	}
+	if lConfig.Type != locationType {
+		return props, errors.Errorf("The location %q has %s type and not the expected %s type", locationName, lConfig.Type, locationType)
+	}
 
 	return props, err
 }


### PR DESCRIPTION
# Pull Request description

## Description of the change
Detect that a location targeted by a deployment has the expected type.

### What I did
If the targeted location exists, check that its type is the same as the requested infrastructure type.

### How to verify it
Request deployments on a location `locName` corresponding to a given infrastructure type `infraType`. 
Define in yorc a location  `locName` having type `locType` different from `infraType`

Check that deployment fails with the following error message : 
"The location  `locName` has  type `locType` and not the expected `infraType` type"

### Description for the changelog
Check for location type mismatch ([GH-550](https://github.com/ystia/yorc/issues/550))

## Applicable Issues

Closes #550 