### PR TITLE
[Backport 4.0] Fix Bintray sunsetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Can't bootstrap Yorc as BinTray is now unavailable ([GH-727](https://github.com/ystia/yorc/issues/727))
+
 ## 4.0.5 (March 22, 2021)
 
 ### ENHANCEMENTS

--- a/commands/bootstrap/inputs.go
+++ b/commands/bootstrap/inputs.go
@@ -1552,7 +1552,7 @@ func getYorcDownloadURL() string {
 			yorcVersion)
 	} else {
 		downloadURL = fmt.Sprintf(
-			"https://dl.bintray.com/ystia/yorc-engine/%s/yorc-%s.tgz",
+			"https://github.com/ystia/yorc/releases/download/v%s/yorc-%s.tgz",
 			yorcVersion, yorcVersion)
 	}
 	return downloadURL


### PR DESCRIPTION
# Pull Request description

## Description of the change

Download binaries from GitHub instead of BinTray.

All releases present in Artifactory are now on GH Releases.

### Description for the changelog

* Can't bootstrap Yorc as BinTray is now unavailable ([GH-727](https://github.com/ystia/yorc/issues/727))

## Applicable Issues

Fixes #727 
Backport of #728 