### PR TITLE
Added openstack compute instance user_data property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### ENHANCEMENTS
+
+* Add the ability to define OpenStack Compute Instance user_data ([GH-735](https://github.com/ystia/yorc/issues/735))
+
 ### BUG FIXES
 
 * Workflow with asynchronous action never stops after another step failure  ([GH-733](https://github.com/ystia/yorc/issues/733))

--- a/data/tosca/yorc-openstack-types.yml
+++ b/data/tosca/yorc-openstack-types.yml
@@ -3,7 +3,7 @@ tosca_definitions_version: yorc_tosca_simple_yaml_1_0
 metadata:
   template_name: yorc-openstack-types
   template_author: yorc
-  template_version: 1.2.1
+  template_version: 1.3.0
 
 imports:
   - yorc: <yorc-types.yml>
@@ -143,6 +143,10 @@ node_types:
         description: Metadata key/value pairs to make available from within the instance
         entry_schema:
           type: string
+        required: false
+      user_data:
+        type: string
+        description: User data to provide when launching the instance
         required: false
     requirements:
       - group:

--- a/prov/terraform/openstack/osinstance.go
+++ b/prov/terraform/openstack/osinstance.go
@@ -172,10 +172,13 @@ func generateComputeInstance(ctx context.Context, opts osInstanceOptions) (Compu
 	if toscaVal != nil && toscaVal.RawString() != "" {
 		err = json.Unmarshal([]byte(toscaVal.RawString()), &instance.Metadata)
 		if err != nil {
-			err = errors.Wrapf(err, "Expected a map of strings for the metadata value of node %s instance %s, got: %s",
+			return instance, errors.Wrapf(err, "Expected a map of strings for the metadata value of node %s instance %s, got: %s",
 				opts.nodeName, opts.instanceName, toscaVal.RawString())
 		}
 	}
+
+	instance.UserData, err = deployments.GetStringNodeProperty(ctx, opts.deploymentID,
+		opts.nodeName, "user_data", false)
 
 	return instance, err
 }

--- a/prov/terraform/openstack/osinstance_test.go
+++ b/prov/terraform/openstack/osinstance_test.go
@@ -97,7 +97,7 @@ func testSimpleOSInstance(t *testing.T) {
 	require.Len(t, compute.Metadata, 2)
 	require.Equal(t, "firstValue", compute.Metadata["firstKey"])
 	require.Equal(t, "secondValue", compute.Metadata["secondKey"])
-
+	require.Contains(t, compute.UserData, "cloud-config")
 	require.Len(t, compute.Provisioners, 0)
 	require.Contains(t, infrastructure.Resource, "null_resource")
 	require.Len(t, infrastructure.Resource["null_resource"], 1)

--- a/prov/terraform/openstack/resources.go
+++ b/prov/terraform/openstack/resources.go
@@ -46,6 +46,7 @@ type ComputeInstance struct {
 	KeyPair          string            `json:"key_pair,omitempty"`
 	SchedulerHints   SchedulerHints    `json:"scheduler_hints,omitempty"`
 	Metadata         map[string]string `json:"metadata,omitempty"`
+	UserData         string            `json:"user_data,omitempty"`
 	commons.Resource
 }
 

--- a/prov/terraform/openstack/testdata/simpleOSInstance.yaml
+++ b/prov/terraform/openstack/testdata/simpleOSInstance.yaml
@@ -26,6 +26,7 @@ topology_template:
         key_pair: yorc
         security_groups: openbar,default
         metadata: {get_input: vm_metadata}
+        user_data: "#cloud-config\nwrite_files:\n- content: |\n    test\n  owner: root:root\n  path: /etc/test.txt\n  permissions: '0644'"
       capabilities:
         endpoint:
           properties:


### PR DESCRIPTION
# Pull Request description

## Description of the change

The OpenStack API provides a Compute Instance property `user_data` allowing to provide configuration information or scripts used by cloud-init.
Added the corresponding property in Yorc TOSCA type for OpenStack compute instances.


### What I did

`data/tosca/yorc-openstack-types.yml`
Added the property `user_data` to the TOSCA type `yorc.nodes.openstack.Compute` and increased the minor version

`prov/terraform/openstack/osinstance.go`
Getting the compute instance user_data value from the topology

`prov/terraform/openstack/osinstance_test.go`
Added a test on this new property

`prov/terraform/openstack/resources.go`
Added a field UserData to the golang type used for an OpenStack Compute instance

`prov/terraform/openstack/testdata/simpleOSInstance.yaml `
Added the new property in a topology used in tests

### Description for the changelog

Add the ability to define OpenStack Compute Instance user_data ([GH-735](https://github.com/ystia/yorc/issues/735))

## Applicable Issues

Closes #735

Associated issue on Alien4Cloud Yorc provider: https://github.com/alien4cloud/alien4cloud-yorc-provider/pull/26
