### PR TITLE
Fix error on canceling a running deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Bootstrap may failed with a nil pointer error if download of a component fails ([GH-634](https://github.com/ystia/yorc/issues/634))
 * Missing concurrency limit during data migration for logs and events file storage ([GH-640](https://github.com/ystia/yorc/issues/640))
+* Unable to undeploy a deployment in progress from Alien4Cloud ([GH-630](https://github.com/ystia/yorc/issues/630))
 
 ## 4.0.0 (April 17, 2020)
 

--- a/tasks/consul_test.go
+++ b/tasks/consul_test.go
@@ -91,5 +91,8 @@ func TestRunConsulTasksPackageTests(t *testing.T) {
 		t.Run("TestIsStepRegistrationInProgress", func(t *testing.T) {
 			testIsStepRegistrationInProgress(t)
 		})
+		t.Run("TestCheckAndSetTaskErrorMessage", func(t *testing.T) {
+			testCheckAndSetTaskErrorMessage(t)
+		})
 	})
 }

--- a/tasks/workflow/step.go
+++ b/tasks/workflow/step.go
@@ -216,13 +216,11 @@ func (s *step) run(ctx context.Context, cfg config.Configuration, deploymentID s
 				s.setStatus(tasks.TaskStepStatusERROR)
 				if !bypassErrors {
 					tasks.NotifyErrorOnTask(s.t.taskID)
-					// set task status and generic error message
-					err2 := checkAndSetTaskStatus(ctx, s.t.targetID, s.t.taskID, tasks.TaskStatusFAILED, errors.Errorf("Workflow %q step%q failed.", workflowName, s.Name))
-					if err2 != nil {
-						events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, deploymentID).Registerf("failed to set task status to error for step:%q: %v", s.Name, err2)
-					}
+					// only set generic error message here.
+					// Task status is handled in task execution final function
+					tasks.CheckAndSetTaskErrorMessage(s.t.taskID, fmt.Sprintf("Workflow %q step %q failed.", workflowName, s.Name), false)
 
-					err2 = s.registerOnCancelOrFailureSteps(ctx, workflowName, s.OnFailure)
+					err2 := s.registerOnCancelOrFailureSteps(ctx, workflowName, s.OnFailure)
 					if err2 != nil {
 						events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, deploymentID).Registerf("failed to register on failure steps: %v", err2)
 					}


### PR DESCRIPTION
# Pull Request description

## Description of the change

Do not change task status when we just need to set the error message for task.
task status change should be handled in a unique place.

### What I did

Do not set task status on run step error.
Added a new function that allow to prevent overwriting of error message if a previous one already exist.

### How to verify it

Follow reproduction steps on #630 

### Description for the changelog

* Unable to undeploy a deployment in progress from Alien4Cloud ([GH-630](https://github.com/ystia/yorc/issues/630))

## Applicable Issues

Fixes  #630 

Backport needed on release/4.0 (See #644)