### PR TITLE
[Backport 4.1] Fix Bintray sunsetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## UNRELEASED
 
+### ENHANCEMENTS
+
+* Support Alien4Cloud 3.2.0 ([GH-723](https://github.com/ystia/yorc/issues/723))
+
+### BUG FIXES
+
+* Can't bootstrap Yorc as BinTray is now unavailable ([GH-727](https://github.com/ystia/yorc/issues/727))
+
 ## 4.1.0 (April 11, 2021)
 
 ### DEPENDENCIES

--- a/commands/bootstrap/inputs.go
+++ b/commands/bootstrap/inputs.go
@@ -1552,7 +1552,7 @@ func getYorcDownloadURL() string {
 			yorcVersion)
 	} else {
 		downloadURL = fmt.Sprintf(
-			"https://dl.bintray.com/ystia/yorc-engine/%s/yorc-%s.tgz",
+			"https://github.com/ystia/yorc/releases/download/v%s/yorc-%s.tgz",
 			yorcVersion, yorcVersion)
 	}
 	return downloadURL


### PR DESCRIPTION
# Pull Request description

## Description of the change

Download binaries from GitHub instead of BinTray.

All releases present in Artifactory are now on GH Releases.

### Description for the changelog

* Can't bootstrap Yorc as BinTray is now unavailable ([GH-727](https://github.com/ystia/yorc/issues/727))

## Applicable Issues

Fixes #727 
Backport of #728 