### PR TITLE
[Backport 4.0] Expose slurm jobs attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### FEATURES
+
+* [Slurm] Expose Slurm scontrol show job results as job attributes ([GH-664](https://github.com/ystia/yorc/issues/664))
+
 ### BUG FIXES
 
 * Yorc does not build on Go1.15 ([GH-665](https://github.com/ystia/yorc/issues/665))

--- a/prov/slurm/consul_test.go
+++ b/prov/slurm/consul_test.go
@@ -15,9 +15,10 @@
 package slurm
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/ystia/yorc/v4/config"
 	"github.com/ystia/yorc/v4/locations"
@@ -75,6 +76,9 @@ func TestRunConsulSlurmPackageTests(t *testing.T) {
 		})
 		t.Run("ExecutionCommonPrepareAndSubmitJob", func(t *testing.T) {
 			testExecutionCommonPrepareAndSubmitJob(t)
+		})
+		t.Run("ActionOperatorAnalyzeJob", func(t *testing.T) {
+			testActionOperatorAnalyzeJob(t, srv, cfg)
 		})
 	})
 }

--- a/prov/slurm/monitoring_jobs.go
+++ b/prov/slurm/monitoring_jobs.go
@@ -272,8 +272,7 @@ func (o *actionOperator) logFile(ctx context.Context, cc *api.Client, action *pr
 	}
 	if strings.TrimSpace(output) != "" {
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelDEBUG, deploymentID).RegisterAsString(fmt.Sprintf("Run the command: %q", cmd))
-		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelINFO, deploymentID).RegisterAsString(fmt.Sprintf("%s %s:", fileType, filePath))
-		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelINFO, deploymentID).RegisterAsString("\n" + output)
+		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelINFO, deploymentID).RegisterAsString(fmt.Sprintf("%s %s:\n%s", fileType, filePath, output))
 	}
 
 	// Update the last index

--- a/prov/slurm/monitoring_jobs_test.go
+++ b/prov/slurm/monitoring_jobs_test.go
@@ -1,0 +1,116 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slurm
+
+import (
+	"context"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	ctu "github.com/hashicorp/consul/testutil"
+	"gotest.tools/v3/assert"
+
+	"github.com/ystia/yorc/v4/config"
+	"github.com/ystia/yorc/v4/deployments"
+	"github.com/ystia/yorc/v4/helper/sshutil"
+	"github.com/ystia/yorc/v4/prov"
+	"github.com/ystia/yorc/v4/testutil"
+)
+
+/*
+
+
+ */
+
+func testActionOperatorAnalyzeJob(t *testing.T, srv *ctu.TestServer, cfg config.Configuration) {
+
+	deploymentID := testutil.BuildDeploymentID(t)
+	ctx := context.Background()
+	err := deployments.StoreDeploymentDefinition(ctx, deploymentID, "testdata/jobMonitoringTest.yaml")
+	assert.NilError(t, err)
+
+	cc, err := cfg.GetConsulClient()
+	assert.NilError(t, err)
+
+	type args struct {
+		deploymentID  string
+		nodeName      string
+		action        *prov.Action
+		keepArtifacts bool
+	}
+	tests := []struct {
+		name        string
+		args        args
+		jobInfoFile string
+		want        bool
+		wantErr     bool
+	}{
+		{"MonitorRunningJob", args{deploymentID: deploymentID, nodeName: "Job", action: &prov.Action{ActionType: "job-monitoring", Data: map[string]string{
+			"nodeName":   "Job",
+			"jobID":      "6260",
+			"stepName":   "run",
+			"taskID":     "t1",
+			"workingDir": filepath.Join(cfg.WorkingDirectory, t.Name()),
+		}}, keepArtifacts: false}, "scontrol.txt", false, false},
+		{"MonitorCompletedJob", args{deploymentID: deploymentID, nodeName: "Job", action: &prov.Action{ActionType: "job-monitoring", Data: map[string]string{
+			"nodeName":   "Job",
+			"jobID":      "6260",
+			"stepName":   "run",
+			"taskID":     "t1",
+			"workingDir": filepath.Join(cfg.WorkingDirectory, t.Name()),
+		}}, keepArtifacts: false}, "scontrol_show_job_completed.txt", true, false},
+		{"MonitorFailedJob", args{deploymentID: deploymentID, nodeName: "Job", action: &prov.Action{ActionType: "job-monitoring", Data: map[string]string{
+			"nodeName":   "Job",
+			"jobID":      "6260",
+			"stepName":   "run",
+			"taskID":     "t1",
+			"workingDir": filepath.Join(cfg.WorkingDirectory, t.Name()),
+		}}, keepArtifacts: false}, "scontrol_show_job_failed.txt", true, true},
+		{"JobNotFound", args{deploymentID: deploymentID, nodeName: "Job", action: &prov.Action{ActionType: "job-monitoring", Data: map[string]string{
+			"nodeName":   "Job",
+			"jobID":      "6260",
+			"stepName":   "run",
+			"taskID":     "t1",
+			"workingDir": filepath.Join(cfg.WorkingDirectory, t.Name()),
+		}}, keepArtifacts: false}, "", true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &actionOperator{}
+
+			sshClient := &sshutil.MockSSHClient{
+				MockRunCommand: func(input string) (string, error) {
+					if tt.jobInfoFile != "" {
+						testdataFile := filepath.Join("testdata", tt.jobInfoFile)
+						testdataFileContent, err := ioutil.ReadFile(testdataFile)
+						assert.NilError(t, err, "error parsing sacctResultFile %q", testdataFile)
+						return string(testdataFileContent), nil
+					}
+					return "", nil
+				},
+			}
+
+			got, err := o.analyzeJob(context.Background(), cc, sshClient, tt.args.deploymentID, tt.args.nodeName, tt.args.action, tt.args.keepArtifacts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("actionOperator.analyzeJob() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("actionOperator.analyzeJob() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/prov/slurm/testdata/jobMonitoringTest.yaml
+++ b/prov/slurm/testdata/jobMonitoringTest.yaml
@@ -1,0 +1,97 @@
+tosca_definitions_version: alien_dsl_1_4_0
+
+metadata:
+  template_name: SimpleCompute-Environment
+  template_version: 0.1.0-SNAPSHOT
+  template_author: ${template_author}
+
+description: ""
+
+imports:
+  - path: <yorc-slurm-types.yml>
+
+topology_template:
+  node_templates:
+    Job:
+      metadata:
+        location: testSlurmLocation
+      type: yorc.nodes.slurm.Job
+      properties:
+        tasks: 1
+        nodes: 1
+        batch: false
+        exec_args:
+          - uptime
+  workflows:
+    install:
+      steps:
+        Job_initial:
+          target: Job
+          activities:
+            - set_state: started
+    uninstall:
+      steps:
+        Job_deleting:
+          target: Job
+          activities:
+            - set_state: deleting
+          on_success:
+            - Job_deleted
+        Job_deleted:
+          target: Job
+          activities:
+            - set_state: deleted
+    run:
+      steps:
+        Job_submitting:
+          target: Job
+          activities:
+            - set_state: submitting
+          on_success:
+            - Job_submit
+        Job_submitted:
+          target: Job
+          activities:
+            - set_state: submitted
+          on_success:
+            - Job_executing
+        Job_executing:
+          target: Job
+          activities:
+            - set_state: executing
+          on_success:
+            - Job_run
+        Job_executed:
+          target: Job
+          activities:
+            - set_state: executed
+        Job_submit:
+          target: Job
+          activities:
+            - call_operation: tosca.interfaces.node.lifecycle.Runnable.submit
+          on_success:
+            - Job_submitted
+        Job_run:
+          target: Job
+          activities:
+            - call_operation: tosca.interfaces.node.lifecycle.Runnable.run
+          on_success:
+            - Job_executed
+    cancel:
+      steps:
+        Job_cancelling:
+          target: Job
+          activities:
+            - set_state: cancelling
+          on_success:
+            - Job_cancel
+        Job_cancelled:
+          target: Job
+          activities:
+            - set_state: cancelled
+        Job_cancel:
+          target: Job
+          activities:
+            - call_operation: tosca.interfaces.node.lifecycle.Runnable.cancel
+          on_success:
+            - Job_cancelled

--- a/prov/slurm/testdata/scontrol_show_job_completed.txt
+++ b/prov/slurm/testdata/scontrol_show_job_completed.txt
@@ -1,0 +1,24 @@
+JobId=6260 JobName=test-salloc-Environment
+   UserId=john(1001) GroupId=users(1000)
+   Priority=4294901193 Nice=0 Account=acc_salloc QOS=normal
+   JobState=COMPLETED Reason=None Dependency=(null)
+   Requeue=1 Restarts=0 BatchFlag=0 Reboot=0 ExitCode=0:0
+   RunTime=2-19:42:53 TimeLimit=UNLIMITED TimeMin=N/A
+   SubmitTime=2019-02-22T15:41:51 EligibleTime=2019-02-22T15:41:51
+   StartTime=2019-02-22T15:41:51 EndTime=Unknown
+   PreemptTime=None SuspendTime=None SecsPreSuspend=0
+   Partition=all AllocNode:Sid=rangiroa:19844
+   ReqNodeList=(null) ExcNodeList=(null)
+   NodeList=hpda19
+   BatchHost=hpda19
+   NumNodes=1 NumCPUs=1 CPUs/Task=1 ReqB:S:C:T=0:0:*:*
+   TRES=cpu=1,mem=16384,node=1
+   Socks/Node=* NtasksPerN:B:S:C=0:0:*:* CoreSpec=*
+   MinCPUsNode=1 MinMemoryNode=16G MinTmpDiskNode=0
+   Features=(null) Gres=(null) Reservation=(null)
+   Shared=OK Contiguous=0 Licenses=(null) Network=(null)
+   Command=(null)
+   WorkDir=/home_nfs/john
+   StdOut=/home_nfs/john/file.out
+   StdErr=/home_nfs/john/file.err
+   Power= SICP=0

--- a/prov/slurm/testdata/scontrol_show_job_failed.txt
+++ b/prov/slurm/testdata/scontrol_show_job_failed.txt
@@ -1,0 +1,24 @@
+JobId=6260 JobName=test-salloc-Environment
+   UserId=john(1001) GroupId=users(1000)
+   Priority=4294901193 Nice=0 Account=acc_salloc QOS=normal
+   JobState=FAILED Reason=None Dependency=(null)
+   Requeue=1 Restarts=0 BatchFlag=0 Reboot=0 ExitCode=0:0
+   RunTime=2-19:42:53 TimeLimit=UNLIMITED TimeMin=N/A
+   SubmitTime=2019-02-22T15:41:51 EligibleTime=2019-02-22T15:41:51
+   StartTime=2019-02-22T15:41:51 EndTime=Unknown
+   PreemptTime=None SuspendTime=None SecsPreSuspend=0
+   Partition=all AllocNode:Sid=rangiroa:19844
+   ReqNodeList=(null) ExcNodeList=(null)
+   NodeList=hpda19
+   BatchHost=hpda19
+   NumNodes=1 NumCPUs=1 CPUs/Task=1 ReqB:S:C:T=0:0:*:*
+   TRES=cpu=1,mem=16384,node=1
+   Socks/Node=* NtasksPerN:B:S:C=0:0:*:* CoreSpec=*
+   MinCPUsNode=1 MinMemoryNode=16G MinTmpDiskNode=0
+   Features=(null) Gres=(null) Reservation=(null)
+   Shared=OK Contiguous=0 Licenses=(null) Network=(null)
+   Command=(null)
+   WorkDir=/home_nfs/john
+   StdOut=/home_nfs/john/file.out
+   StdErr=/home_nfs/john/file.err
+   Power= SICP=0


### PR DESCRIPTION
# Pull Request description

## Description of the change

This is a backport of #668 

### What I did

Publish Slurm job fields retrieved by `scontrol show job` command as attributes. This command is already run during job monitoring. Attributes are published only if they are missing or updated.

### How to verify it

Run a Simple Slurm job or a Singularity Slurm job and check attributes

### Description for the changelog

* [Slurm] Expose Slurm scontrol show job results as job attributes ([GH-664](https://github.com/ystia/yorc/issues/664))

## Applicable Issues

Fixes #664 
Backported from #668 
