### PR TITLE
[Back-port release_4.0] Fix possible nil pointer use when we can't get a workflow definition from store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### BUG FIXES
 
+* Panic due to nil pointer dereference may happen when retrieving a workflow ([GH-691](https://github.com/ystia/yorc/issues/691))
 * Empty directories not removed after ansible executions can lead to inodes exhaustion ([GH-683](https://github.com/ystia/yorc/issues/683))
 
 ## 4.0.3 (August 27, 2020)

--- a/deployments/workflows.go
+++ b/deployments/workflows.go
@@ -16,11 +16,12 @@ package deployments
 
 import (
 	"context"
+	"path"
+	"strings"
+
 	"github.com/ystia/yorc/v4/log"
 	"github.com/ystia/yorc/v4/storage"
 	"github.com/ystia/yorc/v4/storage/types"
-	"path"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -125,6 +126,10 @@ func ResolveWorkflowOutputs(ctx context.Context, deploymentID, workflowName stri
 	wf, err := GetWorkflow(ctx, deploymentID, workflowName)
 	if err != nil {
 		return nil, err
+	}
+
+	if wf == nil {
+		return nil, errors.Errorf("Can't resolve outputs of workflow %q in deployment %q, workflow definition not found", workflowName, deploymentID)
 	}
 
 	outputs := make(map[string]*TOSCAValue)

--- a/rest/dep_workflow.go
+++ b/rest/dep_workflow.go
@@ -120,7 +120,9 @@ func (s *Server) newWorkflowHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			log.Panic(err)
 		}
-
+		if wf == nil {
+			log.Panic(errors.Errorf("Can't check inputs of workflow %q in deployment %q, workflow definition not found", workflowName, deploymentID))
+		}
 		for inputName, def := range wf.Inputs {
 			// A property is considered as required by default, unless def.Required
 			// is set to false
@@ -204,6 +206,9 @@ func (s *Server) getWorkflowHandler(w http.ResponseWriter, r *http.Request) {
 	wf, err := deployments.GetWorkflow(ctx, deploymentID, workflowName)
 	if err != nil {
 		log.Panic(err)
+	}
+	if wf == nil {
+		log.Panic(errors.Errorf("Can't retrieve workflow %q in deployment %q, workflow definition not found", workflowName, deploymentID))
 	}
 	encodeJSONResponse(w, r, Workflow{Name: workflowName, Workflow: *wf})
 }

--- a/tasks/workflow/builder/builder.go
+++ b/tasks/workflow/builder/builder.go
@@ -37,6 +37,10 @@ func BuildWorkFlow(ctx context.Context, deploymentID, wfName string) (map[string
 		return nil, err
 	}
 
+	if wf == nil {
+		return nil, errors.Errorf("Can't build workflow %q in deployment %q, workflow definition not found", wfName, deploymentID)
+	}
+
 	if wf.Steps == nil || len(wf.Steps) == 0 {
 		return nil, deployments.NewInconsistentDeploymentError(deploymentID)
 	}

--- a/tasks/workflow/step.go
+++ b/tasks/workflow/step.go
@@ -405,6 +405,10 @@ func (s *step) getActivityInputParameters(ctx context.Context, activity builder.
 		return nil, err
 	}
 
+	if wf == nil {
+		return nil, errors.Errorf("Can't retrieve inputs for an activity of workflow %q in deployment %q, workflow definition not found", workflowName, deploymentID)
+	}
+
 	for inputName, propDef := range wf.Inputs {
 
 		if _, ok := result[inputName]; ok {


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Check nil workflows returned by `deployments.GetWorkflow()` and return errors instead of trying to use a nil pointer.

### Description for the changelog

* Panic due to nil pointer dereference may happen when retrieving a workflow ([GH-691](https://github.com/ystia/yorc/issues/691))

## Applicable Issues

Fixes #691 
Back-ported from #692 