### PR TITLE
List location name and type even when no properties provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Location is not listed if its properties are missing ([GH-625](https://github.com/ystia/yorc/issues/625))
+
 ## 4.0.0-rc.1 (March 30, 2020)
 
 ### FEATURES

--- a/commands/locations/locations_list.go
+++ b/commands/locations/locations_list.go
@@ -62,6 +62,11 @@ func listLocations(client httputil.HTTPClient) error {
 
 func displayLocationInfo(table tabutil.Table, locationName, locationType string, properties config.DynamicMap, colorize bool, operation int) {
 	propKeys := properties.Keys()
+	if len(propKeys) == 0 {
+		// Display at least location name and type
+		displayProperties(table, locationName, locationType, 0, "", "", 0, colorize, operation)
+		return
+	}
 	for i := 0; i < len(propKeys); i++ {
 		propValue := properties.Get(propKeys[i])
 		displayProperties(table, locationName, locationType, i, propKeys[i], propValue, 0, colorize, operation)


### PR DESCRIPTION
# Pull Request description

## Description of the change
Detect that a location properties are not provided, and add it to the outpul table.

### What I did
Add only location name and type to the output table.

### How to verify it
Add a location with no preperties:
`yorc loc add -d '{"name": "g1", "type": "google", "properties": {}}'`

Then list locations and check g1 is in the output table

### Description for the changelog

## Applicable Issues
https://github.com/ystia/yorc/issues/625