### PR TITLE
[Backport release/4.0] Fix build issues on Go 1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Yorc does not build on Go1.15 ([GH-665](https://github.com/ystia/yorc/issues/665))
+
 ## 4.0.2 (July 10, 2020)
 
 ### SECURITY FIXES

--- a/deployments/definition_store.go
+++ b/deployments/definition_store.go
@@ -17,7 +17,6 @@ package deployments
 import (
 	"context"
 	"fmt"
-	"github.com/ystia/yorc/v4/log"
 	"io/ioutil"
 	"os"
 	"path"
@@ -31,6 +30,7 @@ import (
 	"github.com/ystia/yorc/v4/deployments/store"
 	"github.com/ystia/yorc/v4/events"
 	"github.com/ystia/yorc/v4/helper/consulutil"
+	"github.com/ystia/yorc/v4/log"
 	"github.com/ystia/yorc/v4/storage"
 	storageTypes "github.com/ystia/yorc/v4/storage/types"
 	"github.com/ystia/yorc/v4/tosca"
@@ -529,7 +529,7 @@ func storeOperationOutputVAOnType(ctx context.Context, deploymentID, typeName, i
 		return err
 	}
 
-	tType, typePath, err := getTypeFromName(nil, deploymentID, typeName)
+	tType, typePath, err := getTypeFromName(ctx, deploymentID, typeName)
 	if err != nil {
 		return err
 	}

--- a/deployments/nodes.go
+++ b/deployments/nodes.go
@@ -813,13 +813,14 @@ func CreateNewNodeStackInstances(ctx context.Context, deploymentID, nodeName str
 
 // createNodeInstance creates required elements for a new node
 func createNodeInstance(consulStore consulutil.ConsulStore, deploymentID, nodeName, instanceName string) {
+	ctx := context.Background()
 	instancePath := path.Join(consulutil.DeploymentKVPrefix, deploymentID, "topology", "instances", nodeName)
 	toscaID := nodeName + "-" + instanceName
 	consulStore.StoreConsulKeyAsString(path.Join(instancePath, instanceName, "attributes/state"), tosca.NodeStateInitial.String())
 	consulStore.StoreConsulKeyAsString(path.Join(instancePath, instanceName, "attributes/tosca_name"), nodeName)
 	consulStore.StoreConsulKeyAsString(path.Join(instancePath, instanceName, "attributes/tosca_id"), toscaID)
 	// Publish a status change event and attribute update
-	_, err := events.PublishAndLogInstanceStatusChange(nil, deploymentID, nodeName, instanceName, tosca.NodeStateInitial.String())
+	_, err := events.PublishAndLogInstanceStatusChange(ctx, deploymentID, nodeName, instanceName, tosca.NodeStateInitial.String())
 	if err != nil {
 		log.Printf("%+v", err)
 	}
@@ -829,7 +830,7 @@ func createNodeInstance(consulStore consulutil.ConsulStore, deploymentID, nodeNa
 	attrs["state"] = tosca.NodeStateInitial.String()
 	attrs["tosca_name"] = nodeName
 	attrs["tosca_id"] = toscaID
-	err = events.PublishAndLogMapAttributeValueChange(nil, deploymentID, nodeName, instanceName, attrs, "updated")
+	err = events.PublishAndLogMapAttributeValueChange(ctx, deploymentID, nodeName, instanceName, attrs, "updated")
 	if err != nil {
 		log.Printf("%+v", err)
 	}

--- a/deployments/types.go
+++ b/deployments/types.go
@@ -17,14 +17,16 @@ package deployments
 import (
 	"context"
 	"fmt"
+	"path"
+
 	"github.com/pkg/errors"
+
 	"github.com/ystia/yorc/v4/deployments/store"
 	"github.com/ystia/yorc/v4/helper/collections"
 	"github.com/ystia/yorc/v4/helper/consulutil"
 	"github.com/ystia/yorc/v4/storage"
 	"github.com/ystia/yorc/v4/storage/types"
 	"github.com/ystia/yorc/v4/tosca"
-	"path"
 )
 
 type typeMissingError struct {
@@ -488,7 +490,7 @@ func getTypePropertyDefinition(ctx context.Context, deploymentID, typeName, prop
 }
 
 func getTypeAttributeDefinition(ctx context.Context, deploymentID, typeName, attributeName string) (*tosca.AttributeDefinition, error) {
-	mapAttrs, err := getTypeAttributeDefinitions(nil, deploymentID, typeName)
+	mapAttrs, err := getTypeAttributeDefinitions(ctx, deploymentID, typeName)
 	if err != nil {
 		return nil, err
 	}

--- a/prov/hostspool/hostspool_structs_test.go
+++ b/prov/hostspool/hostspool_structs_test.go
@@ -75,7 +75,7 @@ func TestHostStatusJSONUnmarshalling(t *testing.T) {
 			}
 
 			if !tt.wantErr && r != tt.expectedResult {
-				t.Errorf("json.Unmarshal() result = %q, expected %q", string(r), tt.expectedResult)
+				t.Errorf("json.Unmarshal() result = %q, expected %q", r.String(), tt.expectedResult.String())
 			}
 		})
 	}

--- a/tasks/collector/collector.go
+++ b/tasks/collector/collector.go
@@ -17,7 +17,6 @@ package collector
 import (
 	"context"
 	"fmt"
-	"github.com/ystia/yorc/v4/events"
 	"path"
 	"strconv"
 	"time"
@@ -27,6 +26,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/ystia/yorc/v4/deployments"
+	"github.com/ystia/yorc/v4/events"
 	"github.com/ystia/yorc/v4/helper/consulutil"
 	"github.com/ystia/yorc/v4/log"
 	"github.com/ystia/yorc/v4/tasks"
@@ -114,7 +114,7 @@ func (c *Collector) ResumeTask(ctx context.Context, taskID string) error {
 		return err
 	}
 
-	tasks.EmitTaskEventWithContextualLogs(nil, targetID, taskID, taskType, workflowName, tasks.TaskStatusINITIAL.String())
+	tasks.EmitTaskEventWithContextualLogs(ctx, targetID, taskID, taskType, workflowName, tasks.TaskStatusINITIAL.String())
 	return nil
 }
 

--- a/testdata/ci/runner/Jenkinsfile
+++ b/testdata/ci/runner/Jenkinsfile
@@ -79,7 +79,7 @@ kind: Pod
 spec:
   containers:
   - name: yorc-ci-builder
-    image: golang:1-stretch
+    image: golang:1
     imagePullPolicy: Always
     command:
     - cat
@@ -106,6 +106,8 @@ spec:
                     tar czvf yorc.tgz yorc
                     echo "Yorc version:"
                     ./yorc version | tee yorc_version.txt
+                    echo -ne "\\nRuntime version: " | tee -a yorc_version.txt
+                    go version -v yorc | sed -e 's/^.*: \\(.*\\)\$/\\1/g' | tee -a yorc_version.txt
                     """
                 )
                 stash includes: 'yorc.tgz', name: 'yorc-bin'

--- a/testdata/ci/runner/Jenkinsfile
+++ b/testdata/ci/runner/Jenkinsfile
@@ -80,6 +80,7 @@ spec:
   containers:
   - name: yorc-ci-builder
     image: golang:1-stretch
+    imagePullPolicy: Always
     command:
     - cat
     tty: true


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fix build issues on Go 1.15

### What I did

* Replaced all uses of `nil` contexts by `context.Background()`.
* Fixed some type conversion issues

### How to verify it

1. Install go 1.15
2. run `make`

### Description for the changelog

* Yorc does not build on Go1.15 ([GH-665](https://github.com/ystia/yorc/issues/665))

## Applicable Issues

Fixes #665
Backport of #666 on release/4.0 branch
