### PR TITLE
[Back-port 4.0] Support ssh connection retries

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -256,6 +256,8 @@ func setConfig() {
 	serverCmd.PersistentFlags().String("locations_file_path", "", "File path to locations configuration. This configuration is taken in account for the first time the server starts.")
 	serverCmd.PersistentFlags().Int("concurrency_limit_for_upgrades", config.DefaultUpgradesConcurrencyLimit, "Limit of concurrency used in Upgrade processes. If not set the default value will be used")
 	serverCmd.PersistentFlags().Duration("ssh_connection_timeout", config.DefaultSSHConnectionTimeout, "Timeout to establish SSH connection from Yorc SSH client. If not set the default value will be used")
+	serverCmd.PersistentFlags().Duration("ssh_connection_retry_backoff", config.DefaultSSHConnectionRetryBackoff, "Backoff duration before retrying an ssh connection. This may be superseded by a location attribute if supported.")
+	serverCmd.PersistentFlags().Uint64("ssh_connection_max_retries", config.DefaultSSHConnectionMaxRetries, "Maximum number of retries (attempts are retries + 1) before giving-up to connect. This may be superseded by a location attribute if supported.")
 
 	serverCmd.PersistentFlags().Duration("tasks_dispatcher_long_poll_wait_time", config.DefaultTasksDispatcherLongPollWaitTime, "Wait time when long polling for executions tasks to dispatch to workers")
 	serverCmd.PersistentFlags().Duration("tasks_dispatcher_lock_wait_time", config.DefaultTasksDispatcherLockWaitTime, "Wait time for acquiring a lock for an execution task")
@@ -321,6 +323,8 @@ func setConfig() {
 	viper.BindPFlag("locations_file_path", serverCmd.PersistentFlags().Lookup("locations_file_path"))
 	viper.BindPFlag("concurrency_limit_for_upgrades", serverCmd.PersistentFlags().Lookup("concurrency_limit_for_upgrades"))
 	viper.BindPFlag("ssh_connection_timeout", serverCmd.PersistentFlags().Lookup("ssh_connection_timeout"))
+	viper.BindPFlag("ssh_connection_retry_backoff", serverCmd.PersistentFlags().Lookup("ssh_connection_retry_backoff"))
+	viper.BindPFlag("ssh_connection_max_retries", serverCmd.PersistentFlags().Lookup("ssh_connection_max_retries"))
 
 	viper.BindPFlag("tasks.dispatcher.long_poll_wait_time", serverCmd.PersistentFlags().Lookup("tasks_dispatcher_long_poll_wait_time"))
 	viper.BindPFlag("tasks.dispatcher.lock_wait_time", serverCmd.PersistentFlags().Lookup("tasks_dispatcher_lock_wait_time"))
@@ -364,6 +368,8 @@ func setConfig() {
 	viper.BindEnv("locations_file_path")
 	viper.BindEnv("concurrency_limit_for_upgrades")
 	viper.BindEnv("ssh_connection_timeout")
+	viper.BindEnv("ssh_connection_retry_backoff")
+	viper.BindEnv("ssh_connection_max_retries")
 
 	//Bind Consul environment variables flags
 	for key := range consulConfiguration {
@@ -399,6 +405,8 @@ func setConfig() {
 	viper.SetDefault("disable_ssh_agent", false)
 	viper.SetDefault("concurrency_limit_for_upgrades", config.DefaultUpgradesConcurrencyLimit)
 	viper.SetDefault("ssh_connection_timeout", config.DefaultSSHConnectionTimeout)
+	viper.SetDefault("ssh_connection_retry_backoff", config.DefaultSSHConnectionRetryBackoff)
+	viper.SetDefault("ssh_connection_max_retries", config.DefaultSSHConnectionMaxRetries)
 
 	viper.SetDefault("tasks.dispatcher.long_poll_wait_time", config.DefaultTasksDispatcherLongPollWaitTime)
 	viper.SetDefault("tasks.dispatcher.lock_wait_time", config.DefaultTasksDispatcherLockWaitTime)

--- a/config/config.go
+++ b/config/config.go
@@ -84,6 +84,12 @@ const DefaultUpgradesConcurrencyLimit = 1000
 // DefaultSSHConnectionTimeout is the default timeout for SSH connections
 const DefaultSSHConnectionTimeout = 10 * time.Second
 
+// DefaultSSHConnectionRetryBackoff is the default duration before retring connect for SSH connections
+const DefaultSSHConnectionRetryBackoff = 1 * time.Second
+
+// DefaultSSHConnectionMaxRetries is the default maximum number of retries before giving up (number of attempts is number of retries + 1)
+const DefaultSSHConnectionMaxRetries uint64 = 3
+
 // Configuration holds config information filled by Cobra and Viper (see commands package for more information)
 type Configuration struct {
 	Ansible                          Ansible       `yaml:"ansible,omitempty" mapstructure:"ansible"`
@@ -112,6 +118,8 @@ type Configuration struct {
 	Storage                          Storage       `yaml:"storage,omitempty" mapstructure:"storage"`
 	UpgradeConcurrencyLimit          int           `yaml:"concurrency_limit_for_upgrades,omitempty" mapstructure:"concurrency_limit_for_upgrades"`
 	SSHConnectionTimeout             time.Duration `yaml:"ssh_connection_timeout,omitempty" mapstructure:"ssh_connection_timeout"`
+	SSHConnectionRetryBackoff        time.Duration `yaml:"ssh_connection_retry_backoff,omitempty" mapstructure:"ssh_connection_retry_backoff"`
+	SSHConnectionMaxRetries          uint64        `yaml:"ssh_connection_max_retries,omitempty" mapstructure:"ssh_connection_max_retries"`
 }
 
 // DockerSandbox holds the configuration for a docker sandbox
@@ -298,15 +306,48 @@ func (dm DynamicMap) GetIntOrDefault(name string, defaultValue int) int {
 	return cast.ToInt(dm.Get(name))
 }
 
+// GetInt64OrDefault returns the value of the given key casted into an int64.
+// The given default value is returned if not found.
+func (dm DynamicMap) GetInt64OrDefault(name string, defaultValue int64) int64 {
+	if !dm.IsSet(name) {
+		return defaultValue
+	}
+	return cast.ToInt64(dm.Get(name))
+}
+
 // GetInt64 returns the value of the given key casted into an int64.
 // 0 is returned if not found.
 func (dm DynamicMap) GetInt64(name string) int64 {
 	return cast.ToInt64(dm.Get(name))
 }
 
+// GetUint64OrDefault returns the value of the given key casted into an uint64.
+// The given default value is returned if not found.
+func (dm DynamicMap) GetUint64OrDefault(name string, defaultValue uint64) uint64 {
+	if !dm.IsSet(name) {
+		return defaultValue
+	}
+	return cast.ToUint64(dm.Get(name))
+}
+
+// GetUint64 returns the value of the given key casted into an uint64.
+// 0 is returned if not found.
+func (dm DynamicMap) GetUint64(name string) uint64 {
+	return cast.ToUint64(dm.Get(name))
+}
+
 // GetDuration returns the value of the given key casted into a Duration.
 // A 0 duration is returned if not found.
 func (dm DynamicMap) GetDuration(name string) time.Duration {
+	return cast.ToDuration(dm.Get(name))
+}
+
+// GetDurationOrDefault returns the value of the given key casted into a Duration.
+// The given default value is returned if not found.
+func (dm DynamicMap) GetDurationOrDefault(name string, defaultValue time.Duration) time.Duration {
+	if !dm.IsSet(name) {
+		return defaultValue
+	}
 	return cast.ToDuration(dm.Get(name))
 }
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -214,6 +214,14 @@ Globals Command-line options
 
   * ``--ssh_connection_timeout``: Timeout to establish SSH connection from Yorc SSH client, especially used for Slurm and HostsPool locations. If not set the default value of `10 s` will be used.
 
+.. _option_ssh_connection_retry_backoff_cmd:
+
+  * ``--ssh_connection_retry_backoff``: Backoff duration before retrying an ssh connection. This may be superseded by a location attribute if supported. (default 1s)
+
+.. _option_ssh_connection_max_retries_cmd:
+
+  * ``--ssh_connection_max_retries``: Maximum number of retries (attempts are retries + 1) before giving-up to connect. This may be superseded by a location attribute if supported. (default 3)
+
 
 .. _yorc_config_file_section:
 
@@ -316,6 +324,14 @@ Below is an example of configuration file with TLS enabled.
 .. _option_ssh_connection_timeout_cfg:
 
   * ``ssh_connection_timeout``: Equivalent to :ref:`--ssh_connection_timeout <option_ssh_connection_timeout_cmd>` command-line flag.
+
+.. _option_ssh_connection_retry_backoff_cfg:
+
+  * ``ssh_ssh_connection_retry_backoff``: Equivalent to :ref:`--ssh_ssh_connection_retry_backoff <option_ssh_connection_retry_backoff_cmd>` command-line flag.
+
+.. _option_ssh_connection_max_retries_cfg:
+
+  * ``ssh_connection_max_retries``: Equivalent to :ref:`--ssh_connection_max_retries <option_ssh_connection_max_retries_cmd>` command-line flag.
 
 .. _yorc_config_file_ansible_section:
 
@@ -875,6 +891,14 @@ Environment variables
 
   * ``YORC_SSH_CONNECTION_TIMEOUT``: Equivalent to :ref:`--ssh_connection_timeout <option_ssh_connection_timeout_cmd>` command-line flag.
 
+.. _option_ssh_connection_retry_backoff_env:
+
+  * ``YORC_SSH_CONNECTION_RETRY_BACKOFF``: Equivalent to :ref:`--ssh_connection_retry_backoff <option_ssh_connection_retry_backoff_cmd>` command-line flag.
+
+.. _option_ssh_connection_max_retries_env:
+
+  * ``YORC_SSH_CONNECTION_MAX_RETRIES``: Equivalent to :ref:`--ssh_connection_max_retries <option_ssh_connection_max_retries_cmd>` command-line flag.
+
 .. _option_log_env:
 
   * ``YORC_LOG``: If set to ``1`` or ``DEBUG``, enables debug logging for Yorc.
@@ -1109,28 +1133,40 @@ Slurm
 
 Slurm location type is ``slurm`` in lower case.
 
-+----------------------------------+------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
-|     Property Name                |                          Description                             | Data Type |                     Required                      | Default |
-|                                  |                                                                  |           |                                                   |         |
-+==================================+==================================================================+===========+===================================================+=========+
-| ``user_name``                    | SSH Username to be used to connect to the Slurm Client's node    | string    | yes (see below for alternatives)                  |         |
-+----------------------------------+------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
-| ``password``                     | SSH Password to be used to connect to the Slurm Client's node    | string    | Either this or ``private_key`` should be provided |         |
-+----------------------------------+------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
-| ``private_key``                  | SSH Private key to be used to connect to the Slurm Client's node | string    | Either this or ``password`` should be provided    |         |
-+----------------------------------+------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
-| ``url``                          | IP address of the Slurm Client's node                            | string    | yes                                               |         |
-+----------------------------------+------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
-| ``port``                         | SSH Port to be used to connect to the Slurm Client's node        | string    | yes                                               |         |
-+----------------------------------+------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
-| ``default_job_name``             | Default name for the job allocation.                             | string    | no                                                |         |
-+----------------------------------+------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
-| ``job_monitoring_time_interval`` | Default duration for job monitoring time interval                | string    | no                                                |   5s    |
-+----------------------------------+------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
-| ``enforce_accounting``           | If true, account properties are mandatory for jobs and computes  | boolean   | no                                                |  false  |
-+----------------------------------+------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
-| ``keep_job_remote_artifacts``    | If true, job artifacts are not deleted at the end of the job.    | boolean   | no                                                |  false  |
-+----------------------------------+------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
++----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
+|          Property Name           |                                   Description                                   | Data Type |                     Required                      | Default |
+|                                  |                                                                                 |           |                                                   |         |
++==================================+=================================================================================+===========+===================================================+=========+
+| ``user_name``                    | SSH Username to be used to connect to the Slurm Client's node                   | string    | yes (see below for alternatives)                  |         |
++----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
+| ``password``                     | SSH Password to be used to connect to the Slurm Client's node                   | string    | Either this or ``private_key`` should be provided |         |
++----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
+| ``private_key``                  | SSH Private key to be used to connect to the Slurm Client's node                | string    | Either this or ``password`` should be provided    |         |
++----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
+| ``url``                          | IP address of the Slurm Client's node                                           | string    | yes                                               |         |
++----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
+| ``port``                         | SSH Port to be used to connect to the Slurm Client's node                       | string    | yes                                               |         |
++----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
+| ``default_job_name``             | Default name for the job allocation.                                            | string    | no                                                |         |
++----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
+| ``job_monitoring_time_interval`` | Default duration for job monitoring time interval                               | string    | no                                                | 5s      |
++----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
+| ``enforce_accounting``           | If true, account properties are mandatory for jobs and computes                 | boolean   | no                                                | false   |
++----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
+| ``keep_job_remote_artifacts``    | If true, job artifacts are not deleted at the end of the job.                   | boolean   | no                                                | false   |
++----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
+| ``ssh_connection_timeout``       | Allow to superseded                                                             | Duration  | no                                                | false   |
+|                                  | :ref:`--ssh_connection_timeout <option_ssh_connection_timeout_cmd>`             |           |                                                   |         |
+|                                  | global server option for this specific location.                                |           |                                                   |         |
++----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
+| ``ssh_connection_retry_backoff`` | Allow to superseded                                                             | Duration  | no                                                | false   |
+|                                  | :ref:`--ssh_connection_retry_backoff <option_ssh_connection_retry_backoff_cmd>` |           |                                                   |         |
+|                                  | global server option for this specific location.                                |           |                                                   |         |
++----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
+| ``ssh_connection_max_retries``   | Allow to superseded                                                             | uint64    | no                                                | false   |
+|                                  | :ref:`--ssh_connection_max_retries <option_ssh_connection_max_retries_cmd>`     |           |                                                   |         |
+|                                  | global server option for this specific location.                                |           |                                                   |         |
++----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
 
 An alternative way to specify user credentials for SSH connection to the Slurm Client's node (user_name, password or private_key), is to provide them as application properties.
 In this case, Yorc gives priority to the application provided properties.
@@ -1144,7 +1180,7 @@ Storage configuration
 
 Different artifacts (topologies, logs, events, tasks...) are stored by Yorc during an application deployment.
 
-Previously, everything was stored in Consul KV. 
+Previously, everything was stored in Consul KV.
 Starting with version 4.0.0, we choosed to refactor the way Yorc stores data mainly for performance reasons, and also to make it more flexible.
 Yorc can now store the different kind of artifacts in different ``stores`` configured in a new section of the configuration file called ``storage``.
 
@@ -1235,7 +1271,7 @@ A store configuration is defined with:
 | ``properties``                   | Specific store implementation properties.                        | map       | no               |                 |
 +----------------------------------+------------------------------------------------------------------+-----------+------------------+-----------------+
 
-``migrate_data_from_consul`` allows to migrate data from ``consul`` to another store implementation. 
+``migrate_data_from_consul`` allows to migrate data from ``consul`` to another store implementation.
 This is useful when a new store is configured (different from consul...) for logs or events.
 
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1155,15 +1155,15 @@ Slurm location type is ``slurm`` in lower case.
 +----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
 | ``keep_job_remote_artifacts``    | If true, job artifacts are not deleted at the end of the job.                   | boolean   | no                                                | false   |
 +----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
-| ``ssh_connection_timeout``       | Allow to superseded                                                             | Duration  | no                                                | false   |
+| ``ssh_connection_timeout``       | Allow to supersede                                                              | Duration  | no                                                | false   |
 |                                  | :ref:`--ssh_connection_timeout <option_ssh_connection_timeout_cmd>`             |           |                                                   |         |
 |                                  | global server option for this specific location.                                |           |                                                   |         |
 +----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
-| ``ssh_connection_retry_backoff`` | Allow to superseded                                                             | Duration  | no                                                | false   |
+| ``ssh_connection_retry_backoff`` | Allow to supersede                                                              | Duration  | no                                                | false   |
 |                                  | :ref:`--ssh_connection_retry_backoff <option_ssh_connection_retry_backoff_cmd>` |           |                                                   |         |
 |                                  | global server option for this specific location.                                |           |                                                   |         |
 +----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+
-| ``ssh_connection_max_retries``   | Allow to superseded                                                             | uint64    | no                                                | false   |
+| ``ssh_connection_max_retries``   | Allow to supersede                                                              | uint64    | no                                                | false   |
 |                                  | :ref:`--ssh_connection_max_retries <option_ssh_connection_max_retries_cmd>`     |           |                                                   |         |
 |                                  | global server option for this specific location.                                |           |                                                   |         |
 +----------------------------------+---------------------------------------------------------------------------------+-----------+---------------------------------------------------+---------+

--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/satori/go.uuid v1.0.0
 	github.com/sethgrid/pester v0.0.0-20190127155807-68a33a018ad0 // indirect
+	github.com/sethvargo/go-retry v0.1.0
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cast v1.3.0
 	github.com/spf13/cobra v0.0.6

--- a/go.sum
+++ b/go.sum
@@ -432,6 +432,8 @@ github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516 h1:ofR1ZdrNSkiWcMs
 github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516/go.mod h1:Yow6lPLSAXx2ifx470yD/nUe22Dv5vBvxK/UK9UUTVs=
 github.com/sethgrid/pester v0.0.0-20190127155807-68a33a018ad0 h1:X9XMOYjxEfAYSy3xK1DzO5dMkkWhs9E9UCcS1IERx2k=
 github.com/sethgrid/pester v0.0.0-20190127155807-68a33a018ad0/go.mod h1:Ad7IjTpvzZO8Fl0vh9AzQ+j/jYZfyp2diGwI8m5q+ns=
+github.com/sethvargo/go-retry v0.1.0 h1:8sPqlWannzcReEcYjHSNw9becsiYudcwTD7CasGjQaI=
+github.com/sethvargo/go-retry v0.1.0/go.mod h1:JzIOdZqQDNpPkQDmcqgtteAcxFLtYpNF/zJCM1ysDg8=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/helper/sshutil/server_test.go
+++ b/helper/sshutil/server_test.go
@@ -1,0 +1,172 @@
+// Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sshutil
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/binary"
+	"fmt"
+	"net"
+
+	"github.com/ystia/yorc/v4/log"
+	"golang.org/x/crypto/ssh"
+)
+
+type execCommandHandler func(string) (string, uint32)
+
+func defaultExecCommandHandler(command string) (string, uint32) {
+	return command, 0
+}
+
+type serverConfig struct {
+	*ssh.ServerConfig
+	execCommandHandler execCommandHandler
+}
+
+type sshServerConfigCallback func(*serverConfig)
+
+func newServer(ctx context.Context, cb sshServerConfigCallback) net.Addr {
+
+	// An SSH server is represented by a ServerConfig, which holds
+	// certificate details and handles authentication of ServerConns.
+	config := &ssh.ServerConfig{
+		// Remove to disable password auth.
+		PasswordCallback: func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
+			// Should use constant-time compare (or better, salt+hash) in
+			// a production setting.
+			if c.User() == "testuser" && string(pass) == "tiger" {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("password rejected for %q", c.User())
+		},
+
+		// Remove to disable public key auth.
+		PublicKeyCallback: func(c ssh.ConnMetadata, pubKey ssh.PublicKey) (*ssh.Permissions, error) {
+			return &ssh.Permissions{}, nil
+
+		},
+	}
+
+	config.SetDefaults()
+
+	private, err := rsa.GenerateKey(config.Rand, 4096)
+	if err != nil {
+		log.Fatal("Failed to generate private key: ", err)
+	}
+
+	privateSigner, err := ssh.NewSignerFromKey(private)
+	if err != nil {
+		log.Fatal("Failed to parse private key: ", err)
+	}
+
+	config.AddHostKey(privateSigner)
+
+	serverConfig := &serverConfig{
+		ServerConfig:       config,
+		execCommandHandler: defaultExecCommandHandler,
+	}
+
+	if cb != nil {
+		cb(serverConfig)
+	}
+
+	// Once a ServerConfig has been configured, connections can be
+	// accepted.
+
+	var lc net.ListenConfig
+	listener, err := lc.Listen(ctx, "tcp", "127.0.0.1:")
+	if err != nil {
+		log.Fatal("failed to listen for connection: ", err)
+	}
+	go func() {
+		for {
+			nConn, err := listener.Accept()
+			if err != nil {
+				log.Print("failed to accept incoming connection: ", err)
+				continue
+			}
+
+			// Before use, a handshake must be performed on the incoming
+			// net.Conn.
+			conn, chans, reqs, err := ssh.NewServerConn(nConn, config)
+			if err != nil {
+				log.Print("failed to handshake: ", err)
+				continue
+			}
+
+			// The incoming Request channel must be serviced.
+			go ssh.DiscardRequests(reqs)
+
+			go func() {
+				defer conn.Close()
+
+				// Service the incoming Channel channel.
+				for {
+					var newChannel ssh.NewChannel
+					select {
+					case newChannel = <-chans:
+					case <-ctx.Done():
+						return
+					}
+					// Channels have a type, depending on the application level
+					// protocol intended. In the case of a shell, the type is
+					// "session" and ServerShell may be used to present a simple
+					// terminal interface.
+					if newChannel.ChannelType() != "session" {
+						newChannel.Reject(ssh.UnknownChannelType, "unknown channel type")
+						continue
+					}
+					channel, requests, err := newChannel.Accept()
+					if err != nil {
+						log.Printf("Could not accept channel: %v", err)
+						return
+					}
+
+					// Sessions have out-of-band requests such as "shell",
+					// "pty-req" and "env".  Here we handle only the
+					// "shell" request.
+					go func(in <-chan *ssh.Request) {
+						for req := range in {
+							switch req.Type {
+							case "exec":
+
+								req.Reply(true, nil)
+								var payload = struct{ Command string }{}
+
+								ssh.Unmarshal(req.Payload, &payload)
+
+								result, status := serverConfig.execCommandHandler(payload.Command)
+								channel.Write([]byte(result))
+
+								b := make([]byte, 4)
+								binary.BigEndian.PutUint32(b, status)
+								channel.SendRequest("exit-status", false, b)
+								channel.CloseWrite()
+								channel.Close()
+
+							default:
+								req.Reply(false, nil)
+							}
+						}
+					}(requests)
+
+				}
+
+			}()
+		}
+	}()
+	return listener.Addr()
+}

--- a/helper/sshutil/sshutil.go
+++ b/helper/sshutil/sshutil.go
@@ -115,6 +115,8 @@ func (client *SSHClient) makeRetryFunc(f func(ctx context.Context) error) func()
 			}
 			return f(ctx)
 		})
+		// Unwrap error as we don't want to see retry.retryableError
+		// not my preference but will work (see https://github.com/sethvargo/go-retry/pull/2)
 		return goerr.Unwrap(err)
 	}
 }

--- a/prov/hostspool/hostspool_mgr.go
+++ b/prov/hostspool/hostspool_mgr.go
@@ -17,7 +17,6 @@ package hostspool
 import (
 	"context"
 	"fmt"
-	"github.com/ystia/yorc/v4/config"
 	"path"
 	"reflect"
 	"strconv"
@@ -29,6 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/ystia/yorc/v4/config"
 	"github.com/ystia/yorc/v4/helper/consulutil"
 	"github.com/ystia/yorc/v4/helper/labelsutil"
 	"github.com/ystia/yorc/v4/helper/sshutil"
@@ -77,9 +77,11 @@ type SSHClientFactory func(config *ssh.ClientConfig, conn Connection) sshutil.Cl
 func NewManager(cc *api.Client, cfg config.Configuration) Manager {
 	return NewManagerWithSSHFactory(cc, cfg, func(config *ssh.ClientConfig, conn Connection) sshutil.Client {
 		return &sshutil.SSHClient{
-			Config: config,
-			Host:   conn.Host,
-			Port:   int(conn.Port),
+			Config:       config,
+			Host:         conn.Host,
+			Port:         int(conn.Port),
+			MaxRetries:   cfg.SSHConnectionMaxRetries,
+			RetryBackoff: cfg.SSHConnectionRetryBackoff,
 		}
 	})
 }

--- a/prov/slurm/helper.go
+++ b/prov/slurm/helper.go
@@ -59,7 +59,7 @@ func getSSHClient(cfg config.Configuration, credentials *types.Credential, locat
 	SSHConfig := &ssh.ClientConfig{
 		User:            credentials.User,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Timeout:         cfg.SSHConnectionTimeout,
+		Timeout:         locationProps.GetDurationOrDefault("ssh_connection_timeout", cfg.SSHConnectionTimeout),
 	}
 
 	// Set an authentication method. At least one authentication method
@@ -86,9 +86,11 @@ func getSSHClient(cfg config.Configuration, credentials *types.Credential, locat
 	}
 
 	return &sshutil.SSHClient{
-		Config: SSHConfig,
-		Host:   locationProps.GetString("url"),
-		Port:   port,
+		Config:       SSHConfig,
+		Host:         locationProps.GetString("url"),
+		Port:         port,
+		MaxRetries:   locationProps.GetUint64OrDefault("ssh_connection_max_retries", cfg.SSHConnectionMaxRetries),
+		RetryBackoff: locationProps.GetDurationOrDefault("ssh_connection_retry_backoff", cfg.SSHConnectionRetryBackoff),
 	}, nil
 }
 


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Implemented a retry mechanism for ssh connections

Also slightly changed the connection timeout to just target time for opening a connection not whole time to execute the command

Added the possibility to overwrite general ssh connection timeout and retries in Slurm location config.

### Description for the changelog

* Support ssh connection retries ([GH-688](https://github.com/ystia/yorc/issues/688))

## Applicable Issues

Closes #688 
Back-ported to branch release/4.0 from #700 