### PR TITLE
Fix uses of deprecated k8s apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### BUG FIXES
 
+* Kubernetes Client uses deprecated apis removed on recent versions of K8S (v1.17+) ([GH-645](https://github.com/ystia/yorc/issues/645))
 * Bootstrap may failed with a nil pointer error if download of a component fails ([GH-634](https://github.com/ystia/yorc/issues/634))
 * Missing concurrency limit during data migration for logs and events file storage ([GH-640](https://github.com/ystia/yorc/issues/640))
 * Unable to undeploy a deployment in progress from Alien4Cloud ([GH-630](https://github.com/ystia/yorc/issues/630))

--- a/prov/kubernetes/controller_test.go
+++ b/prov/kubernetes/controller_test.go
@@ -16,9 +16,6 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/ystia/yorc/v4/storage"
-	"github.com/ystia/yorc/v4/storage/types"
-	"github.com/ystia/yorc/v4/tosca"
 	"testing"
 
 	ctu "github.com/hashicorp/consul/testutil"
@@ -26,6 +23,9 @@ import (
 
 	"github.com/ystia/yorc/v4/helper/consulutil"
 	"github.com/ystia/yorc/v4/log"
+	"github.com/ystia/yorc/v4/storage"
+	"github.com/ystia/yorc/v4/storage/types"
+	"github.com/ystia/yorc/v4/tosca"
 )
 
 func testsController(t *testing.T, srv *ctu.TestServer) {

--- a/prov/kubernetes/execution_test.go
+++ b/prov/kubernetes/execution_test.go
@@ -17,29 +17,30 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"github.com/ystia/yorc/v4/storage"
-	"github.com/ystia/yorc/v4/storage/types"
-	"github.com/ystia/yorc/v4/tosca"
 	"path"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/ystia/yorc/v4/helper/consulutil"
-	"github.com/ystia/yorc/v4/prov"
-	"github.com/ystia/yorc/v4/tasks"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/ystia/yorc/v4/helper/consulutil"
+	"github.com/ystia/yorc/v4/prov"
+	"github.com/ystia/yorc/v4/storage"
+	"github.com/ystia/yorc/v4/storage/types"
+	"github.com/ystia/yorc/v4/tasks"
+	"github.com/ystia/yorc/v4/tosca"
 )
 
 var JSONvalidDeployment = `
 {
-  "apiVersion": "extensions/v1beta1",
+  "apiVersion": "apps/v1",
   "kind": "Deployment",
   "metadata": {
      "name": "test-deploy"
@@ -675,7 +676,7 @@ func testExecutionManageNamespaceDeletion(t *testing.T) {
 	// One ns "test-ns", 1 controler
 	k8s1 := newTestSimpleK8s()
 	k8s1.clientset.CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}})
-	k8s1.clientset.ExtensionsV1beta1().Deployments("test-ns").Create(&v1beta1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deploy"}})
+	k8s1.clientset.AppsV1().Deployments("test-ns").Create(&v1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deploy"}})
 
 	type args struct {
 		clientset         kubernetes.Interface

--- a/prov/kubernetes/k8s_utils_test.go
+++ b/prov/kubernetes/k8s_utils_test.go
@@ -19,9 +19,8 @@ import (
 	"strings"
 	"testing"
 
-	appsv1 "k8s.io/api/apps/v1beta1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -122,9 +121,9 @@ func TestGetNoneExternalIPAdress(t *testing.T) {
 Currently support only : StatefulSet, PVC, Service and Deployment */
 func mockSupportedResources() map[string]runtime.Object {
 	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvcTest", Namespace: "test-ns"}}
-	dep := &v1beta1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deploymentTest", Namespace: "test-ns"}}
-	sts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "statefulSetTest", Namespace: "test-ns"},
-		Spec: appsv1.StatefulSetSpec{}}
+	dep := &v1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deploymentTest", Namespace: "test-ns"}}
+	sts := &v1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "statefulSetTest", Namespace: "test-ns"},
+		Spec: v1.StatefulSetSpec{}}
 	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "serviceTest", Namespace: "test-ns"}}
 	supportedRes := make(map[string]runtime.Object)
 	supportedRes["persistentvolumeclaims"] = pvc
@@ -302,7 +301,7 @@ func Test_podControllersInNamespace(t *testing.T) {
 			"Test one deployment left",
 			func() kubernetes.Interface {
 				k8s := newTestSimpleK8s()
-				k8s.clientset.ExtensionsV1beta1().Deployments(nsName).Create(&v1beta1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "my-deployment", Namespace: nsName}})
+				k8s.clientset.AppsV1().Deployments(nsName).Create(&v1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "my-deployment", Namespace: nsName}})
 				return k8s.clientset
 			},
 			args{namespace: nsName},
@@ -312,9 +311,9 @@ func Test_podControllersInNamespace(t *testing.T) {
 			"Test one deployment & 2 statefulSets left",
 			func() kubernetes.Interface {
 				k8s := newTestSimpleK8s()
-				k8s.clientset.AppsV1beta1().StatefulSets(nsName).Create(&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "my-statefulset-1", Namespace: nsName}})
-				k8s.clientset.AppsV1beta1().StatefulSets(nsName).Create(&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "my-statefulset-2", Namespace: nsName}})
-				k8s.clientset.ExtensionsV1beta1().Deployments(nsName).Create(&v1beta1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "my-deployment", Namespace: nsName}})
+				k8s.clientset.AppsV1().StatefulSets(nsName).Create(&v1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "my-statefulset-1", Namespace: nsName}})
+				k8s.clientset.AppsV1().StatefulSets(nsName).Create(&v1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "my-statefulset-2", Namespace: nsName}})
+				k8s.clientset.AppsV1().Deployments(nsName).Create(&v1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "my-deployment", Namespace: nsName}})
 				return k8s.clientset
 			},
 			args{namespace: nsName},

--- a/prov/kubernetes/testdata/org.alien4cloud.kubernetes.api/2.1.1/tosca.yml
+++ b/prov/kubernetes/testdata/org.alien4cloud.kubernetes.api/2.1.1/tosca.yml
@@ -1152,7 +1152,7 @@ node_types:
       apiVersion:
         type: string
         description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
-        default: "apps/v1beta1"
+        default: "apps/v1"
       kind:
         type: string
         description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
@@ -1245,10 +1245,10 @@ node_types:
           inputs:
             KUBE_DEPLOYMENT_ID: { get_attribute: [SELF, deployment_id] }
             NAMESPACE: { get_property: [SELF, namespace] }
-            EXPECTED_INSTANCES: 
+            EXPECTED_INSTANCES:
               type: integer
 
-            INSTANCES_DELTA: 
+            INSTANCES_DELTA:
               type: integer
 
           implementation: scripts/kubectl_deployment_scale.sh


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Change beta versions to stable one

### How to verify it

1. Try to deploy a Deployment on k8s v1.17+

### Description for the changelog

* Kubernetes Client uses deprecated apis removed on recent versions of K8S (v1.17+) ([GH-645](https://github.com/ystia/yorc/issues/645))

## Applicable Issues

Fixes #645 

## Backports

- Should be backported to release/4.0 (#647)