### PR TITLE
Stop printing ES config at startup (so verbose when TLS enabled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### ENHANCEMENTS
 
+* Remove useless/cluttering logs ([GH-681](https://github.com/ystia/yorc/issues/681))
 * Should be able to specify edcsa or rsa ssh keys in gcloud compute instances metadata ([GH-697](https://github.com/ystia/yorc/issues/697))
 * Add the ability to define OpenStack Compute Instance metadata ([GH-687](https://github.com/ystia/yorc/issues/687))
 * Support Alien4Cloud 3.0 ([GH-689](https://github.com/ystia/yorc/issues/689))

--- a/storage/internal/elastic/es_utils.go
+++ b/storage/internal/elastic/es_utils.go
@@ -83,7 +83,9 @@ func prepareEsClient(elasticStoreConfig elasticStoreConf) (*elasticsearch6.Clien
 	log.Printf("\t- Will %srefresh index before waiting for indexation", willRefresh)
 	log.Printf("\t- While migrating data, the max bulk request size will be %d documents and will never exceed %d kB",
 		elasticStoreConfig.maxBulkCount, elasticStoreConfig.maxBulkSize)
-	log.Printf("\t- Will use this ES client configuration: %+v", esConfig)
+	if log.IsDebug() {
+		log.Printf("\t- Will use this ES client configuration: %+v", esConfig)
+	}
 
 	esClient, e := elasticsearch6.NewClient(esConfig)
 	if e != nil {

--- a/storage/internal/elastic/store.go
+++ b/storage/internal/elastic/store.go
@@ -272,7 +272,7 @@ func (s *elasticStore) verifyLastIndex(indexName string, deploymentID string, es
 // 		- let Yorc eventually Set a document that has a less iid than the older known document in ES (concurrence issues)
 // - if no result if found after the the given 'timeout', return empty slice
 func (s *elasticStore) List(ctx context.Context, k string, waitIndex uint64, timeout time.Duration) ([]store.KeyValueOut, uint64, error) {
-	log.Printf("List called k: %s, waitIndex: %d, timeout: %v", k, waitIndex, timeout)
+	log.Debugf("List called k: %s, waitIndex: %d, timeout: %v", k, waitIndex, timeout)
 	if err := utils.CheckKey(k); err != nil {
 		return nil, 0, err
 	}
@@ -324,7 +324,7 @@ func (s *elasticStore) List(ctx context.Context, k string, waitIndex uint64, tim
 			)
 		}
 	}
-	log.Printf("List called result k: %s, waitIndex: %d, timeout: %v, LastIndex: %d, len(values): %d",
+	log.Debugf("List called result k: %s, waitIndex: %d, timeout: %v, LastIndex: %d, len(values): %d",
 		k, waitIndex, timeout, lastIndex, len(values))
 	return values, lastIndex, err
 }

--- a/storage/internal/elastic/utils.go
+++ b/storage/internal/elastic/utils.go
@@ -74,15 +74,7 @@ func appendJSONInBytes(a []byte, v []byte) []byte {
 func _parseInt64StringToInt64(value string) int64 {
 	valueInt, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
-		log.Print(strings.Repeat("#", 20))
-		log.Print(strings.Repeat("#", 20))
-		log.Print(strings.Repeat("#", 20))
-		log.Print(strings.Repeat("#", 20))
 		log.Printf("Fail parsing _parseInt64StringToInt64 %s", value)
-		log.Print(strings.Repeat("#", 20))
-		log.Print(strings.Repeat("#", 20))
-		log.Print(strings.Repeat("#", 20))
-		log.Print(strings.Repeat("#", 20))
 	}
 	return valueInt
 }


### PR DESCRIPTION
# Pull Request description

ES Store was printing it's config at startup, generating too much output almost when TLS is activated.

## Description of the change

### What I did

We'll now print ES config only in debug mode

Fixes #681 
