### PR TITLE
Bugfix release/4.0 Job sched termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### BUG FIXES
 
+* Asynchronous execution termination detection error ([GH-677](https://github.com/ystia/yorc/issues/677))
 * Yorc generates forcePurge tasks on list deployments API endpoint ([GH-674](https://github.com/ystia/yorc/issues/674))
 * Yorc is getting slow when there is a lot of tasks ([GH-671](https://github.com/ystia/yorc/issues/671))
 * Yorc does not build on Go1.15 ([GH-665](https://github.com/ystia/yorc/issues/665))

--- a/tasks/workflow/builder/builder.go
+++ b/tasks/workflow/builder/builder.go
@@ -222,6 +222,7 @@ func BuildInitExecutionOperations(ctx context.Context, deploymentID, taskID, wor
 					Value: []byte(""),
 				},
 			}
+			log.Debugf("Will store runningExecutions with id %q in txn for task %q", execID, taskID)
 			ops = append(ops, stepOps...)
 		}
 	}

--- a/tasks/workflow/step.go
+++ b/tasks/workflow/step.go
@@ -348,7 +348,8 @@ func (s *step) runActivity(wfCtx context.Context, cfg config.Configuration, depl
 				action.AsyncOperation.WorkflowStepInfo = eventInfo
 				// Register scheduled action for asynchronous execution
 				id, err := scheduling.RegisterAction(w.consulClient, deploymentID, timeInterval, action)
-				log.Debugf("Scheduled action with ID;%q has been registered with timeInterval:%s and ID:%q", action.ID, timeInterval.String(), id)
+				action.ID = id
+				log.Debugf("Scheduled action with ID: %q has been registered with timeInterval: %s", action.ID, timeInterval.String(), id)
 				if err != nil {
 					return err
 				}
@@ -357,6 +358,7 @@ func (s *step) runActivity(wfCtx context.Context, cfg config.Configuration, depl
 					return err
 				}
 				defer l.Unlock()
+				log.Debugf("Storing runningExecutions with id %q for task %q", id, s.t.taskID)
 				return consulutil.StoreConsulKeyAsString(path.Join(consulutil.TasksPrefix, s.t.taskID, ".runningExecutions", id), "recurrent action")
 			}()
 		} else {

--- a/tasks/workflow/step.go
+++ b/tasks/workflow/step.go
@@ -349,7 +349,7 @@ func (s *step) runActivity(wfCtx context.Context, cfg config.Configuration, depl
 				// Register scheduled action for asynchronous execution
 				id, err := scheduling.RegisterAction(w.consulClient, deploymentID, timeInterval, action)
 				action.ID = id
-				log.Debugf("Scheduled action with ID: %q has been registered with timeInterval: %s", action.ID, timeInterval.String(), id)
+				log.Debugf("Scheduled action with ID: %q has been registered with timeInterval: %s", action.ID, timeInterval.String())
 				if err != nil {
 					return err
 				}

--- a/tasks/workflow/task_execution.go
+++ b/tasks/workflow/task_execution.go
@@ -80,6 +80,7 @@ func (t *taskExecution) notifyStart() error {
 	if err != nil {
 		return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 	}
+	log.Debugf("Storing runningExecutions with id %q for task %q", t.id, t.taskID)
 	return consulutil.StoreConsulKeyAsString(path.Join(consulutil.TasksPrefix, t.taskID, ".runningExecutions", t.id), consulNodeName)
 }
 
@@ -133,7 +134,7 @@ func numberOfRunningExecutionsForTask(cc *api.Client, taskID string) (*consuluti
 		l.Unlock()
 		return nil, 0, errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 	}
-	log.Debugf("numberOfRunningExecutionsForTask %d", len(keys))
+	log.Debugf("numberOfRunningExecutionsForTask %q: %d", taskID, len(keys))
 	return l, len(keys), nil
 }
 
@@ -148,11 +149,13 @@ func (t *taskExecution) notifyEnd() error {
 
 	kv := t.cc.KV()
 	// Delete our execID
+	log.Debugf("Deleting runningExecutions with id %q for task %q", t.id, t.taskID)
 	_, err = kv.Delete(path.Join(execPath, t.id), nil)
 	if err != nil {
 		return errors.Wrap(err, consulutil.ConsulGenericErrMsg)
 	}
 	if e <= 1 && t.finalFunction != nil {
+		log.Debugf("notifyEnd running finalFunction for taskExecution %q", t.id)
 		return t.finalFunction()
 	}
 	return nil

--- a/tasks/workflow/workflow.go
+++ b/tasks/workflow/workflow.go
@@ -72,6 +72,7 @@ func createWorkflowStepsOperations(taskID string, steps []*step) api.KVTxnOps {
 			},
 		}
 		ops = append(ops, stepOps...)
+		log.Debugf("Will store runningExecutions with id %q in txn for task %q", execID, taskID)
 	}
 	return ops
 }

--- a/testdata/ci/features/Job.feature
+++ b/testdata/ci/features/Job.feature
@@ -3,12 +3,17 @@
 #
 
 @Job
+@openstack
+@gcp
+@hp
 Feature: Deploy a TestJobApp application using Alien4Cloud with a job mock
 
   Background: Deploying required artifacts
     Given I have uploaded the artifact named "org-ystia-samples-jobmock" to Alien
     And I have built the artifact named "testJob" from templates named "testJob" to Alien
     And I have uploaded the artifact named "testJob" to Alien
+    And I have built the artifact named "testJobsSched" from templates named "testJobsSched" to Alien
+    And I have uploaded the artifact named "testJobsSched" to Alien
 
   @CI
   @cleanupAlien
@@ -31,5 +36,19 @@ Feature: Deploy a TestJobApp application using Alien4Cloud with a job mock
     And I cancel the last run workflow
 
     Then The status of the workflow is finally "CANCELLED" waiting max "30" seconds
+
+  @CI
+  @cleanupAlien
+  Scenario: Run a workload and check its workflow status
+    Given I have created an application named "TestJobWorkloadApp" based on template named "org.ystia.ci.tests.test_job_sched"
+    And I have deployed the application named "TestJobWorkloadApp"
+
+    When I run the workflow named "run"
+
+    Then The status of the workflow is finally "SUCCEEDED" waiting max "60" seconds
+    And The status of the instance "0" of the node named "DelayJob1" is "executed"
+    And The status of the instance "0" of the node named "DelayJob21" is "executed"
+    And The status of the instance "0" of the node named "DelayJob22" is "executed"
+    And The status of the instance "0" of the node named "DelayJob3" is "executed"
 
 

--- a/testdata/ci/runner/Jenkinsfile
+++ b/testdata/ci/runner/Jenkinsfile
@@ -3,6 +3,7 @@ pipeline {
     options {
         skipDefaultCheckout true
         lock('yorc-ci-hostspool')
+        ansiColor('xterm')
     }
     parameters {
         choice(name: 'INFRA_FILTER', choices: ['all', 'openstack', 'gcp', 'hp'], description: 'Run on specific infrastructure (all by default)')

--- a/testdata/ci/templates/testJobsSched/types.yaml
+++ b/testdata/ci/templates/testJobsSched/types.yaml
@@ -1,0 +1,62 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: org.ystia.ci.tests.test_job_sched
+  template_version: 1.0.0-SNAPSHOT
+  template_author: test
+
+description: ""
+
+imports:
+  - org.ystia.samples.job.mock:1.0.0-SNAPSHOT
+  - tosca-normative-types:1.0.0-ALIEN20
+
+topology_template:
+  node_templates:
+    DelayJob1:
+      type: org.ystia.samples.job.mocks.DelayJob
+      properties:
+        run_delay: 1
+        random_status: false
+        failure: false
+    DelayJob21:
+      type: org.ystia.samples.job.mocks.DelayJob
+      properties:
+        run_delay: 1
+        random_status: false
+        failure: false
+      requirements:
+        - dependsOnDelayJob1Feature:
+            type_requirement: dependency
+            node: DelayJob1
+            capability: tosca.capabilities.Node
+            relationship: tosca.relationships.DependsOn
+    DelayJob22:
+      type: org.ystia.samples.job.mocks.DelayJob
+      properties:
+        run_delay: 5
+        random_status: false
+        failure: false
+      requirements:
+        - dependsOnDelayJob1Feature:
+            type_requirement: dependency
+            node: DelayJob1
+            capability: tosca.capabilities.Node
+            relationship: tosca.relationships.DependsOn
+    DelayJob3:
+      type: org.ystia.samples.job.mocks.DelayJob
+      properties:
+        run_delay: 1
+        random_status: false
+        failure: false
+      requirements:
+        - dependsOnDelayJob21Feature:
+            type_requirement: dependency
+            node: DelayJob21
+            capability: tosca.capabilities.Node
+            relationship: tosca.relationships.DependsOn
+        - dependsOnDelayJob22Feature:
+            type_requirement: dependency
+            node: DelayJob22
+            capability: tosca.capabilities.Node
+            relationship: tosca.relationships.DependsOn


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fix a regression introduced in PR #661 for fixing issue #659

### What I did

Fix wrong task ID used to compute running execution for a task.
In a scheduled action we should check for the workflow taskID and not the action taskID.

Also I activated some jobs tests to run in CI automatically.

### Description for the changelog

* Asynchronous execution termination detection error ([GH-677](https://github.com/ystia/yorc/issues/677))

## Applicable Issues

Fixes #677 
Ported to  develop (4.1.0-milestone.1 snapshot) in #679 
