### PR TITLE
Bugfix: Bootstrap Download error not handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Bootstrap may failed with a nil pointer error if download of a component fails ([GH-634](https://github.com/ystia/yorc/issues/634))
+
 ## 4.0.0 (April 17, 2020)
 
 ### BUG FIXES

--- a/commands/bootstrap/setup.go
+++ b/commands/bootstrap/setup.go
@@ -487,16 +487,15 @@ func download(url, fileName, destinationPath string, overwrite bool) (string, er
 		defer outputFile.Close()
 
 		response, err := http.Get(url)
-
-		//bar
-		bar := pb.Full.Start(int(response.ContentLength))
-		barReader := bar.NewProxyReader(response.Body)
-
 		if err != nil {
 			outputFile.Close()
 			return filePath, err
 		}
 		defer response.Body.Close()
+
+		//bar
+		bar := pb.Full.Start(int(response.ContentLength))
+		barReader := bar.NewProxyReader(response.Body)
 
 		_, err = io.Copy(outputFile, barReader)
 		outputFile.Close()


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Fix missing handling of error on download bootstrap components

### How to verify it

1. Start a bootstrap
2. Simulate a network error when downloading

### Description for the changelog

* Bootstrap may failed with a nil pointer error if download of a component fails ([GH-634](https://github.com/ystia/yorc/issues/634))

## Applicable Issues

Fixes #634 