### PR TITLE
Feature/events and logs elastic storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### FEATURES
+
+* Added an ElasticSearch store for events and logs ([GH-658](https://github.com/ystia/yorc/issues/658))
+
 ### SECURITY FIXES
 
 * Fix [vulnerability in golang.org/x/crypto/ssh](https://snyk.io/vuln/SNYK-GOLANG-GOLANGORGXCRYPTOSSH-551923) by upgrading dependency

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1178,6 +1178,7 @@ Yorc supports 5 store ``implementations``:
   * ``cipherFile``
   * ``fileCache``
   * ``cipherFileCache``
+  * ``elastic`` (experimental)
 
 By default, ``Log`` and ``Event`` store types use ``consul`` implementation, and ``Deployment`` store uses ``fileCache``.
 
@@ -1388,6 +1389,54 @@ Stores configuration is saved once when Yorc server starts. If you want to re-in
 If no storage configuration is set, default stores implementations are used as defined previously to handle all store types (``Deployment``, ``Log`` and ``Event``).
 
 If any storage configuration is set with partial stores types, the missing store types will be added with default implementations.
+
+elastic
+^^^^^^^
+
+This store ables you to store ``Log`` s and ``Event`` s in elasticsearch.
+
+.. warning::
+    This storage is only suitable to store logs and events.
+
+ 1 index for logs, 1 index for events.
+
++-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
+|     Property Name           |           Description                              | Data Type |   Required       | Default         |
++=============================+====================================================+===========+==================+=================+
+| ``es_urls``                 | the ES cluster urls                                | []string  | yes              |                 |
++-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
+| ``ca_cert_path``            | path to the CACert when TLS is activated for ES    | string    | no               |                 |
++-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
+| ``index_prefix``            | indexes used by yorc can be prefixed               | string    | no               |   yorc_         |
++-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
+| ``es_query_period``         | when querying logs and event, we wait this timeout | duration  | no               |   4s            |
+|                             | before each request when it returns nothing (until |           |                  |                 |
+|                             | something is returned or the waitTimeout is        |           |                  |                 |
+|                             | reached)                                           |           |                  |                 |
++-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
+| ``es_refresh_wait_timeout`` | used to wait for more than refresh_interval (1s)   | duration  | no               |   2s            |
+|                             | (until something is returned or the waitTimeout is |           |                  |                 |
+|                             | is reached)                                        |           |                  |                 |
++-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
+| ``es_force_refresh``        | when querying ES, force refresh index before when  | bool      | no               |   false         |
+|                             | waiting for refresh.                               |           |                  |                 |
++-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
+| ``max_bulk_size``           | the maximum size (in kB) of bulk request sent when | int64     | no               |   4000          |
+|                             | while migrating data                               |           |                  |                 |
++-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
+| ``max_bulk_count``          | maximum size (in term of number of documents) when | int64     | no               |   1000          |
+|                             | of bulk request sent while migrating data          |           |                  |                 |
++-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
+| ``cluster_id``              | used to distinguish logs & events in the indexes   | string    | no               |                 |
+|                             | if different yorc cluster are writting in the same |           |                  |                 |
+|                             | elastic cluster.                                   |           |                  |                 |
+|                             | If not set, the consul.datacenter will be used.    |           |                  |                 |
++-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
+| ``trace_requests``          | to print ES requests (for debug only)              | bool      | no               |   false         |
++-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
+| ``trace_events``            | to trace events & logs when sent (for debug only)  | bool      | no               |   false         |
++-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
+
 
 Vault configuration
 -------------------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1398,14 +1398,21 @@ This store ables you to store ``Log`` s and ``Event`` s in elasticsearch.
 .. warning::
     This storage is only suitable to store logs and events.
 
- 1 index for logs, 1 index for events.
+ Per Yorc cluster : 1 index for logs, 1 index for events.
 
 +-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
 |     Property Name           |           Description                              | Data Type |   Required       | Default         |
 +=============================+====================================================+===========+==================+=================+
 | ``es_urls``                 | the ES cluster urls                                | []string  | yes              |                 |
 +-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
-| ``ca_cert_path``            | path to the CACert when TLS is activated for ES    | string    | no               |                 |
+| ``ca_cert_path``            | path to the PEM encoded CA's certificate file when | string    | no               |                 |
+|                             | TLS is activated for ES                            |           |                  |                 |
++-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
+| ``cert_path``               | path to a PEM encoded certificate file when TLS    | string    | no               |                 |
+|                             | is activated for ES                                |           |                  |                 |
++-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
+| ``key_path``                | path to a PEM encoded private key file when TLS    | string    | no               |                 |
+|                             | is activated for ES                                |           |                  |                 |
 +-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
 | ``index_prefix``            | indexes used by yorc can be prefixed               | string    | no               |   yorc_         |
 +-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
@@ -1428,7 +1435,7 @@ This store ables you to store ``Log`` s and ``Event`` s in elasticsearch.
 |                             | of bulk request sent while migrating data          |           |                  |                 |
 +-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+
 | ``cluster_id``              | used to distinguish logs & events in the indexes   | string    | no               |                 |
-|                             | if different yorc cluster are writting in the same |           |                  |                 |
+|                             | if different yorc cluster are writing in the same  |           |                  |                 |
 |                             | elastic cluster.                                   |           |                  |                 |
 |                             | If not set, the consul.datacenter will be used.    |           |                  |                 |
 +-----------------------------+----------------------------------------------------+-----------+------------------+-----------------+

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/duosecurity/duo_api_golang v0.0.0-20200206192355-a9725220d6ca // indirect
 	github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4
+	github.com/elastic/go-elasticsearch/v6 v6.8.6-0.20200428134631-c5be8f8ee116
 	github.com/fatih/color v1.7.0
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/duosecurity/duo_api_golang v0.0.0-20200206192355-a9725220d6ca h1:/YYq
 github.com/duosecurity/duo_api_golang v0.0.0-20200206192355-a9725220d6ca/go.mod h1:jdoEJUIrTIxN7nNTwwqA3TBNcSM+W1lrWM6OXVhjbG8=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4 h1:qk/FSDDxo05wdJH28W+p5yivv7LuLYLRXPPD8KQCtZs=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/elastic/go-elasticsearch/v6 v6.8.6-0.20200428134631-c5be8f8ee116 h1:Cukct/JLkvYHsHgC810jQKMT6emk9v/fspxPbDKJSoo=
+github.com/elastic/go-elasticsearch/v6 v6.8.6-0.20200428134631-c5be8f8ee116/go.mod h1:UwaDJsD3rWLM5rKNFzv9hgox93HoX8utj1kxD9aFUcI=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/storage/internal/elastic/config.go
+++ b/storage/internal/elastic/config.go
@@ -1,0 +1,179 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elastic
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cast"
+	"github.com/ystia/yorc/v4/config"
+	"github.com/ystia/yorc/v4/log"
+	"reflect"
+	"time"
+)
+
+var elasticStoreConfType = reflect.TypeOf(elasticStoreConf{})
+
+// elasticStoreConf represents the elastic store configuration that can be set in store.properties configuration.
+type elasticStoreConf struct {
+	// The ES cluster urls (array or CSV)
+	esUrls []string `json:"es_urls"`
+	// The path to the CACert file when TLS is activated for ES
+	caCertPath string `json:"ca_cert_path"`
+	// All index used by yorc will be prefixed by this prefix
+	indicePrefix string `json:"index_prefix" default:"yorc_"`
+	// When querying logs and event, we wait this timeout before each request when it returns nothing
+	// (until something is returned or the waitTimeout is reached)
+	esQueryPeriod time.Duration `json:"es_query_period" default:"4s"`
+	// This timeout is used to wait for more than refresh_interval = 1s when querying logs and events indexes
+	esRefreshWaitTimeout time.Duration `json:"es_refresh_wait_timeout" default:"2s"`
+	// When querying ES, force refresh index before waiting for refresh
+	esForceRefresh bool `json:"es_force_refresh" default:"false"`
+	// This is the maximum size (in kB) of bulk request sent while migrating data
+	maxBulkSize int `json:"max_bulk_size" default:"4000"`
+	// This is the maximum size (in term of number of documents) of bulk request sent while migrating data
+	maxBulkCount int `json:"max_bulk_count" default:"1000"`
+	// This optional ID will be used to distinguish logs & events in the indexes. If not set, we'll use the Consul.Datacenter
+	clusterID string `json:"cluster_id"`
+	// Set to true if you want to print ES requests (for debug only)
+	traceRequests bool `json:"trace_requests" default:"false"`
+	// Set to true if you want to trace events & logs when sent (for debug only)
+	traceEvents bool `json:"trace_events" default:"false"`
+}
+
+// Get the tag for this field (for internal usage only: fatal if not found !).
+func getElasticStorageConfigPropertyTag(fn string, tn string) (tagValue string, e error) {
+	f, found := elasticStoreConfType.FieldByName(fn)
+	if !found {
+		e = errors.Errorf("Not able to get field %s on elasticStoreConf struct, there is an issue with this code !", fn)
+		return
+	}
+	tagValue = f.Tag.Get(tn)
+	if tagValue == "" {
+		e = errors.Errorf("Not able to get field %s's tag %s value on elasticStoreConf struct, there is an issue with this code !\"", fn, tn)
+		return
+	}
+	return
+}
+
+// The configuration of the elastic store is defined regarding default values and store 'properties' dynamic map.
+// Will fail if the required es_urls is not set in store 'properties'
+func getElasticStoreConfig(yorcConfig config.Configuration, storeConfig config.Store) (cfg elasticStoreConf, e error) {
+	storeProperties := storeConfig.Properties
+	var t string
+	// The ES urls is required
+	t, e = getElasticStorageConfigPropertyTag("esUrls", "json")
+	if e != nil {
+		return
+	}
+	if storeProperties.IsSet(t) {
+		cfg.esUrls = storeProperties.GetStringSlice(t)
+		if cfg.esUrls == nil || len(cfg.esUrls) == 0 {
+			e = errors.Errorf("Not able to get ES configuration for elastic store, es_urls store property seems empty : %+v", storeProperties.Get(t))
+			return
+		}
+	} else {
+		log.Fatal("Not able to get ES configuration for elastic store, es_urls store property should be set !")
+	}
+	// Define the clusterID
+	t, e = getElasticStorageConfigPropertyTag("clusterID", "json")
+	if e != nil {
+		return
+	}
+	if storeProperties.IsSet(t) {
+		cfg.clusterID = storeProperties.GetString(t)
+	}
+	if len(cfg.clusterID) == 0 {
+		cfg.clusterID = yorcConfig.Consul.Datacenter
+		log.Printf("clusterID not provided or empty, using consul datacenter (%s) as clusterID", yorcConfig.Consul.Datacenter)
+	}
+	if len(cfg.clusterID) == 0 {
+		e = errors.Errorf("Not able to define clusterID, please check configuration !")
+		return
+	}
+	// Define store optional / default configuration
+	t, e = getElasticStorageConfigPropertyTag("caCertPath", "json")
+	if storeProperties.IsSet(t) {
+		cfg.caCertPath = storeProperties.GetString(t)
+	}
+	cfg.esForceRefresh, e = getBoolFromSettingsOrDefaults("esForceRefresh", storeProperties)
+	t, e = getElasticStorageConfigPropertyTag("indicePrefix", "json")
+	if storeProperties.IsSet(t) {
+		cfg.indicePrefix = storeProperties.GetString(t)
+	} else {
+		cfg.indicePrefix, e = getElasticStorageConfigPropertyTag("indicePrefix", "default")
+	}
+	cfg.esQueryPeriod, e = getDurationFromSettingsOrDefaults("esQueryPeriod", storeProperties)
+	cfg.esRefreshWaitTimeout, e = getDurationFromSettingsOrDefaults("esRefreshWaitTimeout", storeProperties)
+	cfg.maxBulkSize, e = getIntFromSettingsOrDefaults("maxBulkSize", storeProperties)
+	cfg.maxBulkCount, e = getIntFromSettingsOrDefaults("maxBulkCount", storeProperties)
+	cfg.traceRequests, e = getBoolFromSettingsOrDefaults("traceRequests", storeProperties)
+	cfg.traceEvents, e = getBoolFromSettingsOrDefaults("traceEvents", storeProperties)
+	// If any error have been encountered, it will be returned
+	return
+}
+
+// Get the duration from store config properties, fallback to required default value defined in struc.
+func getDurationFromSettingsOrDefaults(fn string, dm config.DynamicMap) (v time.Duration, er error) {
+	t, er := getElasticStorageConfigPropertyTag(fn, "json")
+	if er != nil {
+		return
+	}
+	if dm.IsSet(t) {
+		v = dm.GetDuration(t)
+		return
+	}
+	t, er = getElasticStorageConfigPropertyTag(fn, "default")
+	if er != nil {
+		return
+	}
+	v = cast.ToDuration(t)
+	return
+}
+
+// Get the int from store config properties, fallback to required default value defined in struc.
+func getIntFromSettingsOrDefaults(fn string, dm config.DynamicMap) (v int, err error) {
+	t, err := getElasticStorageConfigPropertyTag(fn, "json")
+	if err != nil {
+		return
+	}
+	if dm.IsSet(t) {
+		v = dm.GetInt(t)
+		return
+	}
+	t, err = getElasticStorageConfigPropertyTag(fn, "default")
+	if err != nil {
+		return
+	}
+	v = cast.ToInt(t)
+	return
+}
+
+// Get the bool from store config properties, fallback to required default value defined in struc.
+func getBoolFromSettingsOrDefaults(fn string, dm config.DynamicMap) (v bool, e error) {
+	t, e := getElasticStorageConfigPropertyTag(fn, "json")
+	if e != nil {
+		return
+	}
+	if dm.IsSet(t) {
+		v = dm.GetBool(t)
+		return
+	}
+	t, e = getElasticStorageConfigPropertyTag(fn, "default")
+	if e != nil {
+		return
+	}
+	v = cast.ToBool(t)
+	return
+}

--- a/storage/internal/elastic/config.go
+++ b/storage/internal/elastic/config.go
@@ -31,6 +31,10 @@ type elasticStoreConf struct {
 	esUrls []string `json:"es_urls"`
 	// The path to the CACert file when TLS is activated for ES
 	caCertPath string `json:"ca_cert_path"`
+	// The path to a PEM encoded certificate file when TLS is activated for ES
+	certPath string `json:"cert_path"`
+	// The path to a PEM encoded private key file when TLS is activated for ES
+	keyPath string `json:"key_path"`
 	// All index used by yorc will be prefixed by this prefix
 	indicePrefix string `json:"index_prefix" default:"yorc_"`
 	// When querying logs and event, we wait this timeout before each request when it returns nothing
@@ -106,6 +110,14 @@ func getElasticStoreConfig(yorcConfig config.Configuration, storeConfig config.S
 	t, e = getElasticStorageConfigPropertyTag("caCertPath", "json")
 	if storeProperties.IsSet(t) {
 		cfg.caCertPath = storeProperties.GetString(t)
+	}
+	t, e = getElasticStorageConfigPropertyTag("certPath", "json")
+	if storeProperties.IsSet(t) {
+		cfg.certPath = storeProperties.GetString(t)
+	}
+	t, e = getElasticStorageConfigPropertyTag("keyPath", "json")
+	if storeProperties.IsSet(t) {
+		cfg.keyPath = storeProperties.GetString(t)
 	}
 	cfg.esForceRefresh, e = getBoolFromSettingsOrDefaults("esForceRefresh", storeProperties)
 	t, e = getElasticStorageConfigPropertyTag("indicePrefix", "json")

--- a/storage/internal/elastic/es_utils.go
+++ b/storage/internal/elastic/es_utils.go
@@ -40,8 +40,6 @@ func prepareEsClient(elasticStoreConfig elasticStoreConf) (*elasticsearch6.Clien
 	var esConfig elasticsearch6.Config
 	esConfig = elasticsearch6.Config{Addresses: elasticStoreConfig.esUrls}
 
-	// TODO: https://gist.github.com/michaljemala/d6f4e01c4834bf47a9c4
-
 	if len(elasticStoreConfig.caCertPath) > 0 {
 		log.Printf("Reading CACert file from %s", elasticStoreConfig.caCertPath)
 		caCert, err := ioutil.ReadFile(elasticStoreConfig.caCertPath)

--- a/storage/internal/elastic/es_utils.go
+++ b/storage/internal/elastic/es_utils.go
@@ -1,0 +1,326 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elastic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	elasticsearch6 "github.com/elastic/go-elasticsearch/v6"
+	"github.com/elastic/go-elasticsearch/v6/esapi"
+	"github.com/pkg/errors"
+	"github.com/ystia/yorc/v4/log"
+	"github.com/ystia/yorc/v4/storage/store"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+)
+
+var pfalse = false
+
+func prepareEsClient(elasticStoreConfig elasticStoreConf) (*elasticsearch6.Client, error) {
+	log.Printf("Elastic storage will run using this configuration: %+v", elasticStoreConfig)
+
+	var esConfig elasticsearch6.Config
+	esConfig = elasticsearch6.Config{Addresses: elasticStoreConfig.esUrls}
+
+	if len(elasticStoreConfig.caCertPath) > 0 {
+		log.Printf("Reading CACert file from %s", elasticStoreConfig.caCertPath)
+		cert, err := ioutil.ReadFile(elasticStoreConfig.caCertPath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Not able to read Cert file from <%s>", elasticStoreConfig.caCertPath)
+		}
+		esConfig.CACert = cert
+	}
+	if log.IsDebug() || elasticStoreConfig.traceRequests {
+		// In debug mode or when traceRequests option is activated, we add a custom logger that print requests & responses
+		log.Printf("\t- Tracing ES requests & response can be expensive and verbose !")
+		esConfig.Logger = &debugLogger{}
+	}
+
+	log.Printf("\t- Index prefix will be %s", elasticStoreConfig.indicePrefix)
+	log.Printf("\t- Documents will be segregated by clusterId : %s", elasticStoreConfig.clusterID)
+	log.Printf("\t- Will query ES for logs or events every %v and will wait for index refresh during %v",
+		elasticStoreConfig.esQueryPeriod, elasticStoreConfig.esRefreshWaitTimeout)
+	willRefresh := ""
+	if !elasticStoreConfig.esForceRefresh {
+		willRefresh = "not "
+	}
+	log.Printf("\t- Will %srefresh index before waiting for indexation", willRefresh)
+	log.Printf("\t- While migrating data, the max bulk request size will be %d documents and will never exceed %d kB",
+		elasticStoreConfig.maxBulkCount, elasticStoreConfig.maxBulkSize)
+	log.Printf("\t- Will use this ES client configuration: %+v", esConfig)
+
+	esClient, e := elasticsearch6.NewClient(esConfig)
+	log.Printf("Here is the ES cluster info")
+	log.Println(esClient.Info())
+	return esClient, e
+}
+
+// Init ES index for logs or events storage: create it if not found.
+func initStorageIndex(c *elasticsearch6.Client, elasticStoreConfig elasticStoreConf, storeType string) error {
+
+	indexName := getIndexName(elasticStoreConfig, storeType)
+	log.Printf("Checking if index <%s> already exists", indexName)
+
+	// check if the sequences index exists
+	req := esapi.IndicesExistsRequest{
+		Index:           []string{indexName},
+		ExpandWildcards: "none",
+		AllowNoIndices:  &pfalse,
+	}
+	res, err := req.Do(context.Background(), c)
+	defer closeResponseBody("IndicesExistsRequest:"+indexName, res)
+
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode == 200 {
+		log.Printf("Indice %s was found, nothing to do !", indexName)
+		return nil
+	} else if res.StatusCode == 404 {
+		log.Printf("Indice %s was not found, let's create it !", indexName)
+
+		requestBodyData := buildInitStorageIndexQuery()
+
+		// indice doest not exist, let's create it
+		req := esapi.IndicesCreateRequest{
+			Index: indexName,
+			Body:  strings.NewReader(requestBodyData),
+		}
+		res, err := req.Do(context.Background(), c)
+		defer closeResponseBody("IndicesCreateRequest:"+indexName, res)
+		if err = handleESResponseError(res, "IndicesCreateRequest:"+indexName, requestBodyData, err); err != nil {
+			return err
+		}
+	} else {
+		return handleESResponseError(res, "IndicesExistsRequest:"+indexName, "", err)
+	}
+	return nil
+}
+
+// Perform a refresh query on ES cluster for this particular index.
+func refreshIndex(c *elasticsearch6.Client, indexName string) {
+	req := esapi.IndicesRefreshRequest{
+		Index:           []string{indexName},
+		ExpandWildcards: "none",
+		AllowNoIndices:  &pfalse,
+	}
+	res, err := req.Do(context.Background(), c)
+	err = handleESResponseError(res, "IndicesRefreshRequest:"+indexName, "", err)
+	if err != nil {
+		log.Println("An error occurred while refreshing index, due to : %+v", err)
+	}
+	defer closeResponseBody("IndicesRefreshRequest:"+indexName, res)
+}
+
+// Query ES for events or logs specifying the expected results 'size' and the sort 'order'.
+func doQueryEs(c *elasticsearch6.Client, conf elasticStoreConf,
+	index string,
+	query string,
+	waitIndex uint64,
+	size int,
+	order string,
+) (hits int, values []store.KeyValueOut, lastIndex uint64, err error) {
+
+	log.Debugf("Search ES %s using query: %s", index, query)
+	lastIndex = waitIndex
+
+	res, e := c.Search(
+		c.Search.WithContext(context.Background()),
+		c.Search.WithIndex(index),
+		c.Search.WithSize(size),
+		c.Search.WithBody(strings.NewReader(query)),
+		// important sort on iid
+		c.Search.WithSort("iid:"+order),
+	)
+	if e != nil {
+		err = errors.Wrapf(err, "Failed to perform ES search on index %s, query was: <%s>, error was: %+v", index, query, err)
+		return
+	}
+	defer closeResponseBody("Search:"+index, res)
+
+	err = handleESResponseError(res, "Search:"+index, query, e)
+	if err != nil {
+		return
+	}
+
+	var r map[string]interface{}
+	if decodeErr := json.NewDecoder(res.Body).Decode(&r); decodeErr != nil {
+		err = errors.Wrapf(decodeErr,
+			"Not able to decode ES response while performing ES search on index %s, query was: <%s>, response code was %d (%s)",
+			index, query, res.StatusCode, res.Status(),
+		)
+		return
+	}
+
+	hits = int(r["hits"].(map[string]interface{})["total"].(float64))
+	duration := int(r["took"].(float64))
+	log.Debugf("Search ES request on index %s took %dms, hits=%d, response code was %d (%s)", index, duration, hits, res.StatusCode, res.Status())
+
+	lastIndex = decodeEsQueryResponse(conf, index, waitIndex, size, r, &values)
+
+	log.Debugf("doQueryEs called result waitIndex: %d, LastIndex: %d, len(values): %d", waitIndex, lastIndex, len(values))
+	return hits, values, lastIndex, nil
+}
+
+// Decode the response and define the last index
+func decodeEsQueryResponse(conf elasticStoreConf, index string, waitIndex uint64, size int, r map[string]interface{}, values *[]store.KeyValueOut) (lastIndex uint64) {
+	lastIndex = waitIndex
+	// Print the ID and document source for each hit.
+	i := 0
+	for _, hit := range r["hits"].(map[string]interface{})["hits"].([]interface{}) {
+		id := hit.(map[string]interface{})["_id"].(string)
+		source := hit.(map[string]interface{})["_source"].(map[string]interface{})
+		iid := source["iidStr"]
+		iidUInt64, err := parseInt64StringToUint64(iid.(string))
+		if err != nil {
+			log.Printf("Not able to parse iid_str property %s as uint64, document id: %s, source: %+v, ignoring this document !", iid, id, source)
+		} else {
+			jsonString, err := json.Marshal(source)
+			if err != nil {
+				log.Printf("Not able to marshall document source, document id: %s, source: %+v, ignoring this document !", id, source)
+			} else {
+				// since the result is sorted on iid, we can use the last hit to define lastIndex
+				lastIndex = iidUInt64
+				if conf.traceEvents {
+					i++
+					waitTimestamp := _getTimestampFromUint64(waitIndex)
+					iidInt64 := _parseInt64StringToInt64(iid.(string))
+					iidTimestamp := time.Unix(0, iidInt64)
+					log.Printf("ESList-%s;%d,%v,%d,%d,%s,%v,%d,%d",
+						index, waitIndex, waitTimestamp, size, i, iid, iidTimestamp, iidInt64, lastIndex)
+				}
+				// append value to result
+				*values = append(*values, store.KeyValueOut{
+					Key:             id,
+					LastModifyIndex: iidUInt64,
+					Value:           source,
+					RawValue:        jsonString,
+				})
+			}
+		}
+	}
+	return
+}
+
+// Send the bulk request to ES and ensure no error is returned.
+func sendBulkRequest(c *elasticsearch6.Client, opeCount int, body *[]byte) error {
+	log.Printf("About to bulk request containing %d operations (%d bytes)", opeCount, len(*body))
+	if log.IsDebug() {
+		log.Debugf("About to send bulk request query to ES: %s", string(*body))
+	}
+
+	// Prepare ES bulk request
+	req := esapi.BulkRequest{
+		Body: bytes.NewReader(*body),
+	}
+	res, err := req.Do(context.Background(), c)
+	defer closeResponseBody("BulkRequest", res)
+
+	if err != nil {
+		return err
+	} else if res.IsError() {
+		return handleESResponseError(res, "BulkRequest", string(*body), err)
+	} else {
+		var rsp map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&rsp)
+		if err != nil {
+			// Don't know if the bulk request response contains error so fail by default
+			return errors.Errorf(
+				"The bulk request succeeded (%s), but not able to decode the response, so not able to determine if bulk operations are correctly handled",
+				res.Status(),
+			)
+		}
+		if rsp["errors"].(bool) {
+			// The bulk request contains errors
+			return errors.Errorf("The bulk request succeeded, but the response contains errors : %+v", rsp)
+		}
+	}
+	log.Printf("Bulk request containing %d operations (%d bytes) has been accepted successfully", opeCount, len(*body))
+	return nil
+}
+
+// Consider the ES Response and wrap errors when needed
+func handleESResponseError(res *esapi.Response, requestDescription string, query string, requestError error) error {
+	if requestError != nil {
+		return errors.Wrapf(requestError, "Error while sending %s, query was: %s", requestDescription, query)
+	}
+	if res.IsError() {
+		return errors.Errorf(
+			"An error was returned by ES while sending %s, status was %s, query was: %s, response: %+v",
+			requestDescription, res.Status(), query, res.String())
+	}
+	return nil
+}
+
+// Close response body, if an error occur, just print it
+func closeResponseBody(requestDescription string, res *esapi.Response) {
+	err := res.Body.Close()
+	if err != nil {
+		log.Printf("[%s] Was not able to close resource response body, error was: %+v", requestDescription, err)
+	}
+}
+
+type debugLogger struct{}
+
+// RequestBodyEnabled makes the client pass request body to logger
+func (l *debugLogger) RequestBodyEnabled() bool { return true }
+
+// ResponseBodyEnabled makes the client pass response body to logger
+func (l *debugLogger) ResponseBodyEnabled() bool { return true }
+
+// LogRoundTrip will use log to debug ES request and response (when debug is activated)
+func (l *debugLogger) LogRoundTrip(
+	req *http.Request,
+	res *http.Response,
+	err error,
+	start time.Time,
+	dur time.Duration,
+) error {
+
+	var level string
+	switch {
+	case err != nil:
+		level = "Exception"
+	case res != nil && res.StatusCode > 0 && res.StatusCode < 300:
+		level = "Success"
+	case res != nil && res.StatusCode > 299 && res.StatusCode < 500:
+		level = "Warn"
+	case res != nil && res.StatusCode > 499:
+		level = "Error"
+	default:
+		level = "Unknown"
+	}
+
+	var reqBuffer, resBuffer bytes.Buffer
+	if req != nil && req.Body != nil && req.Body != http.NoBody {
+		// We explicitly ignore errors here since it's a debug feature
+		_, _ = io.Copy(&reqBuffer, req.Body)
+	}
+	reqStr := reqBuffer.String()
+	if res != nil && res.Body != nil && res.Body != http.NoBody {
+		// We explicitly ignore errors here since it's a debug feature
+		_, _ = io.Copy(&resBuffer, res.Body)
+	}
+	resStr := resBuffer.String()
+	log.Printf("ES Request [%s][%v][%s][%s][%d][%v] [%+v] : [%+v]",
+		level, start, req.Method, req.URL.String(), res.StatusCode, dur, reqStr, resStr)
+
+	return nil
+}

--- a/storage/internal/elastic/es_utils.go
+++ b/storage/internal/elastic/es_utils.go
@@ -88,8 +88,14 @@ func prepareEsClient(elasticStoreConfig elasticStoreConf) (*elasticsearch6.Clien
 	log.Printf("\t- Will use this ES client configuration: %+v", esConfig)
 
 	esClient, e := elasticsearch6.NewClient(esConfig)
-	log.Printf("Here is the ES cluster info")
-	log.Println(esClient.Info())
+	if e != nil {
+		return nil, errors.Wrapf(e, "Not able build ES client")
+	}
+	infoResponse, e := esClient.Info()
+	if e != nil {
+		return nil, errors.Wrapf(e, "The ES cluster info request failed")
+	}
+	log.Printf("Here is the ES cluster info: %+v", infoResponse)
 	return esClient, e
 }
 

--- a/storage/internal/elastic/queries.go
+++ b/storage/internal/elastic/queries.go
@@ -1,0 +1,158 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elastic
+
+import "strconv"
+
+// Return the query that is used to create indexes for event and log storage.
+// We only index the needed fields to optimize ES indexing performance (no dynamic mapping).
+func buildInitStorageIndexQuery() (query string) {
+	query = `
+{
+     "settings": {
+         "refresh_interval": "1s"
+     },
+     "mappings": {
+         "_doc": {
+             "_all": {"enabled": false},
+             "dynamic": "false",
+             "properties": {
+                 "clusterId": {
+                     "type": "keyword",
+                     "index": true
+                 },
+                 "deploymentId": {
+                     "type": "keyword",
+                     "index": true
+                 },
+                 "iid": {
+                     "type": "long",
+                     "index": true
+                 },
+                 "iidStr": {
+                     "type": "keyword",
+                     "index": false
+                 }
+             }
+         }
+     }
+}`
+	return
+}
+
+// This ES aggregation query is built using clusterId and eventually deploymentId.
+func buildLastModifiedIndexQuery(clusterID string, deploymentID string) (query string) {
+	if len(deploymentID) == 0 {
+		query = `
+{
+    "aggs" : {
+        "max_iid" : {
+            "filter" : {
+				"term": { "clusterId": "` + clusterID + `" }
+            },
+            "aggs" : {
+                "last_index" : { "max" : { "field" : "iid" } }
+            }
+        }
+    }
+}`
+	} else {
+		query = `
+{
+    "aggs" : {
+        "max_iid" : {
+            "filter" : {
+                "bool": {
+                    "must": [
+                        { "term": { "deploymentId": "` + deploymentID + `" } },
+                        { "term": { "clusterId": "` + clusterID + `" } }
+                     ]
+                }
+            },
+            "aggs" : {
+                "last_index" : { "max" : { "field" : "iid" } }
+            }
+        }
+    }
+}`
+	}
+	return
+}
+
+func getRangeQuery(waitIndex uint64, maxIndex uint64) (rangeQuery string) {
+	if maxIndex > 0 {
+		rangeQuery = `
+            {
+               "range":{
+                  "iid":{
+                     "gt": "` + strconv.FormatUint(waitIndex, 10) + `",
+					 "lte": "` + strconv.FormatUint(maxIndex, 10) + `"
+                  }
+               }
+            }`
+	} else {
+		rangeQuery = `
+            {
+               "range":{
+                  "iid":{
+                     "gt": "` + strconv.FormatUint(waitIndex, 10) + `"
+                  }
+               }
+            }`
+	}
+	return
+}
+
+// This ES range query is built using 'waitIndex' and eventually 'maxIndex' and filtered using 'clusterId' and eventually 'deploymentId'.
+func getListQuery(clusterID string, deploymentID string, waitIndex uint64, maxIndex uint64) (query string) {
+	rangeQuery := getRangeQuery(waitIndex, maxIndex)
+	if len(deploymentID) == 0 {
+		query = `
+{
+   "query":{
+      "bool":{
+         "must":[
+            {
+               "term":{
+                  "clusterId":"` + clusterID + `"
+               }
+            },` + rangeQuery + `
+         ]
+      }
+   }
+}`
+	} else {
+		query = `
+{
+   "query":{
+      "bool":{
+         "must":[
+            {
+               "term":{
+                  "clusterId":"` + clusterID + `"
+               }
+            },
+            {
+               "term":{
+                  "deploymentId":"` + deploymentID + `"
+               }
+            },` + rangeQuery + `
+         ]
+      }
+   }
+}`
+	}
+	return
+}

--- a/storage/internal/elastic/store.go
+++ b/storage/internal/elastic/store.go
@@ -1,0 +1,350 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package elastic provides an implementation of a storage that index/get documents to/from Elasticsearch 6.x.
+// This store can only manage logs and events for the moment. It will fail if you try to use it for other store types.
+package elastic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	elasticsearch6 "github.com/elastic/go-elasticsearch/v6"
+	"github.com/elastic/go-elasticsearch/v6/esapi"
+	"github.com/pkg/errors"
+	"github.com/ystia/yorc/v4/config"
+	"github.com/ystia/yorc/v4/log"
+	"github.com/ystia/yorc/v4/storage/encoding"
+	"github.com/ystia/yorc/v4/storage/store"
+	"github.com/ystia/yorc/v4/storage/utils"
+	"math"
+	"strings"
+	"time"
+)
+
+type elasticStore struct {
+	codec    encoding.Codec
+	esClient *elasticsearch6.Client
+	cfg      elasticStoreConf
+}
+
+// NewStore returns a new Elastic store.
+// Since the elastic store can only manage logs or events, it will panic is it's configured for anything else.
+// At init stage, we display ES cluster info and initialise indexes if they are not found.
+func NewStore(cfg config.Configuration, storeConfig config.Store) (store.Store, error) {
+
+	// Just fail if this storage is used for anything different from logs or events
+	for _, t := range storeConfig.Types {
+		if t != "Log" && t != "Event" {
+			return nil, errors.Errorf("Elastic store is not able to manage <%s>, just Log or Event, please change your config", t)
+		}
+	}
+
+	// Get specific config from storage properties
+	elasticStoreConfig, err := getElasticStoreConfig(cfg, storeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	esClient, err := prepareEsClient(elasticStoreConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	err = initStorageIndex(esClient, elasticStoreConfig, "logs")
+	if err != nil {
+		return nil, errors.Wrapf(err, "Not able to init index for eventType <%s>", "logs")
+	}
+	err = initStorageIndex(esClient, elasticStoreConfig, "events")
+	if err != nil {
+		return nil, errors.Wrapf(err, "Not able to init index for eventType <%s>", "events")
+	}
+
+	return &elasticStore{encoding.JSON, esClient, elasticStoreConfig}, nil
+}
+
+// Set index a document (log or event) into ES.
+func (s *elasticStore) Set(ctx context.Context, k string, v interface{}) error {
+	log.Debugf("Set called will key %s", k)
+
+	if err := utils.CheckKeyAndValue(k, v); err != nil {
+		return err
+	}
+
+	storeType, body, err := buildElasticDocument(s.cfg.clusterID, k, v)
+	if err != nil {
+		return err
+	}
+
+	indexName := getIndexName(s.cfg, storeType)
+	if log.IsDebug() {
+		log.Debugf("About to index this document into ES index <%s> : %+v", indexName, string(body))
+	}
+
+	// Prepare ES request
+	req := esapi.IndexRequest{
+		Index:        indexName,
+		DocumentType: "_doc",
+		Body:         bytes.NewReader(body),
+	}
+	res, err := req.Do(context.Background(), s.esClient)
+	defer closeResponseBody("IndexRequest:"+indexName, res)
+	if err != nil || res.IsError() {
+		err = handleESResponseError(res, "Index:"+indexName, string(body), err)
+		return err
+	}
+	return nil
+}
+
+// SetCollection index collections using ES bulk requests.
+// We consider both 'max_bulk_size' and 'max_bulk_count' to define bulk requests size.
+func (s *elasticStore) SetCollection(ctx context.Context, keyValues []store.KeyValueIn) error {
+	totalDocumentCount := len(keyValues)
+	log.Printf("SetCollection called with an array of size %d", totalDocumentCount)
+	start := time.Now()
+
+	if keyValues == nil || totalDocumentCount == 0 {
+		return nil
+	}
+
+	// Just estimate the iteration count
+	iterationCount := int(math.Ceil(float64(totalDocumentCount) / float64(s.cfg.maxBulkCount)))
+	log.Printf(
+		"max_bulk_count is %d, so a minimum of %d iterations will be necessary to bulk index the %d documents",
+		s.cfg.maxBulkCount, iterationCount, totalDocumentCount,
+	)
+
+	// The current index in []keyValues (also the number of documents indexed)
+	var kvi = 0
+	// The number of iterations
+	var i = 0
+	// Iterate over the []keyValues
+	for {
+		if kvi == totalDocumentCount {
+			// We have reached the end of []keyValues
+			break
+		}
+		fmt.Printf("Bulk iteration %d", i)
+
+		maxBulkSizeInBytes := s.cfg.maxBulkSize * 1024
+		// Prepare a slice of max capacity
+		var body = make([]byte, 0, maxBulkSizeInBytes)
+		// Number of operation in the current bulk request
+		opeCount := 0
+		// Each iteration is a single bulk request
+		for {
+			if kvi == totalDocumentCount || opeCount == s.cfg.maxBulkCount {
+				// We have reached the end of []keyValues OR the max items allowed in a single bulk request (max_bulk_count)
+				break
+			}
+			added, err := eventuallyAppendValueToBulkRequest(s.cfg, s.cfg.clusterID, &body, keyValues[kvi], maxBulkSizeInBytes)
+			if err != nil {
+				return err
+			} else if !added {
+				// The document hasn't been added (too big), let's include it in next bulk
+				break
+			} else {
+				kvi++
+				opeCount++
+			}
+		}
+		// The bulk request must be terminated by a newline
+		body = append(body, "\n"...)
+		// Send the request
+		err := sendBulkRequest(s.esClient, opeCount, &body)
+		if err != nil {
+			return err
+		}
+		// Increment the number of iterations
+		i++
+	}
+	elapsed := time.Since(start)
+	log.Printf("A total of %d documents have been successfully indexed using %d bulk requests, took %v", kvi, i, elapsed)
+	return nil
+}
+
+// Delete removes ES documents using a deleteByRequest query.
+func (s *elasticStore) Delete(ctx context.Context, k string, recursive bool) error {
+	log.Debugf("Delete called k: %s, recursive: %t", k, recursive)
+
+	// Extract index name and deploymentID by parsing the key
+	storeType, deploymentID := extractStoreTypeAndDeploymentID(k)
+	indexName := getIndexName(s.cfg, storeType)
+	log.Debugf("storeType is: %s, indexName is %s, deploymentID is: %s", storeType, indexName, deploymentID)
+
+	query := `{"query" : { "bool" : { "must" : [{ "term": { "clusterId" : "` + s.cfg.clusterID + `" }}, { "term": { "deploymentId" : "` + deploymentID + `" }}]}}}`
+	log.Debugf("query is : %s", query)
+
+	var MaxInt = 1024000
+
+	req := esapi.DeleteByQueryRequest{
+		Index: []string{indexName},
+		Size:  &MaxInt,
+		Body:  strings.NewReader(query),
+	}
+	res, err := req.Do(context.Background(), s.esClient)
+	defer closeResponseBody("DeleteByQueryRequest:"+indexName, res)
+	err = handleESResponseError(res, "DeleteByQueryRequest:"+indexName, query, err)
+	return err
+}
+
+// GetLastModifyIndex return the last index which is found by querying ES using aggregation and a 0 size request.
+func (s *elasticStore) GetLastModifyIndex(k string) (lastIndex uint64, e error) {
+	log.Debugf("GetLastModifyIndex called k: %s", k)
+
+	// Extract index name and deploymentID by parsing the key
+	storeType, deploymentID := extractStoreTypeAndDeploymentID(k)
+	indexName := getIndexName(s.cfg, storeType)
+	log.Debugf("storeType is: %s, indexName is: %s, deploymentID is: %s", storeType, indexName, deploymentID)
+
+	// The lastIndex is query by using ES aggregation query ~= MAX(iid) HAVING deploymentId AND clusterId
+	query := buildLastModifiedIndexQuery(s.cfg.clusterID, deploymentID)
+	log.Debugf("buildLastModifiedIndexQuery is : %s", query)
+
+	resSearch, err := s.esClient.Search(
+		s.esClient.Search.WithContext(context.Background()),
+		s.esClient.Search.WithIndex(indexName),
+		s.esClient.Search.WithSize(0),
+		s.esClient.Search.WithBody(strings.NewReader(query)),
+	)
+	defer closeResponseBody("LastModifiedIndexQuery for "+k, resSearch)
+	e = handleESResponseError(resSearch, "LastModifiedIndexQuery for "+k, query, err)
+	if e != nil {
+		return
+	}
+
+	var r map[string]interface{}
+	if err := json.NewDecoder(resSearch.Body).Decode(&r); err != nil {
+		e = errors.Wrapf(
+			err,
+			"Not able to parse response body after LastModifiedIndexQuery was sent for key %s, status was %s, query was: %s",
+			k, resSearch.Status(), query,
+		)
+		return
+	}
+
+	total := r["hits"].(map[string]interface{})["total"].(float64)
+	if total > 0 {
+		// ES returns aggregations as float, we have a precision loss of few ns
+		lastIndexR := r["aggregations"].(map[string]interface{})["max_iid"].(map[string]interface{})["last_index"].(map[string]interface{})["value"].(float64)
+		log.Debugf("Received lastIndexReceived: %v, lastIndex: %v", lastIndexR, lastIndex)
+		lastIndex = uint64(lastIndexR)
+		// The ES max result was a float, there is a risk that this is not really the lastIndex
+		// We need to verify
+		lastIndex = s.verifyLastIndex(indexName, deploymentID, lastIndex)
+	}
+	return lastIndex, nil
+}
+
+// We need to ensure the lastIndex returned by the aggregation query is really the last
+// Actually, when elasticsearch aggregates, it returns a float so we loss precession (few ns).
+// We request the docs with iid > waitIndex to ensure the returned lastIndex is REALLY the last.
+func (s *elasticStore) verifyLastIndex(indexName string, deploymentID string, estimatedLastIndex uint64) uint64 {
+	query := getListQuery(s.cfg.clusterID, deploymentID, estimatedLastIndex, 0)
+	// size = 1 no need for the documents
+	hits, _, lastIndex, err := doQueryEs(s.esClient, s.cfg, indexName, query, estimatedLastIndex, 1, "desc")
+	if err != nil {
+		log.Printf("An error occurred while verifying lastIndex, returning the initial value %d, error was : %+v",
+			estimatedLastIndex, err)
+	}
+	log.Printf("%d hits while searching %s (%s) using the estimated lastIndex %d, lastIndex is now %d",
+		hits, indexName, deploymentID, estimatedLastIndex, lastIndex)
+	return lastIndex
+}
+
+// List simulates long polling request by :
+// - periodically querying ES for documents (Aggregation to get the max iid and 0 size result).
+// - if a some result is found, wait some time (es_refresh_wait_timeout) in order to:
+//   	- let ES index recently added documents AND to let
+// 		- let Yorc eventually Set a document that has a less iid than the older known document in ES (concurrence issues)
+// - if no result if found after the the given 'timeout', return empty slice
+func (s *elasticStore) List(ctx context.Context, k string, waitIndex uint64, timeout time.Duration) ([]store.KeyValueOut, uint64, error) {
+	log.Printf("List called k: %s, waitIndex: %d, timeout: %v", k, waitIndex, timeout)
+	if err := utils.CheckKey(k); err != nil {
+		return nil, 0, err
+	}
+
+	// Extract indice name by parsing the key
+	storeType, deploymentID := extractStoreTypeAndDeploymentID(k)
+	indexName := getIndexName(s.cfg, storeType)
+	log.Debugf("storeType is: %s, indexName is: %s, deploymentID is: %s", storeType, indexName, deploymentID)
+
+	query := getListQuery(s.cfg.clusterID, deploymentID, waitIndex, 0)
+
+	now := time.Now()
+	end := now.Add(timeout - s.cfg.esRefreshWaitTimeout)
+	log.Debugf("Now is : %v, date after timeout will be %v (ES timeout duration will be %v)", now, end, timeout-s.cfg.esRefreshWaitTimeout)
+	var values = make([]store.KeyValueOut, 0)
+	var lastIndex = waitIndex
+	var hits = 0
+	var err error
+	for {
+		// first just query to know if they is something to fetch, we just want the max iid (so order desc, size 1)
+		hits, values, lastIndex, err = doQueryEs(s.esClient, s.cfg, indexName, query, waitIndex, 1, "desc")
+		if err != nil {
+			return values, waitIndex, errors.Wrapf(err, "Failed to request ES logs or events, error was: %+v", err)
+		}
+		now := time.Now()
+		if hits > 0 || now.After(end) {
+			break
+		}
+		log.Debugf("hits is %d and timeout not reached, sleeping %v ...", hits, s.cfg.esQueryPeriod)
+		time.Sleep(s.cfg.esQueryPeriod)
+	}
+	if hits > 0 {
+		// we do have something to retrieve, we will just wait esRefreshWaitTimeout to let any document that has just been stored to be indexed
+		// then we just retrieve this 'time window' (between waitIndex and lastIndex)
+		query := getListQuery(s.cfg.clusterID, deploymentID, waitIndex, lastIndex)
+		if s.cfg.esForceRefresh {
+			// force refresh for this index
+			refreshIndex(s.esClient, indexName)
+		}
+		time.Sleep(s.cfg.esRefreshWaitTimeout)
+		oldHits := hits
+		hits, values, lastIndex, err = doQueryEs(s.esClient, s.cfg, indexName, query, waitIndex, 10000, "asc")
+		if err != nil {
+			return values, waitIndex, errors.Wrapf(err, "Failed to request ES logs or events (after waiting for refresh)")
+		}
+		if log.IsDebug() && hits > oldHits {
+			log.Debugf("%d > %d so sleeping %v to wait for ES refresh was useful (index %s), %d documents has been fetched",
+				hits, oldHits, s.cfg.esRefreshWaitTimeout, indexName, len(values),
+			)
+		}
+	}
+	log.Printf("List called result k: %s, waitIndex: %d, timeout: %v, LastIndex: %d, len(values): %d",
+		k, waitIndex, timeout, lastIndex, len(values))
+	return values, lastIndex, err
+}
+
+// Get is not used for logs nor events: fails in FATAL.
+func (s *elasticStore) Get(k string, v interface{}) (bool, error) {
+	if err := utils.CheckKeyAndValue(k, v); err != nil {
+		return false, err
+	}
+	return false, errors.Errorf("Function Get(string, interface{}) not yet implemented for Elastic store !")
+}
+
+// Exist is not used for logs nor events: fails in FATAL.
+func (s *elasticStore) Exist(k string) (bool, error) {
+	if err := utils.CheckKey(k); err != nil {
+		return false, err
+	}
+	return false, errors.Errorf("Function Exist(string) not yet implemented for Elastic store !")
+}
+
+// Keys is not used for logs nor events: fails in FATAL.
+func (s *elasticStore) Keys(k string) ([]string, error) {
+	return nil, errors.Errorf("Function Keys(string) not yet implemented for Elastic store !")
+}

--- a/storage/internal/elastic/store.go
+++ b/storage/internal/elastic/store.go
@@ -193,6 +193,7 @@ func (s *elasticStore) Delete(ctx context.Context, k string, recursive bool) err
 		Index: []string{indexName},
 		Size:  &MaxInt,
 		Body:  strings.NewReader(query),
+		Conflicts: "proceed",
 	}
 	res, err := req.Do(context.Background(), s.esClient)
 	defer closeResponseBody("DeleteByQueryRequest:"+indexName, res)

--- a/storage/internal/elastic/utils.go
+++ b/storage/internal/elastic/utils.go
@@ -1,0 +1,189 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elastic
+
+import (
+	"encoding/json"
+	"github.com/pkg/errors"
+	"github.com/ystia/yorc/v4/log"
+	"github.com/ystia/yorc/v4/storage/store"
+	"github.com/ystia/yorc/v4/storage/utils"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Precompiled regex to extract storeType and timestamp from a key of the form: "_yorc/logs/MyApp/2020-06-07T21:03:17.812178429Z".
+var storeTypeAndTimestampRegex = regexp.MustCompile(`(?m)\_yorc\/(\w+)\/.+\/(.*)`)
+
+// Parse a key of form  "_yorc/logs/MyApp/2020-06-07T21:03:17.812178429Z" to get the store type (logs|events) and the timestamp.
+func extractStoreTypeAndTimestamp(k string) (storeType string, timestamp string) {
+	res := storeTypeAndTimestampRegex.FindAllStringSubmatch(k, -1)
+	for i := range res {
+		storeType = res[i][1]
+		timestamp = res[i][2]
+	}
+	return storeType, timestamp
+}
+
+// Precompiled regex to extract storeType and deploymentId from a key of the form: "_yorc/events/" or "_yorc/logs/MyApp" or "_yorc/logs/MyApp/".
+var storeTypeAndDeploymentIDRegex = regexp.MustCompile(`(?m)\_yorc\/(\w+)\/?(.+)?\/?`)
+
+// Parse a key of form "_yorc/events/" or "_yorc/logs/MyApp" or "_yorc/logs/MyApp/" to get the store type (logs|events) and eventually the deploymentId.
+func extractStoreTypeAndDeploymentID(k string) (storeType string, deploymentID string) {
+	res := storeTypeAndDeploymentIDRegex.FindAllStringSubmatch(k, -1)
+	for i := range res {
+		storeType = res[i][1]
+		if len(res[i]) == 3 {
+			deploymentID = res[i][2]
+			if strings.HasSuffix(deploymentID, "/") {
+				deploymentID = deploymentID[:len(deploymentID)-1]
+			}
+		}
+	}
+	return storeType, deploymentID
+}
+
+// We need to append JSON directly into []byte to avoid useless and costly marshaling / unmarshaling.
+func appendJSONInBytes(a []byte, v []byte) []byte {
+	last := len(a) - 1
+	lastByte := a[last]
+	// just append v at the end
+	a = append(a, v...)
+	// then slice
+	for i, s := range v {
+		a[last+i] = s
+	}
+	a[last+len(v)] = lastByte
+	return a
+}
+
+func _parseInt64StringToInt64(value string) int64 {
+	valueInt, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		log.Print(strings.Repeat("#", 20))
+		log.Print(strings.Repeat("#", 20))
+		log.Print(strings.Repeat("#", 20))
+		log.Print(strings.Repeat("#", 20))
+		log.Printf("Fail parsing _parseInt64StringToInt64 %s", value)
+		log.Print(strings.Repeat("#", 20))
+		log.Print(strings.Repeat("#", 20))
+		log.Print(strings.Repeat("#", 20))
+		log.Print(strings.Repeat("#", 20))
+	}
+	return valueInt
+}
+
+func parseInt64StringToUint64(value string) (uint64, error) {
+	valueInt, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, errors.Wrapf(err, "Not able to parse string: %s to int64, error was: %+v", value, err)
+	}
+	result := uint64(valueInt)
+	return result, nil
+}
+
+func _getTimestampFromUint64(nanoTimestamp uint64) time.Time {
+	nanoTimestampStr := strconv.FormatUint(nanoTimestamp, 10)
+	ts := _parseInt64StringToInt64(nanoTimestampStr)
+	return time.Unix(0, ts)
+}
+
+// The max uint is 9223372036854775807 (19 cars), this is the maximum nano for a time (2262-04-12 00:47:16.854775807 +0100 CET).
+// Since we use nanotimestamp as ID for events and logs, and since we store this ID as string in ES index, we must ensure that
+// the string will be comparable.
+func getSortableStringFromUint64(nanoTimestamp uint64) string {
+	nanoTimestampStr := strconv.FormatUint(nanoTimestamp, 10)
+	if len(nanoTimestampStr) < 19 {
+		nanoTimestampStr = strings.Repeat("0", 19-len(nanoTimestampStr)) + nanoTimestampStr
+	}
+	return nanoTimestampStr
+}
+
+// The document is enriched by adding 'clusterId' and 'iid' properties.
+// This addition is done by directly manipulating the []byte in order to avoid costly successive marshal / unmarshal operations.
+func buildElasticDocument(clusterID string, k string, rawMessage interface{}) (string, []byte, error) {
+	// Extract indice name and timestamp by parsing the key
+	storeType, timestamp := extractStoreTypeAndTimestamp(k)
+	log.Debugf("storeType is: %s, timestamp: %s", storeType, timestamp)
+
+	// Convert timestamp to an int64
+	eventDate, err := time.Parse(time.RFC3339Nano, timestamp)
+	if err != nil {
+		return storeType, nil, errors.Wrapf(err, "failed to parse timestamp %+v as time, error was: %+v", timestamp, err)
+	}
+	// Convert to UnixNano int64
+	iid := eventDate.UnixNano()
+
+	// This is the piece of 'JSON' we want to append
+	a := `,"iid":"` + strconv.FormatInt(iid, 10) + `","iidStr":"` + strconv.FormatInt(iid, 10) + `","clusterId":"` + clusterID + `"`
+	// v is a json.RawMessage
+	raw := rawMessage.(json.RawMessage)
+	raw = appendJSONInBytes(raw, []byte(a))
+
+	return storeType, raw, nil
+}
+
+// An error is returned if :
+// - it's not valid (key or value nil)
+// - the size of the resulting bulk operation exceed the maximum authorized for a bulk request
+// The value is not added if it's size + the current body size exceed the maximum authorized for a bulk request.
+// Return a bool indicating if the value has been added to the bulk request body.
+func eventuallyAppendValueToBulkRequest(c elasticStoreConf, clusterID string, body *[]byte, kv store.KeyValueIn, maxBulkSizeInBytes int) (bool, error) {
+	if err := utils.CheckKeyAndValue(kv.Key, kv.Value); err != nil {
+		return false, err
+	}
+
+	storeType, document, err := buildElasticDocument(clusterID, kv.Key, kv.Value)
+	if err != nil {
+		return false, err
+	}
+	log.Debugf("About to add a document of size %d bytes to bulk request", len(document))
+
+	// The bulk action
+	index := `{"index":{"_index":"` + getIndexName(c, storeType) + `","_type":"_doc"}}`
+	bulkOperation := make([]byte, 0)
+	bulkOperation = append(bulkOperation, index...)
+	bulkOperation = append(bulkOperation, "\n"...)
+	bulkOperation = append(bulkOperation, document...)
+	bulkOperation = append(bulkOperation, "\n"...)
+	log.Debugf("About to add a bulk operation of size %d bytes to bulk request, current size of bulk request body is %d bytes", len(bulkOperation), len(*body))
+
+	// 1 = len("\n") the last newline that will be appended to terminate the bulk request
+	estimatedBodySize := len(*body) + len(bulkOperation) + 1
+	if len(bulkOperation)+1 > maxBulkSizeInBytes {
+		return false, errors.Errorf(
+			"A bulk operation size (order + document %s) is greater than the maximum bulk size authorized (%dkB) : %d > %d, this document can't be sent to ES, please adapt your configuration !",
+			kv.Key, c.maxBulkSize, len(bulkOperation)+1, maxBulkSizeInBytes,
+		)
+	}
+	if estimatedBodySize > maxBulkSizeInBytes {
+		log.Printf(
+			"The limit of bulk size (%d kB) will be reached (%d > %d), the current document will be sent in the next bulk request",
+			c.maxBulkSize, estimatedBodySize, maxBulkSizeInBytes,
+		)
+		return false, nil
+	}
+	log.Debugf("Append document built from key %s to bulk request body, storeType was %s", kv.Key, storeType)
+	// Append the bulk operation
+	*body = append(*body, bulkOperation...)
+	return true, nil
+}
+
+// The index name are prefixed to avoid index name collisions.
+func getIndexName(c elasticStoreConf, storeType string) string {
+	return c.indicePrefix + storeType
+}

--- a/storage/store_mgr.go
+++ b/storage/store_mgr.go
@@ -31,12 +31,15 @@ import (
 	"github.com/ystia/yorc/v4/helper/consulutil"
 	"github.com/ystia/yorc/v4/log"
 	"github.com/ystia/yorc/v4/storage/internal/consul"
+	"github.com/ystia/yorc/v4/storage/internal/elastic"
 	"github.com/ystia/yorc/v4/storage/internal/file"
 	"github.com/ystia/yorc/v4/storage/store"
 	"github.com/ystia/yorc/v4/storage/types"
 )
 
 const consulStoreImpl = "consul"
+
+const elasticStoreImpl = "elastic"
 
 const fileStoreImpl = "file"
 
@@ -361,6 +364,11 @@ func createStoreImpl(cfg config.Configuration, configStore config.Store) (store.
 		}
 	case strings.ToLower(consulStoreImpl):
 		storeImpl = consul.NewStore()
+	case strings.ToLower(elasticStoreImpl):
+		storeImpl, err = elastic.NewStore(cfg, configStore)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		log.Printf("[WARNING] unknown store implementation:%q. This will be ignored.", impl)
 	}


### PR DESCRIPTION
# Pull Request description

Here is a PR that embed a proposition of implementation for a new Yorc storage that stores events and logs into Elasticsearch 6.x.

## Description of the change

### What I did

An implementation for a new Yorc storage that stores events and logs into Elasticsearch 6.x.

### How I did it

We have 2 index per datacenter: one for logs and one for events. 

At startup, index are created if they don't exist. They are optimized for Yorc usage (no indexation of contents, no dynamic mapping, no all ...).

In Yorc, events and logs are identified by the timestamp (nano). I've decided to use a sortable string representation of the Uint64 representation of this timestamp for several reasons :

- I've observed issue when using long data type in ES mapping. The fact that long data type in ES is a signed 64-bit integer is not not compatible with Uint64.
- the elastic go client I use always consider numbers as float when no decoding is specified (actually seems to be a JSON issue).

So each document is enriched with:
- `iid` : long representation of the timestamps in nanos
- `iid_str` : string representation of this iid
- `deploymentId` : to ease requests concerning a given deployment.

When **Set** is called, the son.RawMessage is enriched by adding these properties in the initial document. Note that we add them by manipulating the []bytes rather than costly successive marshal / unmarshal operations.

When **SetCollection** is called : we use the Bulk API to store the documents. 2 parameters are used to optimize the bulk size : 
- `maxBulkSize` : in kB the max size of a bulk
- `maxBulkCount` : the max documents sent in a bulk request

When **Delete** is called, we use a deleteByQuery ES request to delete the documents.

When **GetLastModifyIndex** is called, we use an aggregation query to get the max `iid`. Note that ES use float under the hood to perform aggregations, so we have a precision loss. That's why we need another query to be sure the aggregation result (max iid) is actually the max value.

When **List** is called : We had to simulate the long polling mechanism. I did it in very naive but efficient way.
- The index is queried using an aggregation query to the max _iid_ available (from waitIndex)
- If 0 result, sleep a bit (`esQueryPeriod`) then query again (until the given timeout expired)
- Then wait for a time out (`esRefreshWaitTimeout`) : we let ES index documents and Yorc eventually store events (avoid leaks due to concurrency under heavy load).
- eventually force a refresh on the index (`esForceRefresh`)
- query the data and return it.

### How to verify it

Unfortunately, I didn't include tests yet. As you know, load tests have been performed successfully.
