### PR TITLE
Fix concurrency issue in workflows execution that may lead to a task never reaching a terminal status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### BUG FIXES
 
+* Concurrency issue in workflows execution may lead to a task never reaching a terminal status ([GH-659](https://github.com/ystia/yorc/issues/659))
 * Bootstrap on Centos 7 on GCP fails ([GH-649](https://github.com/ystia/yorc/issues/649))
 * Kubernetes Client uses deprecated apis removed on recent versions of K8S (v1.17+) ([GH-645](https://github.com/ystia/yorc/issues/645))
 * Bootstrap may failed with a nil pointer error if download of a component fails ([GH-634](https://github.com/ystia/yorc/issues/634))

--- a/tasks/workflow/task_execution.go
+++ b/tasks/workflow/task_execution.go
@@ -133,22 +133,12 @@ func numberOfRunningExecutionsForTask(cc *api.Client, taskID string) (*consuluti
 		l.Unlock()
 		return nil, 0, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 	}
+	log.Debugf("numberOfRunningExecutionsForTask %d", len(keys))
 	return l, len(keys), nil
 }
 
-func doIfNoMoreOtherExecutions(cc *api.Client, taskID string, f func() error) error {
-	l, e, err := numberOfRunningExecutionsForTask(cc, taskID)
-	if err != nil {
-		return err
-	}
-	defer l.Unlock()
-	if e <= 1 && f != nil {
-		return f()
-	}
-	return nil
-}
-
 func (t *taskExecution) notifyEnd() error {
+	log.Debugf("notifyEnd for taskExecution %q", t.id)
 	execPath := path.Join(consulutil.TasksPrefix, t.taskID, ".runningExecutions")
 	l, e, err := numberOfRunningExecutionsForTask(t.cc, t.taskID)
 	if err != nil {

--- a/tasks/workflow/workflow.go
+++ b/tasks/workflow/workflow.go
@@ -86,21 +86,8 @@ func getCallOperationsFromStep(s *step) []string {
 	return ops
 }
 
-func updateTaskStatusAccordingToWorkflowStatusIfLatest(ctx context.Context, cc *api.Client, deploymentID, taskID, workflowName string) error {
-	l, e, err := numberOfRunningExecutionsForTask(cc, taskID)
-	if err != nil {
-		return err
-	}
-	defer l.Unlock()
-	if e <= 1 {
-		// we are the latest
-		_, err := updateTaskStatusAccordingToWorkflowStatus(ctx, deploymentID, taskID, workflowName)
-		return err
-	}
-	return nil
-}
-
 func updateTaskStatusAccordingToWorkflowStatus(ctx context.Context, deploymentID, taskID, workflowName string) (tasks.TaskStatus, error) {
+	log.Debugf("Updating task status according to workflow status. Deployment %q, taskID %q, workflow %q", deploymentID, taskID, workflowName)
 	hasCancelledFlag, err := tasks.TaskHasCancellationFlag(taskID)
 	if err != nil {
 		return tasks.TaskStatusFAILED, errors.Wrapf(err, "Failed to retrieve workflow step statuses with TaskID:%q", taskID)


### PR DESCRIPTION
## Description of the change

### What I did

Fix concurrency issue in workflows execution that may lead to a task never reaching a terminal status.

### How I did it

When ending an asynchronous action (typically a job monitoring) the part of the code that update the task status according to the workflow status was done close but not under the same distributed lock than the deletion of the action execution itself.

This may lead to concurrency issue where this execution and another execution may both think they are not the last execution and do not update the task status.

Also removed some dead code...

### Description for the changelog

* Concurrency issue in workflows execution may lead to a task never reaching a terminal status ([GH-659](https://github.com/ystia/yorc/issues/659))

## Applicable Issues

* Fixes #659 
* Backported to v4.0.2 via #661 
