### PR TITLE
Check Consul startup using the server leader api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### BUG FIXES
 
 * Location is not listed if its properties are missing ([GH-625](https://github.com/ystia/yorc/issues/625))
+* Sometimes Yorc bootstrap fails to start local Yorc instance because Consul is not properly started ([GH-623](https://github.com/ystia/yorc/issues/623))
 
 ## 4.0.0-rc.1 (March 30, 2020)
 

--- a/commands/bootstrap/setup_test.go
+++ b/commands/bootstrap/setup_test.go
@@ -1,0 +1,111 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func Test_waitForConsulReadiness(t *testing.T) {
+	type endpoint struct {
+		started    bool
+		httpStatus int
+		text       string
+	}
+	tests := []struct {
+		name          string
+		endpoint      endpoint
+		shouldSucceed bool
+	}{
+		{"NormalStartup", endpoint{true, 200, `"127.0.0.1:8300"`}, true},
+		{"ConsulStartedButNotReady", endpoint{true, 200, `""`}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.endpoint.httpStatus)
+				w.Write([]byte(tt.endpoint.text))
+			}))
+			if !tt.endpoint.started {
+				// close now!
+				ts.Close()
+			} else {
+				defer ts.Close()
+			}
+			c := make(chan struct{}, 0)
+			go func() {
+				waitForConsulReadiness(ts.URL)
+				close(c)
+			}()
+			var timedOut bool
+			select {
+			case <-c:
+			case <-time.After(6 * time.Second):
+				timedOut = true
+			}
+			if tt.shouldSucceed == timedOut {
+				t.Errorf("expecting waitForConsulReadiness() to succeed but it timedout")
+			} else if !tt.shouldSucceed && !timedOut {
+				t.Errorf("expecting waitForConsulReadiness() to timeout but it succeeded")
+			}
+		})
+	}
+}
+
+func Test_getConsulLeader(t *testing.T) {
+	type endpoint struct {
+		started    bool
+		httpStatus int
+		text       string
+	}
+	tests := []struct {
+		name     string
+		endpoint endpoint
+		want     string
+		wantErr  bool
+	}{
+		{"NormalStartup", endpoint{true, 200, `"127.0.0.1:8300"`}, "127.0.0.1:8300", false},
+		{"ConsulStartedButNotReady", endpoint{true, 200, `""`}, "", false},
+		{"ConsulStartedButBadResponse", endpoint{true, 200, `qsdhjgy@àà*ùù$ugfbdnflv`}, "", false},
+		{"ConsulStartedButBadStatus", endpoint{true, 500, ``}, "", true},
+		{"ConsulNotStarted", endpoint{false, 0, ``}, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.endpoint.httpStatus)
+				w.Write([]byte(tt.endpoint.text))
+			}))
+			defer ts.Close()
+			got, err := getConsulLeader(ts.URL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getConsulLeader() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.endpoint.httpStatus == 500 {
+				assert.ErrorContains(t, err, "500")
+			}
+			if got != tt.want {
+				t.Errorf("getConsulLeader() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -115,6 +115,7 @@ require (
 	gopkg.in/ory-am/dockertest.v3 v3.3.5 // indirect
 	gopkg.in/yaml.v2 v2.2.4
 	gotest.tools v2.2.0+incompatible // indirect
+	gotest.tools/v3 v3.0.0
 	k8s.io/api v0.0.0-20180628040859-072894a440bd
 	k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d
 	k8s.io/client-go v8.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -619,6 +619,7 @@ gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.0 h1:d+tVGRu6X0ZBQ+kyAR8JKi6AXhTP2gmQaoIYaGFz634=
 gotest.tools/v3 v3.0.0/go.mod h1:TUP+/YtXl/dp++T+SZ5v2zUmLVBHmptSb/ajDLCJ+3c=
+gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.0.0-20180628040859-072894a440bd h1:HzgYeLDS1jLxw8DGr68KJh9cdQ5iZJizG0HZWstIhfQ=
 k8s.io/api v0.0.0-20180628040859-072894a440bd/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Stop parsing Consul logs to to detect its startup but use the [leader status API](https://www.consul.io/api/status.html#get-raft-leader) instead.

### How I did it

Redirect consul logs to a file and use the Consul HTTP API to detect the startup.
Wait forever to startup, if it fails badly we are expecting the user to check logs and stop bootstrap using Ctrl+C.

### How to verify it

Bootstrap using a slow machine :wink: 

### Description for the changelog

* Sometimes Yorc bootstrap fails to start local Yorc instance because Consul is not properly started ([GH-623](https://github.com/ystia/yorc/issues/623))

## Applicable Issues

Fixes #623 