### PR TITLE
Migrate to new sortorder import path

### DIFF
--- a/deployments/definition_store_test.go
+++ b/deployments/definition_store_test.go
@@ -29,8 +29,8 @@ import (
 	"strings"
 	"testing"
 	"time"
-	"vbom.ml/util/sortorder"
 
+	"github.com/fvbommel/sortorder"
 	ctu "github.com/hashicorp/consul/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/deployments/nodes.go
+++ b/deployments/nodes.go
@@ -22,8 +22,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fvbommel/sortorder"
 	"github.com/pkg/errors"
-	"vbom.ml/util/sortorder"
 
 	"github.com/ystia/yorc/v4/events"
 	"github.com/ystia/yorc/v4/helper/consulutil"

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/fatih/color v1.7.0
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.7
+	github.com/fvbommel/sortorder v1.0.1
 	github.com/go-sql-driver/mysql v1.5.0 // indirect
 	github.com/gocql/gocql v0.0.0-20200228163523-cd4b606dd2fb // indirect
 	github.com/golang/snappy v0.0.1 // indirect
@@ -89,7 +90,6 @@ require (
 	github.com/stevedomin/termtable v0.0.0-20150929082024-09d29f3fd628
 	github.com/stretchr/testify v1.4.0
 	github.com/tmc/dot v0.0.0-20180926222610-6d252d5ff882
-	github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 // indirect
 	github.com/ystia/tdt2go v0.3.0
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
@@ -106,7 +106,6 @@ require (
 	k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d
 	k8s.io/client-go v8.0.0+incompatible
 	k8s.io/kube-openapi v0.0.0-20190709113604-33be087ad058 // indirect
-	vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc
 )
 
 // Due to this capital letter thing we have troubles and we have to replace it explicitly

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fvbommel/sortorder v1.0.1 h1:dSnXLt4mJYH25uDDGa3biZNQsozaUWDSWeKJ0qqFfzE=
+github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -481,8 +483,6 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
-github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 h1:j2hhcujLRHAg872RWAV5yaUrEjHEObwDv3aImCaNLek=
-github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/ystia/tdt2go v0.3.0 h1:BmsZ0vsZQvsdhHz01XXy1mH2i0VjQFSRUalH0sQKcIg=
 github.com/ystia/tdt2go v0.3.0/go.mod h1:jMICTU+LGFMsG8LxSECoLXoDZoSuA9ofSiqLubtFnK8=
@@ -632,5 +632,3 @@ k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUc
 k8s.io/kube-openapi v0.0.0-20190709113604-33be087ad058 h1:di3XCwddOR9cWBNpfgXaskhh6cgJuwcK54rvtwUaC10=
 k8s.io/kube-openapi v0.0.0-20190709113604-33be087ad058/go.mod h1:nfDlWeOsu3pUf4yWGL+ERqohP4YsZcBJXWMK+gkzOA4=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
-vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc h1:MksmcCZQWAQJCTA5T0jgI/0sJ51AVm4Z41MrmfczEoc=
-vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=


### PR DESCRIPTION
# Pull Request description

Due to some issues with the server handling the vanity imports, I unfortunately had to move the `vbom.ml/util` package to `github.com/fvbommel/util`. Since I was breaking import paths anyway, I decided to also move the much more popular `sortorder` sub-package to `github.com/fvbommel/sortorder` instead.

See fvbommel/util#7

## Description of the change

I've updated the import path to the new location.

### What I did

I've updated the import path where it was used.

### How I did it

I've updated the import path where it was used.

### How to verify it

The actual code of the imported package hasn't changed, [as can be seen in the Blame view](https://github.com/fvbommel/sortorder/blame/master/natsort.go).
The only changes to the .go files have been to remove the vanity import and to remove a test dependency.

### Description for the changelog

Updated import path of vbom.ml/util/sortorder to github.com/fvbommel/sortorder

## Applicable Issues

None.
