### PR TITLE
Changed default Alien4Cloud download URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### ENHANCEMENTS
+
+* Alien4Cloud download URL change ([GH-637](https://github.com/ystia/yorc/issues/637))
+
 ### BUG FIXES
 
 * Bootstrap may failed with a nil pointer error if download of a component fails ([GH-634](https://github.com/ystia/yorc/issues/634))

--- a/commands/bootstrap/inputs.go
+++ b/commands/bootstrap/inputs.go
@@ -119,7 +119,7 @@ var (
 		"alien4cloud.download_url": defaultInputType{
 			description: "Alien4Cloud download URL",
 			value: fmt.Sprintf(
-				"https://fastconnect.org/maven/content/repositories/opensource/alien4cloud/alien4cloud-dist/%s/alien4cloud-dist-%s-dist.tar.gz",
+				"https://www.portaildulibre.fr/nexus/repository/opensource-releases/alien4cloud/alien4cloud-premium-dist/%s/alien4cloud-premium-dist-%s-dist.tar.gz",
 				alien4cloudVersion, alien4cloudVersion),
 		},
 		"alien4cloud.port": defaultInputType{

--- a/doc/bootstrap.rst
+++ b/doc/bootstrap.rst
@@ -190,7 +190,7 @@ Bootstrapping the setup using command line options
 
 The following ``yorc bootstrap`` option are available:
 
-  * ``--alien4cloud_download_url`` Alien4Cloud download URL (defaults to the Alien4Cloud version compatible with this Yorc, under https://fastconnect.org/maven/content/repositories/opensource/alien4cloud/alien4cloud-dist/)
+  * ``--alien4cloud_download_url`` Alien4Cloud download URL (defaults to the Alien4Cloud version compatible with this Yorc, under https://www.portaildulibre.fr/nexus/repository/opensource-releases/alien4cloud/alien4cloud-premium-dist/)
   * ``--alien4cloud_password`` Alien4Cloud password (default, admin)
   * ``--alien4cloud_port`` Alien4Cloud port (default 8088)
   * ``--alien4cloud_user`` Alien4Cloud user (default, admin)


### PR DESCRIPTION
# Pull Request description

## Description of the change

Updated the default Alien4Cloud download URL used in Yorc bootstrap, not anymore available under https://fastconnect.org/

### How to verify it

Execute a yorc bootstrap without specifying a URL for Alien4Cloud distribution (to use the default value).

### Description for the changelog

Alien4Cloud download URL change ([GH-637](https://github.com/ystia/yorc/issues/637))

## Applicable Issues

Fixes #637 
