### PR TITLE
Display location without properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Location is not listed if its properties are missing ([GH-625](https://github.com/ystia/yorc/issues/625))
+
 ## 4.0.0-rc.1 (March 30, 2020)
 
 ### FEATURES

--- a/commands/locations/locations_list.go
+++ b/commands/locations/locations_list.go
@@ -62,9 +62,13 @@ func listLocations(client httputil.HTTPClient) error {
 
 func displayLocationInfo(table tabutil.Table, locationName, locationType string, properties config.DynamicMap, colorize bool, operation int) {
 	propKeys := properties.Keys()
-	for i := 0; i < len(propKeys); i++ {
-		propValue := properties.Get(propKeys[i])
-		displayProperties(table, locationName, locationType, i, propKeys[i], propValue, 0, colorize, operation)
+	if len(propKeys) > 0 {
+		for i := 0; i < len(propKeys); i++ {
+			propValue := properties.Get(propKeys[i])
+			displayProperties(table, locationName, locationType, i, propKeys[i], propValue, 0, colorize, operation)
+		}
+	} else {
+		displayRow(table, locationName, locationType, 0, "", "", 0, false, 0)
 	}
 }
 

--- a/commands/locations/locations_list_test.go
+++ b/commands/locations/locations_list_test.go
@@ -40,7 +40,10 @@ func (c *httpClientMockList) Do(req *http.Request) (*http.Response, error) {
 	w := httptest.NewRecorder()
 
 	if req.URL.Path == "/locations" {
-		locations := &rest.LocationCollection{Locations: []rest.AtomLink{{Rel: "location", Href: "/locations/locationOne", LinkType: rest.LinkRelHost}}}
+		locations := &rest.LocationCollection{Locations: []rest.AtomLink{
+			{Rel: "location", Href: "/locations/locationOne", LinkType: rest.LinkRelHost},
+			{Rel: "location", Href: "/locations/locationTwo", LinkType: rest.LinkRelHost},
+		}}
 		b, err := json.Marshal(locations)
 		if err != nil {
 			return nil, errors.New("Failed to build MockList http client response")
@@ -76,6 +79,15 @@ func (c *httpClientMockList) Do(req *http.Request) (*http.Response, error) {
 			},
 		}
 		locationConfig := &rest.LocationConfiguration{Name: "location3", Type: "aws", Properties: locationConfigProps}
+		b, err := json.Marshal(locationConfig)
+		if err != nil {
+			return nil, errors.New("Failed to build Mock http client response")
+		}
+		w.Write(b)
+	}
+
+	if req.URL.Path == "/locations/locationTwo" {
+		locationConfig := &rest.LocationConfiguration{Name: "location3", Type: "slurm"}
 		b, err := json.Marshal(locationConfig)
 		if err != nil {
 			return nil, errors.New("Failed to build Mock http client response")


### PR DESCRIPTION
# Pull Request description

## Description of the change
Handle location without properties in CLI display
### Description for the changelog
* Location is not listed if its properties are missing ([GH-625](https://github.com/ystia/yorc/issues/625))
## Applicable Issues
fixes #625 