### PR TITLE
Backport40/feature/gh 715 dispatcher metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 go:
   - stable
 
-dist: trusty
+dist: xenial
 sudo: required
 
 services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### ENHANCEMENTS
+
+* Added a tasks dispatcher metrics refresh time configuration parameter ([GH-715](https://github.com/ystia/yorc/issues/715))
+
 ## 4.0.4 (October 23, 2020)
 
 ### ENHANCEMENTS

--- a/commands/server.go
+++ b/commands/server.go
@@ -261,6 +261,7 @@ func setConfig() {
 
 	serverCmd.PersistentFlags().Duration("tasks_dispatcher_long_poll_wait_time", config.DefaultTasksDispatcherLongPollWaitTime, "Wait time when long polling for executions tasks to dispatch to workers")
 	serverCmd.PersistentFlags().Duration("tasks_dispatcher_lock_wait_time", config.DefaultTasksDispatcherLockWaitTime, "Wait time for acquiring a lock for an execution task")
+	serverCmd.PersistentFlags().Duration("tasks_dispatcher_metrics_refresh_time", config.DefaultTasksDispatcherMetricsRefreshTime, "Tasks dispatcher metrics refresh time")
 
 	// Flags definition for Yorc HTTP REST API
 	serverCmd.PersistentFlags().Int("http_port", config.DefaultHTTPPort, "Port number for the Yorc HTTP REST API. If omitted or set to '0' then the default port number is used, any positive integer will be used as it, and finally any negative value will let use a random port.")
@@ -328,6 +329,7 @@ func setConfig() {
 
 	viper.BindPFlag("tasks.dispatcher.long_poll_wait_time", serverCmd.PersistentFlags().Lookup("tasks_dispatcher_long_poll_wait_time"))
 	viper.BindPFlag("tasks.dispatcher.lock_wait_time", serverCmd.PersistentFlags().Lookup("tasks_dispatcher_lock_wait_time"))
+	viper.BindPFlag("tasks.dispatcher.metrics_refresh_time", serverCmd.PersistentFlags().Lookup("tasks_dispatcher_metrics_refresh_time"))
 
 	//Bind Flags Yorc HTTP REST API
 	viper.BindPFlag("http_port", serverCmd.PersistentFlags().Lookup("http_port"))
@@ -380,6 +382,7 @@ func setConfig() {
 	viper.BindEnv("purged_deployments_eviction_timeout")
 	viper.BindEnv("tasks.dispatcher.long_poll_wait_time")
 	viper.BindEnv("tasks.dispatcher.lock_wait_time")
+	viper.BindEnv("tasks.dispatcher.metrics_refresh_time")
 
 	//Bind Ansible environment variables flags
 	for key := range ansibleConfiguration {
@@ -410,6 +413,7 @@ func setConfig() {
 
 	viper.SetDefault("tasks.dispatcher.long_poll_wait_time", config.DefaultTasksDispatcherLongPollWaitTime)
 	viper.SetDefault("tasks.dispatcher.lock_wait_time", config.DefaultTasksDispatcherLockWaitTime)
+	viper.SetDefault("tasks.dispatcher.metrics_refresh_time", config.DefaultTasksDispatcherMetricsRefreshTime)
 
 	// Consul configuration default settings
 	for key, value := range consulConfiguration {

--- a/config/config.go
+++ b/config/config.go
@@ -78,6 +78,9 @@ const DefaultTasksDispatcherLongPollWaitTime = 1 * time.Minute
 // DefaultTasksDispatcherLockWaitTime is the default wait time for acquiring a lock for an execution task
 const DefaultTasksDispatcherLockWaitTime = 50 * time.Millisecond
 
+// DefaultTasksDispatcherMetricsRefreshTime is the default refresh time for the Tasks dispatcher metrics
+const DefaultTasksDispatcherMetricsRefreshTime = 5 * time.Minute
+
 // DefaultUpgradesConcurrencyLimit is the default limit of concurrency used in Upgrade processes
 const DefaultUpgradesConcurrencyLimit = 1000
 
@@ -203,8 +206,9 @@ type Tasks struct {
 
 // Dispatcher configuration
 type Dispatcher struct {
-	LongPollWaitTime time.Duration `yaml:"long_poll_wait_time,omitempty" mapstructure:"long_poll_wait_time" json:"long_poll_wait_time,omitempty"`
-	LockWaitTime     time.Duration `yaml:"lock_wait_time,omitempty" mapstructure:"lock_wait_time" json:"lock_wait_time,omitempty"`
+	LongPollWaitTime   time.Duration `yaml:"long_poll_wait_time,omitempty" mapstructure:"long_poll_wait_time" json:"long_poll_wait_time,omitempty"`
+	LockWaitTime       time.Duration `yaml:"lock_wait_time,omitempty" mapstructure:"lock_wait_time" json:"lock_wait_time,omitempty"`
+	MetricsRefreshTime time.Duration `yaml:"metrics_refresh_time,omitempty" mapstructure:"metrics_refresh_time" json:"metrics_refresh_time,omitempty"`
 }
 
 // Storage configuration

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -190,6 +190,10 @@ Globals Command-line options
 
   * ``--tasks_dispatcher_lock_wait_time``: Wait time (Golang duration format) for acquiring a lock for an execution task. If not set the default value of `50ms` will be used.
 
+.. _option_tasks_dispatcher_metrics_refresh_time_cmd:
+
+  * ``--tasks_dispatcher_metrics_refresh_time``: Refresh time (Golang duration format) for the tasks dispatcher metrics. If not set the default value of `5m` will be used.
+
 .. _option_workers_cmd:
 
   * ``--workers_number``: Yorc instances use a pool of workers to handle deployment tasks. This option defines the size of this pool. If not set the default value of `30` will be used.
@@ -719,6 +723,7 @@ Below is an example of configuration file with Tasks configuration options.
       dispatcher:
         long_polling_wait_time: "1m"
         lock_wait_time: "50ms"
+        metrics_refresh_time: "5m"
 
 .. _option_tasks_dispatcher_long_polling_wait_time_cfg:
 
@@ -727,6 +732,9 @@ Below is an example of configuration file with Tasks configuration options.
 .. _option_tasks_dispatcher_lock_wait_time_cfg:
 
   * ``lock_wait_time``: Equivalent to :ref:`--tasks_dispatcher_lock_wait_time <option_tasks_dispatcher_lock_wait_time_cmd>` command-line flag.
+
+.. _option_tasks_dispatcher_metrics_refresh_time_cfg:
+  * ``metrics_refresh_time``: Equivalent to :ref:`--tasks_dispatcher_metrics_refresh_time <option_tasks_dispatcher_metrics_refresh_time_cmd>` command-line flag.
 
 Environment variables
 ---------------------
@@ -866,6 +874,10 @@ Environment variables
 .. _option_tasks_dispatcher_lock_wait_time_env:
 
   * ``YORC_TASKS_DISPATCHER_LOCK_WAIT_TIME``: Equivalent to :ref:`--tasks_dispatcher_lock_wait_time <option_tasks_dispatcher_lock_wait_time_cmd>` command-line flag.
+
+.. _option_tasks_dispatcher_metrics_refresh_time_env:
+
+  * ``YORC_TASKS_DISPATCHER_METRICS_REFRESH_TIME``: Equivalent to :ref:`--tasks_dispatcher_metrics_refresh_time <option_tasks_dispatcher_metrics_refresh_time_cmd>` command-line flag.
 
 .. _option_workers_env:
 

--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -1,4 +1,4 @@
-FROM ystia/alpine-consul:1.0.4_consul-1.2.3
+FROM ystia/alpine-consul:1.1.0_consul-1.2.3
 ARG TERRAFORM_VERSION
 ARG ANSIBLE_VERSION
 ARG TF_CONSUL_PLUGIN_VERSION

--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -22,8 +22,6 @@ RUN apk add --update make openssh-client python3 python3-dev gcc musl-dev libffi
     python3 -m ensurepip --upgrade && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
     if [ ! -e /usr/bin/python ]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
-    mkdir /tmp/docker && apk fetch -o /tmp/docker docker && \
-    tar xzf /tmp/docker/*.apk -C / usr/bin/docker && \
     pip install ansible==${ANSIBLE_VERSION} docker-py netaddr jmespath && \
     cd /tmp && \
     curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \

--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -18,7 +18,7 @@ ADD rootfs /
 
 # Python is required here as it should not be removed automatically when uninstalling python-dev
 # We do not install the whole docker package we download the package and extract only the client
-RUN apk add --update make openssh-client python3 python3-dev gcc musl-dev libffi-dev openssl-dev && \
+RUN apk add --update make openssh-client python3 python3-dev gcc musl-dev libffi-dev openssl-dev cargo rust && \
     python3 -m ensurepip --upgrade && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
     if [ ! -e /usr/bin/python ]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \

--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -19,7 +19,7 @@ ADD rootfs /
 # Python is required here as it should not be removed automatically when uninstalling python-dev
 # We do not install the whole docker package we download the package and extract only the client
 RUN apk add --update make openssh-client python3 python3-dev gcc musl-dev libffi-dev openssl-dev && \
-    python3 -m ensurepip && \
+    python3 -m ensurepip --upgrade && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
     if [ ! -e /usr/bin/python ]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
     mkdir /tmp/docker && apk fetch -o /tmp/docker docker && \

--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -17,8 +17,8 @@ ENV YORC_TERRAFORM_PLUGINS_DIR /var/terraform/plugins
 ADD rootfs /
 
 # Python is required here as it should not be removed automatically when uninstalling python-dev
-# We do not install the whole docker package we download the package and extract only the client
-RUN apk add --update make openssh-client python3 python3-dev gcc musl-dev libffi-dev openssl-dev cargo rust && \
+# We do not install the whole docker package but just docker-cli
+RUN apk add --update make openssh-client python3 python3-dev gcc musl-dev libffi-dev openssl-dev docker-cli cargo rust && \
     python3 -m ensurepip --upgrade && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
     if [ ! -e /usr/bin/python ]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
@@ -50,7 +50,7 @@ RUN apk add --update make openssh-client python3 python3-dev gcc musl-dev libffi
     unzip terraform-provider-openstack_${TF_OPENSTACK_PLUGIN_VERSION}_linux_amd64.zip && \
     chmod 775 ${YORC_TERRAFORM_PLUGINS_DIR}/* && \
     echo "Cleaning up" && \
-    apk del make py-pip python-dev gcc musl-dev libffi-dev openssl-dev && \
+    apk del make py-pip python3-dev gcc musl-dev libffi-dev openssl-dev && \
     rm -rf /var/cache/apk/* && \
     rm -fr /tmp/*
 

--- a/tasks/workflow/dispatcher.go
+++ b/tasks/workflow/dispatcher.go
@@ -82,7 +82,7 @@ func (d *Dispatcher) emitMetrics(client *api.Client) {
 		lastWarn := time.Now().Add(-6 * time.Minute)
 		for {
 			select {
-			case <-time.After(time.Second):
+			case <-time.After(d.cfg.Tasks.Dispatcher.MetricsRefreshTime):
 				d.emitWorkersMetrics()
 				d.emitTaskExecutionsMetrics(client, &lastWarn)
 			case <-d.shutdownCh:

--- a/tasks/workflow/dispatcher_test.go
+++ b/tasks/workflow/dispatcher_test.go
@@ -87,8 +87,9 @@ func testDispatcherRun(t *testing.T, srv *testutil.TestServer, client *api.Clien
 		},
 		Tasks: config.Tasks{
 			Dispatcher: config.Dispatcher{
-				LongPollWaitTime: 50 * time.Millisecond,
-				LockWaitTime:     5 * time.Millisecond,
+				LongPollWaitTime:   50 * time.Millisecond,
+				LockWaitTime:       5 * time.Millisecond,
+				MetricsRefreshTime: 50 * time.Millisecond,
 			},
 		},
 	}


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

To avoid huge consul disk writes, even when no workflow execution occurs, due to the emission of dispatcher metrics every second,
added a tasks dispatcher metrics refresh time configuration parameter, with a default value of 5 minutes.

### How to verify it

Install Yorc and deploy an application on it. Once the deployment is done, run this consul command to monitor its write activity:

```
consul monitor -log-level debug | grep PUT | grep _yorc
```
Check we don't see anymore the writes coming from the emisssion of dispatcher metrics as described in issue #715 

### Description for the changelog

Added a tasks dispatcher metrics refresh time configuration parameter ([GH-715](https://github.com/ystia/yorc/issues/715))

## Applicable Issues

Fixes #715 
Backported from #716 
