### PR TITLE
Bugfix/gh 733 action no stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Workflow with asynchronous action never stops after another step failure  ([GH-733](https://github.com/ystia/yorc/issues/733))
+
 ## 4.2.0-milestone.1 (May 06, 2021)
 
 ### ENHANCEMENTS

--- a/prov/scheduling/scheduler/consul_test.go
+++ b/prov/scheduling/scheduler/consul_test.go
@@ -71,5 +71,8 @@ func TestRunConsulSchedulingPackageTests(t *testing.T) {
 		t.Run("testUnregisterAction", func(t *testing.T) {
 			testUnregisterAction(t, client)
 		})
+		t.Run("testUpdateActionData", func(t *testing.T) {
+			testUpdateActionData(t, client)
+		})
 	})
 }

--- a/tasks/workflow/worker.go
+++ b/tasks/workflow/worker.go
@@ -447,6 +447,7 @@ func (w *worker) runAction(ctx context.Context, t *taskExecution) error {
 		}
 	}
 	wasCancelled := new(bool)
+	taskFailure := new(bool)
 	if action.AsyncOperation.TaskID != "" {
 		ctx = operations.SetOperationLogFields(ctx, action.AsyncOperation.Operation)
 		ctx = events.AddLogOptionalFields(ctx, events.LogOptionalFields{
@@ -467,6 +468,7 @@ func (w *worker) runAction(ctx context.Context, t *taskExecution) error {
 			tasks.UpdateTaskStepWithStatus(action.AsyncOperation.TaskID, action.AsyncOperation.StepName, tasks.TaskStepStatusCANCELED)
 		})
 		tasks.MonitorTaskFailure(ctx, action.AsyncOperation.TaskID, func() {
+			*taskFailure = true
 			// Unregister this action asap to prevent new schedulings
 			scheduling.UnregisterAction(w.consulClient, action.ID)
 
@@ -494,6 +496,9 @@ func (w *worker) runAction(ctx context.Context, t *taskExecution) error {
 	deregister, err := operator.ExecAction(ctx, w.cfg, t.taskID, t.targetID, action)
 	if deregister || *wasCancelled {
 		scheduling.UnregisterAction(w.consulClient, action.ID)
+		w.endAction(ctx, t, action, *wasCancelled, err)
+	} else if *taskFailure {
+		err = errors.Errorf("Stopped on task failure")
 		w.endAction(ctx, t, action, *wasCancelled, err)
 	}
 	if err != nil {


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fixed an issue where a workflow will be seen running forever when a synchronous step failed while an asynchronous run action is taking place at the same time. The asynchronous action was unscheduled as expected but its status was not updated and was seen as running forever.

Fixed also an issue when the asynchronous action is updating its action data: there was no check to see if the action has been unregistered, and the action data was added, leaving an isolated key in consul.

### What I did

`prov/scheduling/scheduler/consul_test.go`
`prov/scheduling/scheduler/scheduler_test.go`:
Added a test on UpdateActionData()

`prov/scheduling/scheduling.go`:
Updating action data only when the action data deploymentID key exists

`tasks/workflow/worker.go`:
On task failure, call endAction()


### Description for the changelog

Workflow with asynchronous action never stops after another step failure  ([GH-733](https://github.com/ystia/yorc/issues/733))

## Applicable Issues

Closes #733 

