### PR TITLE
[Backport 4.0] bugfix #671 slowdown with lot of tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### BUG FIXES
 
+* Yorc is getting slow when there is a lot of tasks ([GH-671](https://github.com/ystia/yorc/issues/671))
 * Yorc does not build on Go1.15 ([GH-665](https://github.com/ystia/yorc/issues/665))
 
 ## 4.0.2 (July 10, 2020)

--- a/deployments/deployments.go
+++ b/deployments/deployments.go
@@ -17,11 +17,12 @@ package deployments
 import (
 	"context"
 	"fmt"
-	"github.com/ystia/yorc/v4/storage"
-	"github.com/ystia/yorc/v4/storage/types"
 	"path"
 	"strings"
 	"time"
+
+	"github.com/ystia/yorc/v4/storage"
+	"github.com/ystia/yorc/v4/storage/types"
 
 	"github.com/ystia/yorc/v4/helper/collections"
 
@@ -278,4 +279,16 @@ func DeleteDeployment(ctx context.Context, deploymentID string) error {
 	}
 	// Remove from KV
 	return consulutil.Delete(deploymentKeyPath, true)
+}
+
+// GetDeploymentTaskList returns the list of tasks ids associated with the given deployment
+func GetDeploymentTaskList(ctx context.Context, deploymentID string) ([]string, error) {
+	keys, err := consulutil.GetKeys(path.Join(consulutil.DeploymentKVPrefix, deploymentID, "tasks"))
+	if err != nil {
+		return keys, err
+	}
+	for i := range keys {
+		keys[i] = path.Base(keys[i])
+	}
+	return keys, err
 }

--- a/helper/consulutil/schema.go
+++ b/helper/consulutil/schema.go
@@ -15,7 +15,7 @@
 package consulutil
 
 // YorcSchemaVersion is the version of the data schema in Consul understood by this version of Yorc
-const YorcSchemaVersion = "1.3.0"
+const YorcSchemaVersion = "1.3.1"
 
 // YorcSchemaVersionPath is the path where  the data schema version is stored in Consul
 const YorcSchemaVersionPath = yorcPrefix + "/database_schema_version"

--- a/rest/GH-671-benchmark.md
+++ b/rest/GH-671-benchmark.md
@@ -1,0 +1,18 @@
+# Benchmark comparison of pre and post implementation of GH-671
+
+## Pre-GH-671
+
+```bash
+Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -tags testing -bench ^(BenchmarkGetDeployment)$
+
+goos: linux
+goarch: amd64
+pkg: github.com/ystia/yorc/v4/rest
+BenchmarkGetDeployment/BenchmarkGetDeployment-1-4                522     2156783 ns/op    249247 B/op      1180 allocs/op
+BenchmarkGetDeployment/BenchmarkGetDeployment-10-4               172     6509103 ns/op    708585 B/op      1989 allocs/op
+BenchmarkGetDeployment/BenchmarkGetDeployment-100-4               30    36641276 ns/op   5283954 B/op      9957 allocs/op
+BenchmarkGetDeployment/BenchmarkGetDeployment-1000-4               3   376045837 ns/op  51057704 B/op     90320 allocs/op
+BenchmarkGetDeployment/BenchmarkGetDeployment-10000-4              1  3911817514 ns/op  509427128 B/op    893058 allocs/op
+PASS
+ok    github.com/ystia/yorc/v4/rest  221.152s
+```

--- a/rest/GH-671-benchmark.md
+++ b/rest/GH-671-benchmark.md
@@ -8,11 +8,11 @@ Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -tags testing -bench ^
 goos: linux
 goarch: amd64
 pkg: github.com/ystia/yorc/v4/rest
-BenchmarkGetDeployment/BenchmarkGetDeployment-1-4                522     2156783 ns/op    249247 B/op      1180 allocs/op
-BenchmarkGetDeployment/BenchmarkGetDeployment-10-4               172     6509103 ns/op    708585 B/op      1989 allocs/op
-BenchmarkGetDeployment/BenchmarkGetDeployment-100-4               30    36641276 ns/op   5283954 B/op      9957 allocs/op
-BenchmarkGetDeployment/BenchmarkGetDeployment-1000-4               3   376045837 ns/op  51057704 B/op     90320 allocs/op
-BenchmarkGetDeployment/BenchmarkGetDeployment-10000-4              1  3911817514 ns/op  509427128 B/op    893058 allocs/op
+BenchmarkGetDeployment/BenchmarkGetDeployment-1-4                    613           1773530 ns/op          249218 B/op       1180 allocs/op
+BenchmarkGetDeployment/BenchmarkGetDeployment-10-4                   222           4913325 ns/op          709286 B/op       1991 allocs/op
+BenchmarkGetDeployment/BenchmarkGetDeployment-100-4                   38          37407939 ns/op         5280587 B/op       9951 allocs/op
+BenchmarkGetDeployment/BenchmarkGetDeployment-1000-4                   3         359853481 ns/op        51034448 B/op      89248 allocs/op
+BenchmarkGetDeployment/BenchmarkGetDeployment-10000-4                  1        4153240261 ns/op        509219896 B/op    882108 allocs/op
 PASS
-ok    github.com/ystia/yorc/v4/rest  221.152s
+ok      github.com/ystia/yorc/v4/rest   20.050s
 ```

--- a/rest/GH-671-benchmark.md
+++ b/rest/GH-671-benchmark.md
@@ -16,3 +16,51 @@ BenchmarkGetDeployment/BenchmarkGetDeployment-10000-4                  1        
 PASS
 ok      github.com/ystia/yorc/v4/rest   20.050s
 ```
+
+As we can see response time increase linearly with the number of tasks in the system.
+This is not what we expect.
+
+## Post-GH-671
+
+```bash
+Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -tags testing -bench ^(BenchmarkGetDeployment)$
+
+goos: linux
+goarch: amd64
+pkg: github.com/ystia/yorc/v4/rest
+BenchmarkGetDeployment/BenchmarkGetDeployment-1-4                   1311            951950 ns/op          142578 B/op        948 allocs/op
+BenchmarkGetDeployment/BenchmarkGetDeployment-10-4                  1300            980104 ns/op          142625 B/op        949 allocs/op
+BenchmarkGetDeployment/BenchmarkGetDeployment-100-4                 1464            996585 ns/op          142424 B/op        948 allocs/op
+BenchmarkGetDeployment/BenchmarkGetDeployment-1000-4                1353            898168 ns/op          142408 B/op        948 allocs/op
+BenchmarkGetDeployment/BenchmarkGetDeployment-10000-4               1430            926285 ns/op          142407 B/op        948 allocs/op
+PASS
+ok      github.com/ystia/yorc/v4/rest   31.512s
+```
+
+With this fix response time stay constant whatever is the number of tasks in the system.
+
+## Comparison
+
+```bash
+$ benchcmp rest/old.txt rest/new.txt
+benchmark                                                 old ns/op      new ns/op     delta
+BenchmarkGetDeployment/BenchmarkGetDeployment-1-4         1773530        951950        -46.32%
+BenchmarkGetDeployment/BenchmarkGetDeployment-10-4        4913325        980104        -80.05%
+BenchmarkGetDeployment/BenchmarkGetDeployment-100-4       37407939       996585        -97.34%
+BenchmarkGetDeployment/BenchmarkGetDeployment-1000-4      359853481      898168        -99.75%
+BenchmarkGetDeployment/BenchmarkGetDeployment-10000-4     4153240261     926285        -99.98%
+
+benchmark                                                 old allocs     new allocs     delta
+BenchmarkGetDeployment/BenchmarkGetDeployment-1-4         1180           948            -19.66%
+BenchmarkGetDeployment/BenchmarkGetDeployment-10-4        1991           949            -52.34%
+BenchmarkGetDeployment/BenchmarkGetDeployment-100-4       9951           948            -90.47%
+BenchmarkGetDeployment/BenchmarkGetDeployment-1000-4      89248          948            -98.94%
+BenchmarkGetDeployment/BenchmarkGetDeployment-10000-4     882108         948            -99.89%
+
+benchmark                                                 old bytes     new bytes     delta
+BenchmarkGetDeployment/BenchmarkGetDeployment-1-4         249218        142578        -42.79%
+BenchmarkGetDeployment/BenchmarkGetDeployment-10-4        709286        142625        -79.89%
+BenchmarkGetDeployment/BenchmarkGetDeployment-100-4       5280587       142424        -97.30%
+BenchmarkGetDeployment/BenchmarkGetDeployment-1000-4      51034448      142408        -99.72%
+BenchmarkGetDeployment/BenchmarkGetDeployment-10000-4     509219896     142407        -99.97%
+```

--- a/rest/GH-671-benchmark_test.go
+++ b/rest/GH-671-benchmark_test.go
@@ -1,0 +1,123 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	stdlog "log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/consul/testutil"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/assert"
+
+	"github.com/ystia/yorc/v4/helper/consulutil"
+	"github.com/ystia/yorc/v4/log"
+	"github.com/ystia/yorc/v4/tasks"
+	"github.com/ystia/yorc/v4/tasks/collector"
+	ytestutil "github.com/ystia/yorc/v4/testutil"
+)
+
+func BenchmarkGetDeployment(b *testing.B) {
+	log.SetOutput(ioutil.Discard)
+	stdlog.SetOutput(ioutil.Discard)
+	cfg := ytestutil.SetupTestConfig(b)
+	srv, client := ytestutil.NewTestConsulInstanceWithConfigAndStore(b, func(c *testutil.TestServerConfig) {
+		c.LogLevel = "ERR"
+		c.Stdout = ioutil.Discard
+		c.Stderr = ioutil.Discard
+	}, &cfg)
+	defer func() {
+		srv.Stop()
+		os.RemoveAll(cfg.WorkingDirectory)
+	}()
+
+	deploymentID := ytestutil.BuildDeploymentID(b)
+	loadTestYaml(b, deploymentID)
+
+	benches := []struct {
+		existingTasksNb int
+	}{
+		{1},
+		{10},
+		{100},
+		{1000},
+		{10000},
+	}
+
+	collector := collector.NewCollector(client)
+
+	b.ResetTimer()
+	for _, bb := range benches {
+		b.Run(fmt.Sprintf("BenchmarkGetDeployment-%d", bb.existingTasksNb), func(b *testing.B) {
+			b.StopTimer()
+			taskID, err := collector.RegisterTask(deploymentID, tasks.TaskTypeCustomCommand)
+			assert.NilError(b, err, "failed to register task")
+			_, errGrp, store := consulutil.WithContext(context.Background())
+
+			for i := 0; i < bb.existingTasksNb; i++ {
+				taskPath := path.Join(consulutil.TasksPrefix, fmt.Sprintf("000-task-%08d", i))
+				store.StoreConsulKeyAsString(path.Join(taskPath, "targetId"), fmt.Sprintf("dep-%08d", i))
+				store.StoreConsulKey(path.Join(taskPath, "status"), []byte(strconv.Itoa(int(tasks.TaskStatusINITIAL))))
+				store.StoreConsulKey(path.Join(taskPath, "type"), []byte(strconv.Itoa(int(tasks.TaskTypeDeploy))))
+			}
+			require.NoError(b, errGrp.Wait())
+
+			defer client.KV().DeleteTree(consulutil.TasksPrefix, nil)
+			defer client.KV().DeleteTree(path.Join(consulutil.DeploymentKVPrefix, deploymentID, "tasks"), nil)
+
+			req := httptest.NewRequest("GET", "/deployments/"+deploymentID, nil)
+			req.Header.Set("Accept", mimeTypeApplicationJSON)
+			var resp *http.Response
+			b.StartTimer()
+			for n := 0; n < b.N; n++ {
+				resp = newTestHTTPRouter(client, cfg, req)
+			}
+
+			// stop here as we have delete tree in deferred function
+			b.StopTimer()
+
+			// Sanity checks
+			assert.Assert(b, resp != nil, "unexpected nil response")
+			assert.Equal(b, 200, resp.StatusCode, "unexpected status code")
+
+			body, err := ioutil.ReadAll(resp.Body)
+			assert.NilError(b, err, "unexpected error reading body response")
+
+			depFound := new(Deployment)
+			err = json.Unmarshal(body, depFound)
+			assert.NilError(b, err, "unexpected error unmarshalling json body")
+			expectedDeployment := &Deployment{
+				ID:     "BenchmarkGetDeployment",
+				Status: "INITIAL",
+				Links: []AtomLink{
+					{
+						Rel:      "self",
+						Href:     "/deployments/BenchmarkGetDeployment",
+						LinkType: "application/json",
+					},
+					{
+						Rel:      "node",
+						Href:     "/deployments/BenchmarkGetDeployment/nodes/Compute",
+						LinkType: "application/json",
+					},
+					{
+						Rel:      "task",
+						Href:     "/deployments/BenchmarkGetDeployment/tasks/" + taskID,
+						LinkType: "application/json",
+					},
+				},
+			}
+			assert.DeepEqual(b, depFound, expectedDeployment)
+
+		})
+
+	}
+
+}

--- a/rest/deployments.go
+++ b/rest/deployments.go
@@ -351,7 +351,7 @@ func (s *Server) getDeploymentHandler(w http.ResponseWriter, r *http.Request) {
 		links = append(links, newAtomLink(LinkRelNode, path.Join(r.URL.Path, "nodes", node)))
 	}
 
-	tasksList, err := tasks.GetTasksIdsForTarget(id)
+	tasksList, err := deployments.GetDeploymentTaskList(ctx, id)
 	if err != nil {
 		log.Panic(err)
 	}

--- a/rest/deployments_test.go
+++ b/rest/deployments_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	stdlog "log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -35,15 +34,12 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testutil"
 	"github.com/stretchr/testify/require"
-	"gotest.tools/v3/assert"
 
 	"github.com/ystia/yorc/v4/config"
 	"github.com/ystia/yorc/v4/deployments"
 	"github.com/ystia/yorc/v4/helper/consulutil"
 	"github.com/ystia/yorc/v4/helper/ziputil"
-	"github.com/ystia/yorc/v4/log"
 	"github.com/ystia/yorc/v4/tasks"
-	"github.com/ystia/yorc/v4/tasks/collector"
 	ytestutil "github.com/ystia/yorc/v4/testutil"
 )
 
@@ -408,111 +404,4 @@ func testNewDeployments(t *testing.T, client *api.Client, cfg config.Configurati
 			cleanTest(depID, "")
 		})
 	}
-}
-
-func BenchmarkGetDeployment(b *testing.B) {
-	log.SetOutput(ioutil.Discard)
-	stdlog.SetOutput(ioutil.Discard)
-	cfg := ytestutil.SetupTestConfig(b)
-	srv, client := ytestutil.NewTestConsulInstanceWithConfigAndStore(b, func(c *testutil.TestServerConfig) {
-		c.LogLevel = "ERR"
-		c.Stdout = ioutil.Discard
-		c.Stderr = ioutil.Discard
-	}, &cfg)
-	defer func() {
-		srv.Stop()
-		os.RemoveAll(cfg.WorkingDirectory)
-	}()
-
-	deploymentID := ytestutil.BuildDeploymentID(b)
-	loadTestYaml(b, deploymentID)
-
-	benches := []struct {
-		existingTasksNb int
-	}{
-		{1},
-		{10},
-		{100},
-		{1000},
-		{10000},
-	}
-
-	collector := collector.NewCollector(client)
-	for _, bb := range benches {
-		b.Run(fmt.Sprintf("BenchmarkGetDeployment-%d", bb.existingTasksNb), func(b *testing.B) {
-			taskID, err := collector.RegisterTask(deploymentID, tasks.TaskTypeCustomCommand)
-			assert.NilError(b, err, "failed to register task")
-
-			for i := 0; i < bb.existingTasksNb; i++ {
-				taskPath := path.Join(consulutil.TasksPrefix, fmt.Sprintf("000-task-%08d", i))
-				ok, _, _, err := client.KV().Txn(api.KVTxnOps{
-					&api.KVTxnOp{
-						Verb:  api.KVSet,
-						Key:   path.Join(taskPath, "targetId"),
-						Value: []byte(fmt.Sprintf("dep-%08d", i)),
-					},
-					&api.KVTxnOp{
-						Verb:  api.KVSet,
-						Key:   path.Join(taskPath, "status"),
-						Value: []byte(strconv.Itoa(int(tasks.TaskStatusINITIAL))),
-					},
-					&api.KVTxnOp{
-						Verb:  api.KVSet,
-						Key:   path.Join(taskPath, "type"),
-						Value: []byte(strconv.Itoa(int(tasks.TaskTypeDeploy))),
-					},
-				}, nil)
-				require.True(b, ok)
-				require.NoError(b, err)
-			}
-			defer client.KV().DeleteTree(consulutil.TasksPrefix, nil)
-
-			req := httptest.NewRequest("GET", "/deployments/"+deploymentID, nil)
-			req.Header.Set("Accept", mimeTypeApplicationJSON)
-			var resp *http.Response
-			b.ResetTimer()
-			for n := 0; n < b.N; n++ {
-				resp = newTestHTTPRouter(client, cfg, req)
-			}
-
-			// stop here as we have delete tree in deferred function
-			b.StopTimer()
-
-			// Sanity checks
-			assert.Assert(b, resp != nil, "unexpected nil response")
-			assert.Equal(b, 200, resp.StatusCode, "unexpected status code")
-
-			body, err := ioutil.ReadAll(resp.Body)
-			assert.NilError(b, err, "unexpected error reading body response")
-
-			depFound := new(Deployment)
-			err = json.Unmarshal(body, depFound)
-			assert.NilError(b, err, "unexpected error unmarshalling json body")
-			expectedDeployment := &Deployment{
-				ID:     "BenchmarkGetDeployment",
-				Status: "INITIAL",
-				Links: []AtomLink{
-					{
-						Rel:      "self",
-						Href:     "/deployments/BenchmarkGetDeployment",
-						LinkType: "application/json",
-					},
-					{
-						Rel:      "node",
-						Href:     "/deployments/BenchmarkGetDeployment/nodes/Compute",
-						LinkType: "application/json",
-					},
-					{
-						Rel:      "task",
-						Href:     "/deployments/BenchmarkGetDeployment/tasks/" + taskID,
-						LinkType: "application/json",
-					},
-				},
-			}
-			assert.DeepEqual(b, depFound, expectedDeployment)
-
-		})
-
-	}
-
 }

--- a/rest/deployments_test.go
+++ b/rest/deployments_test.go
@@ -397,7 +397,10 @@ func testNewDeployments(t *testing.T, client *api.Client, cfg config.Configurati
 				require.NoError(t, err)
 				require.NotNil(t, url)
 
-				has, _, status, err := tasks.TargetHasLivingTasks(depID, nil)
+				taskList, err := deployments.GetDeploymentTaskList(req.Context(), depID)
+				require.NoError(t, err)
+
+				has, _, status, err := tasks.HasLivingTasks(taskList, nil)
 				require.True(t, has, "%s should have a registered task", depID)
 				require.Equal(t, tasks.TaskStatusINITIAL.String(), status)
 			}

--- a/server/consul.go
+++ b/server/consul.go
@@ -15,10 +15,11 @@
 package server
 
 import (
-	"github.com/ystia/yorc/v4/config"
 	"io"
 	"os"
 	"strconv"
+
+	"github.com/ystia/yorc/v4/config"
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/consul/api"
@@ -36,6 +37,7 @@ var upgradeToMap = map[string]func(config.Configuration, *api.KV, <-chan struct{
 	"1.1.2": upgradeschema.UpgradeTo112,
 	"1.2.0": upgradeschema.UpgradeTo120,
 	"1.3.0": upgradeschema.UpgradeTo130,
+	"1.3.1": upgradeschema.UpgradeTo131,
 }
 
 var orderedUpgradesVersions []semver.Version

--- a/server/upgradeschema/upgrade_131.go
+++ b/server/upgradeschema/upgrade_131.go
@@ -1,0 +1,58 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgradeschema
+
+import (
+	"context"
+	"path"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/pkg/errors"
+
+	"github.com/ystia/yorc/v4/config"
+	"github.com/ystia/yorc/v4/helper/consulutil"
+	"github.com/ystia/yorc/v4/log"
+)
+
+// UpgradeTo131 allows to upgrade Consul schema from 1.3.0 to 1.3.1
+func UpgradeTo131(cfg config.Configuration, kv *api.KV, leaderch <-chan struct{}) error {
+	log.Print("Upgrading to database version 1.3.1")
+
+	tasks, _, err := kv.Keys(consulutil.TasksPrefix+"/", "/", nil)
+	if err != nil {
+		return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+	}
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+	_, errGrp, store := consulutil.WithContext(ctx)
+	for _, taskPath := range tasks {
+		taskID := path.Base(taskPath)
+		kvp, _, err := kv.Get(path.Join(taskPath, "targetId"), nil)
+		if err != nil {
+			return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+		}
+		if kvp != nil && len(kvp.Value) != 0 {
+			deploymentID := string(kvp.Value)
+			kvp, _, err = kv.Get(path.Join(consulutil.DeploymentKVPrefix, deploymentID, "status"), nil)
+			if err != nil {
+				return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
+			}
+			if kvp != nil && len(kvp.Value) != 0 {
+				store.StoreConsulKeyWithFlags(path.Join(consulutil.DeploymentKVPrefix, deploymentID, "tasks", taskID), nil, 1)
+			}
+		}
+	}
+	return errors.Wrap(errGrp.Wait(), "failed to store task key under deployment")
+}

--- a/server/upgradeschema/upgrade_131_test.go
+++ b/server/upgradeschema/upgrade_131_test.go
@@ -1,0 +1,52 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgradeschema
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/ystia/yorc/v4/helper/consulutil"
+	"github.com/ystia/yorc/v4/testutil"
+)
+
+func TestUpgradeTo131(t *testing.T) {
+	cfg := testutil.SetupTestConfig(t)
+	srv, client := testutil.NewTestConsulInstance(t, &cfg)
+	defer func() {
+		srv.Stop()
+		os.RemoveAll(cfg.WorkingDirectory)
+	}()
+
+	srv.PopulateKV(t, map[string][]byte{
+		path.Join(consulutil.DeploymentKVPrefix, "dep1", "status"): []byte("INITIAL"),
+		path.Join(consulutil.DeploymentKVPrefix, "dep2", "status"): []byte("INITIAL"),
+		path.Join(consulutil.TasksPrefix, "id1", "targetId"):       []byte("dep1"),
+		path.Join(consulutil.TasksPrefix, "id2", "targetId"):       []byte("dep1"),
+		path.Join(consulutil.TasksPrefix, "id3", "targetId"):       []byte("notexist"),
+		path.Join(consulutil.TasksPrefix, "id4", "targetId"):       []byte("dep2"),
+	})
+
+	err := UpgradeTo131(cfg, client.KV(), nil)
+	assert.NilError(t, err)
+	tasks := srv.ListKV(t, path.Join(consulutil.DeploymentKVPrefix, "dep1", "tasks"))
+	assert.DeepEqual(t, tasks, []string{"_yorc/deployments/dep1/tasks/id1", "_yorc/deployments/dep1/tasks/id2"})
+	tasks = srv.ListKV(t, path.Join(consulutil.DeploymentKVPrefix, "dep2", "tasks"))
+	assert.DeepEqual(t, tasks, []string{"_yorc/deployments/dep2/tasks/id4"})
+
+}

--- a/tasks/structs.go
+++ b/tasks/structs.go
@@ -40,3 +40,10 @@ type TaskType int
 // CANCELED
 // )
 type TaskStatus int
+
+// IsDeploymentRelatedTask returns true if the task is related to a deployment
+//
+// Typically query and action tasks are not necessary related to a deployment.
+func IsDeploymentRelatedTask(tt TaskType) bool {
+	return !(tt == TaskTypeQuery || tt == TaskTypeAction)
+}

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -105,6 +105,8 @@ func IsTaskNotFoundError(err error) bool {
 }
 
 // GetTasksIdsForTarget returns IDs of tasks related to a given targetID
+//
+// Deprecated: Prefer deployments.GetDeploymentTaskList() instead if possible
 func GetTasksIdsForTarget(targetID string) ([]string, error) {
 	tasksKeys, err := consulutil.GetKeys(consulutil.TasksPrefix + "/")
 	if err != nil {
@@ -318,13 +320,20 @@ func DeleteTask(taskID string) error {
 // TargetHasLivingTasks checks if a targetID has associated tasks in status INITIAL or RUNNING and returns the id and status of the first one found
 //
 // The last argument specifies tasks types which should be ignored.
+//
+// Deprecated: Prefer HasLivingTasks() instead
 func TargetHasLivingTasks(targetID string, tasksTypesToIgnore []TaskType) (bool, string, string, error) {
-
 	taskIDs, err := GetTasksIdsForTarget(targetID)
 	if err != nil {
 		return false, "", "", errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 	}
+	return HasLivingTasks(taskIDs, tasksTypesToIgnore)
+}
 
+// HasLivingTasks checks if the tasks list contains tasks in status INITIAL or RUNNING and returns the id and status of the first one found
+//
+// The last argument specifies tasks types which should be ignored.
+func HasLivingTasks(taskIDs []string, tasksTypesToIgnore []TaskType) (bool, string, string, error) {
 	for _, taskID := range taskIDs {
 
 		tStatus, err := GetTaskStatus(taskID)

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -637,7 +637,7 @@ func (w *worker) runPurge(ctx context.Context, t *taskExecution) error {
 	}
 	kv := w.consulClient.KV()
 	// Remove from KV all tasks from the current target deployment, except this purge task
-	tasksList, err := tasks.GetTasksIdsForTarget(t.targetID)
+	tasksList, err := deployments.GetDeploymentTaskList(ctx, t.targetID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Keep track of task ids under each deployment.

Previously to know tasks related to a deployment we had to inspect each task.

### How I did it

In consul under `_yorc/deployments/deploymentID/tasks` the task collector add a key for each tasks.

Also added utility functions un `deployments` package to retrieve tasks related to a deployment by listing above keys.

### Description for the changelog

* Yorc is getting slow when there is a lot of tasks ([GH-671](https://github.com/ystia/yorc/issues/671))

## Applicable Issues

fixes #671 
backported from #672 