### PR TITLE
Fixed the parsing of KEY=VALUE pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### ENHANCEMENTS
 
+* Should be able to specify edcsa or rsa ssh keys in gcloud compute instances metadata ([GH-697](https://github.com/ystia/yorc/issues/697))
 * Add the ability to define OpenStack Compute Instance metadata ([GH-687](https://github.com/ystia/yorc/issues/687))
 * Support Alien4Cloud 3.0 ([GH-689](https://github.com/ystia/yorc/issues/689))
 * Upgrade Ansible version from 2.7.9 to 2.10.0 ([GH-648](https://github.com/ystia/yorc/issues/648))

--- a/deployments/nodes.go
+++ b/deployments/nodes.go
@@ -497,7 +497,7 @@ func GetKeyValuePairsNodeProperty(ctx context.Context, deploymentID, nodeName, p
 		values := strings.Split(strValue.RawString(), ",")
 		result = make(map[string]string, len(values))
 		for _, val := range values {
-			keyValuePair := strings.Split(val, "=")
+			keyValuePair := strings.SplitN(val, "=", 2)
 			if len(keyValuePair) != 2 {
 				return result, errors.Errorf("Expected KEY=VALUE format, got %s for property %s on %s",
 					val, propertyName, nodeName)

--- a/prov/terraform/google/compute_instance_test.go
+++ b/prov/terraform/google/compute_instance_test.go
@@ -17,12 +17,13 @@ package google
 import (
 	"context"
 	"fmt"
-	"github.com/ystia/yorc/v4/storage"
-	"github.com/ystia/yorc/v4/storage/types"
-	"github.com/ystia/yorc/v4/tosca"
 	"io/ioutil"
 	"path"
 	"testing"
+
+	"github.com/ystia/yorc/v4/storage"
+	"github.com/ystia/yorc/v4/storage/types"
+	"github.com/ystia/yorc/v4/tosca"
 
 	"github.com/hashicorp/consul/testutil"
 	"github.com/stretchr/testify/assert"
@@ -84,6 +85,8 @@ func testSimpleComputeInstance(t *testing.T, cfg config.Configuration) {
 
 	assert.Equal(t, []string{"tag1", "tag2"}, compute.Tags)
 	assert.Equal(t, map[string]string{"key1": "value1", "key2": "value2"}, compute.Labels)
+
+	assert.Equal(t, map[string]string{"enable-oslogin": "false", "ssh-keys": "testuser:ecdsa-sha2-nistp256 AAAAE2VjZH/LlTXfXIr+N= test.user@name.org"}, compute.Metadata)
 
 	require.Contains(t, infrastructure.Resource, "null_resource")
 	require.Len(t, infrastructure.Resource["null_resource"], 1)

--- a/prov/terraform/google/testdata/simpleComputeInstance.yaml
+++ b/prov/terraform/google/testdata/simpleComputeInstance.yaml
@@ -22,6 +22,7 @@ topology_template:
         service_account: "yorc@yorc.net"
         tags: "tag1, tag2"
         labels: "key1=value1, key2=value2"
+        metadata: "enable-oslogin=false,ssh-keys=testuser:ecdsa-sha2-nistp256 AAAAE2VjZH/LlTXfXIr+N= test.user@name.org"
         scratch_disks:
           - interface: SCSI
           - interface: NVME


### PR DESCRIPTION
# Pull Request description

## Description of the change

Allowing to specify edcsa or rsa ssh keys (that contain the character `=`) in gcloud compute instances metadata

### What I did

Fixed Yorc parsing of `KEY=VALUE` pairs to allow the use of character `=` in the value.
Added a unit test.

### How to verify it

Specifiy an on-demand Google cloud compute instance resource with a ecdsa or rsa key in its metadata in Alien4Cloud.
Deploy an application provisioning a Google cloud compute instance. Check no error occurs.

### Description for the changelog

Should be able to specify edcsa or rsa ssh keys in gcloud compute instances metadata ([GH-697](https://github.com/ystia/yorc/issues/697))

## Applicable Issues

Fixes #697 
