### PR TITLE
Feature/gh 703 openstack volume type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### DEPENDENCIES
 
 * The orchestrator requires now at least Ansible 2.10.0 (upgrade from 2.7.9 introduced in [GH-648](https://github.com/ystia/yorc/issues/648))
+* The orchestrator requires now at least Terraform OpenStack Provider version 1.32.0 (upgrade from 1.9.0 introduced in [GH-703](https://github.com/ystia/yorc/issues/703))
+
 
 ### FEATURES
 
@@ -17,6 +19,7 @@
 
 ### ENHANCEMENTS
 
+* Should be able to specify the type of volume when creating an openstack instance ([GH-703](https://github.com/ystia/yorc/issues/703))
 * Remove useless/cluttering logs ([GH-681](https://github.com/ystia/yorc/issues/681))
 * Should be able to specify edcsa or rsa ssh keys in gcloud compute instances metadata ([GH-697](https://github.com/ystia/yorc/issues/697))
 * Add the ability to define OpenStack Compute Instance metadata ([GH-687](https://github.com/ystia/yorc/issues/687))

--- a/data/tosca/yorc-openstack-types.yml
+++ b/data/tosca/yorc-openstack-types.yml
@@ -36,6 +36,10 @@ data_types:
           source=blank and destination=local, or source=blank and destination=volume
         constraints:
           - greater_or_equal: 1 GB
+      volume_type:
+        type: string
+        required: false
+        description: Volume type
       delete_on_termination:
         type: boolean
         required: false

--- a/doc/upgrade.rst
+++ b/doc/upgrade.rst
@@ -50,6 +50,19 @@ Upgrade Ansible to version 2.10.0:
     sudo pip install ansible==2.10.0
     sudo pip install paramiko
 
+Terraform OpenStack Provider
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Terraform OpenStack Provider needs to be upgraded at least to version 1.32.0.
+
+.. code-block:: bash
+
+    # Assuming Terraform providers are stored at /var/terraform/plugins
+    wget https://releases.hashicorp.com/terraform-provider-openstack/1.9.0/terraform-provider-openstack_1.32.0_linux_amd64.zip
+    sudo rm /var/terraform/plugins/terraform-provider-openstack_*
+    sudo unzip terraform-provider-openstack_1.32.0_linux_amd64.zip -d /var/terraform/plugins
+    sudo chmod 775 /var/terraform/plugins/*
+
 .. _yorc_upgrades_320_section:
 
 Upgrading to Yorc 3.2.0

--- a/prov/terraform/openstack/bs_volume.go
+++ b/prov/terraform/openstack/bs_volume.go
@@ -83,7 +83,7 @@ func computeBootVolume(ctx context.Context, deploymentID, nodeName string) (*Boo
 		return nil, err
 	}
 
-	keys := []string{uuidTOSCAKey, destinationTOSCAKey, sizeTOSCAKey, deleteOnTerminationTOSCAKey}
+	keys := []string{uuidTOSCAKey, destinationTOSCAKey, sizeTOSCAKey, volumeTypeTOSCAKey, deleteOnTerminationTOSCAKey}
 	strValues := make(map[string]string, len(keys))
 	for _, key := range keys {
 		strValues[key], err = deployments.GetStringNodePropertyValue(ctx, deploymentID, nodeName, bootVolumeTOSCAAttr, key)
@@ -94,6 +94,8 @@ func computeBootVolume(ctx context.Context, deploymentID, nodeName string) (*Boo
 
 	vol.UUID = strValues[uuidTOSCAKey]
 	vol.Destination = strValues[destinationTOSCAKey]
+	vol.VolumeType = strValues[volumeTypeTOSCAKey]
+
 	if strValues[sizeTOSCAKey] != "" {
 		vol.Size, err = sizeutil.ConvertToGB(strValues[sizeTOSCAKey])
 		if err != nil {

--- a/prov/terraform/openstack/osinstance_test.go
+++ b/prov/terraform/openstack/osinstance_test.go
@@ -145,7 +145,9 @@ func testOSInstanceWithBootVolume(t *testing.T) {
 	assert.Equal(t, 10, compute.BootVolume.Size,
 		"Wrong boot volume size value")
 	assert.Equal(t, true, compute.BootVolume.DeleteOnTermination,
-		"Wrong boot volume deleta on termination value")
+		"Wrong boot volume delete on termination value")
+	assert.Equal(t, "BurstBuffer", compute.BootVolume.VolumeType,
+		"Wrong boot volume type  value")
 
 	assert.Equal(t, "yorc", compute.KeyPair)
 	assert.Equal(t, "2", compute.FlavorID)

--- a/prov/terraform/openstack/resources.go
+++ b/prov/terraform/openstack/resources.go
@@ -26,6 +26,7 @@ const (
 	sourceTOSCAKey              = "source"
 	destinationTOSCAKey         = "destination"
 	sizeTOSCAKey                = "size"
+	volumeTypeTOSCAKey          = "volume_type"
 	deleteOnTerminationTOSCAKey = "delete_on_termination"
 )
 
@@ -54,6 +55,7 @@ type BootVolume struct {
 	Source              string `json:"source_type"`
 	Destination         string `json:"destination_type,omitempty"`
 	Size                int    `json:"volume_size,omitempty"`
+	VolumeType          string `json:"volume_type,omitempty"`
 	DeleteOnTermination bool   `json:"delete_on_termination,omitempty"`
 }
 

--- a/prov/terraform/openstack/testdata/OSInstanceWithBootVolume.yaml
+++ b/prov/terraform/openstack/testdata/OSInstanceWithBootVolume.yaml
@@ -21,6 +21,7 @@ topology_template:
           source: image
           destination: volume
           size: 10 GB
+          volume_type: BurstBuffer
           delete_on_termination: true
       capabilities:
         endpoint:

--- a/versions.yaml
+++ b/versions.yaml
@@ -6,5 +6,5 @@ terraform_version: 0.11.8
 ansible_version: 2.10.0
 tf_consul_plugin_version: 2.1.0
 tf_aws_plugin_version: 1.36.0
-tf_openstack_plugin_version: 1.9.0
+tf_openstack_plugin_version: 1.32.0
 tf_google_plugin_version: 1.18.0


### PR DESCRIPTION
# Pull Request description

## Description of the change

Added the ability to specify the type of boot volume to create when creating an OpenStack compute instance.
Related issue on the Alien4Cloud Yorc provider: https://github.com/alien4cloud/alien4cloud-yorc-provider/issues/24

### What I did

` data/tosca/yorc-openstack-types.yml`:
Added the property volume_type to data type yorc.datatypes.openstack.BootVolume

`versions.yaml `
Requiring the terrafrom openstack provider version 1.32.0 as the version 1.9.0 we used until now does not support the volume type property.


### Description for the changelog

Should be able to specify the type of volume when creating an openstack instance ([GH-703](https://github.com/ystia/yorc/issues/703))

## Applicable Issues

Closes #703 
