### PR TITLE
[Backport 4.0] Cleanup of ansible execution directories after execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Empty directories not removed after ansible executions can lead to inodes exhaustion ([GH-683](https://github.com/ystia/yorc/issues/683))
+
 ## 4.0.3 (August 27, 2020)
 
 ### FEATURES

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -895,15 +895,16 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 		return err
 	}
 
-	ansibleRecipePath := filepath.Join(ansiblePath, stringutil.UniqueTimestampedName(e.taskID+"_", ""), e.NodeName)
+	ansibleExecutionRootDir := filepath.Join(ansiblePath, stringutil.UniqueTimestampedName(e.taskID+"_", ""))
+	ansibleRecipePath := filepath.Join(ansibleExecutionRootDir, e.NodeName)
 	if e.operation.RelOp.IsRelationshipOperation {
 		ansibleRecipePath = filepath.Join(ansibleRecipePath, e.relationshipType, e.operation.RelOp.TargetRelationship, e.operation.Name, currentInstance)
 	} else {
 		ansibleRecipePath = filepath.Join(ansibleRecipePath, e.operation.Name, currentInstance)
 	}
 
-	if err = os.RemoveAll(ansibleRecipePath); err != nil {
-		err = errors.Wrapf(err, "Failed to remove ansible recipe directory %q for node %q operation %q", ansibleRecipePath, e.NodeName, e.operation.Name)
+	if err = os.RemoveAll(ansibleExecutionRootDir); err != nil {
+		err = errors.Wrapf(err, "Failed to remove ansible execution directory %q for node %q operation %q", ansibleExecutionRootDir, e.NodeName, e.operation.Name)
 		log.Debugf("%+v", err)
 		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, e.deploymentID).RegisterAsString(err.Error())
 		return err
@@ -911,9 +912,9 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 
 	defer func() {
 		if !e.cfg.Ansible.KeepGeneratedRecipes {
-			err := os.RemoveAll(ansibleRecipePath)
+			err := os.RemoveAll(ansibleExecutionRootDir)
 			if err != nil {
-				err = errors.Wrapf(err, "Failed to remove ansible recipe directory %q for node %q operation %q", ansibleRecipePath, e.NodeName, e.operation.Name)
+				err = errors.Wrapf(err, "Failed to remove ansible execution directory %q for node %q operation %q", ansibleExecutionRootDir, e.NodeName, e.operation.Name)
 				log.Debugf("%+v", err)
 				events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, e.deploymentID).RegisterAsString(err.Error())
 			}
@@ -1085,7 +1086,10 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 	// Build archives for artifacts
 	for artifactName, artifactPath := range e.Artifacts {
 		tarPath := filepath.Join(ansibleRecipePath, artifactName+".tar")
-		buildArchive(e.OverlayPath, artifactPath, tarPath)
+		err := buildArchive(e.OverlayPath, artifactPath, tarPath)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = e.ansibleRunner.runAnsible(ctx, retry, currentInstance, ansibleRecipePath)
@@ -1167,7 +1171,11 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 						}
 					}
 				} else {
-					tasks.SetTaskData(e.taskID, e.NodeName+"-"+instanceID+"-"+strings.Join(splits[0:len(splits)-1], "_"), line[1])
+					err := tasks.SetTaskData(e.taskID, e.NodeName+"-"+instanceID+"-"+strings.Join(splits[0:len(splits)-1], "_"), line[1])
+					if err != nil {
+						return err
+					}
+
 				}
 			}
 		}

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -903,13 +903,6 @@ func (e *executionCommon) executeWithCurrentInstance(ctx context.Context, retry 
 		ansibleRecipePath = filepath.Join(ansibleRecipePath, e.operation.Name, currentInstance)
 	}
 
-	if err = os.RemoveAll(ansibleExecutionRootDir); err != nil {
-		err = errors.Wrapf(err, "Failed to remove ansible execution directory %q for node %q operation %q", ansibleExecutionRootDir, e.NodeName, e.operation.Name)
-		log.Debugf("%+v", err)
-		events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelERROR, e.deploymentID).RegisterAsString(err.Error())
-		return err
-	}
-
 	defer func() {
 		if !e.cfg.Ansible.KeepGeneratedRecipes {
 			err := os.RemoveAll(ansibleExecutionRootDir)


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

`prov/ansible/execution.go`
In the deferred function doing the cleanup after the playbook execution, deleting recursively the timestamped directory that was created for the execution

misc change not rleated to the issue: fixed two cases where a returned error was ignored.

`prov/ansible/execution_test.go`
Added a test checking directories created for an execution are deleted after the execution


### How to verify it

Deploy a topology with a compute instance and a component implementing standard and/or runnable interfaces.
Check during the workflow execution that as soon as a workflow step executing a component operation is executed, the corresponding timestamped directories under `<working dir>/<deployment ID>/ansible/`is removed.
Check once the workflow is done, that there is no timestamped directory under `<working dir>/<deployment ID>/ansible/`.

### Description for the changelog

Empty directories not removed after ansible executions can lead to inodes exhaustion ([GH-683](https://github.com/ystia/yorc/issues/683))

## Applicable Issues

* Fixes #683
* Backported from #684
