### PR TITLE
Add concurrency limit during data migration for file storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### BUG FIXES
 
 * Bootstrap may failed with a nil pointer error if download of a component fails ([GH-634](https://github.com/ystia/yorc/issues/634))
+* Missing concurrency limit during data migration for logs and events file storage ([GH-640](https://github.com/ystia/yorc/issues/640))
 
 ## 4.0.0 (April 17, 2020)
 

--- a/storage/store/test.go
+++ b/storage/store/test.go
@@ -71,7 +71,8 @@ func SetupTestConfig(t testing.TB) config.Configuration {
 	assert.Nil(t, err)
 
 	return config.Configuration{
-		WorkingDirectory: workingDir,
+		WorkingDirectory:        workingDir,
+		UpgradeConcurrencyLimit: config.DefaultUpgradesConcurrencyLimit,
 	}
 }
 

--- a/testutil/helper.go
+++ b/testutil/helper.go
@@ -99,6 +99,7 @@ func SetupTestConfig(t testing.TB) config.Configuration {
 	assert.Nil(t, err)
 
 	return config.Configuration{
-		WorkingDirectory: workingDir,
+		WorkingDirectory:        workingDir,
+		UpgradeConcurrencyLimit: config.DefaultUpgradesConcurrencyLimit,
 	}
 }


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did
Add concurrency limit during data migration for file storage

### Description for the changelog
* Missing concurrency limit during data migration for logs and events file storage ([GH-640](https://github.com/ystia/yorc/issues/640))
## Applicable Issues
fixes #640 