### PR TITLE
[Backport 4.0] Workflow with asynchronous action never stops after another step failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Workflow with asynchronous action never stops after another step failure  ([GH-733](https://github.com/ystia/yorc/issues/733))
+
 ## 4.0.6 (May 06, 2021)
 
 ### BUG FIXES

--- a/prov/scheduling/scheduler/consul_test.go
+++ b/prov/scheduling/scheduler/consul_test.go
@@ -71,5 +71,8 @@ func TestRunConsulSchedulingPackageTests(t *testing.T) {
 		t.Run("testUnregisterAction", func(t *testing.T) {
 			testUnregisterAction(t, client)
 		})
+		t.Run("testUpdateActionData", func(t *testing.T) {
+			testUpdateActionData(t, client)
+		})
 	})
 }


### PR DESCRIPTION
# Pull Request description

Backport to 4.0 of pull request https://github.com/ystia/yorc/pull/734

## Description of the change

Fixed an issue where a workflow will be seen running forever when a synchronous step failed while an asynchronous run action is taking place at the same time. The asynchronous action was unscheduled as expected but its status was not updated and was seen as running forever.

Fixed also an issue when the asynchronous action is updating its action data: there was no check to see if the action has been unregistered, and the action data was added, leaving an isolated key in consul.

### What I did

`prov/scheduling/scheduler/consul_test.go`
`prov/scheduling/scheduler/scheduler_test.go`:
Added a test on UpdateActionData()

`prov/scheduling/scheduling.go`:
Updating action data only when the action data deploymentID key exists

`tasks/workflow/worker.go`:
On task failure, call endAction()


### Description for the changelog

Workflow with asynchronous action never stops after another step failure  ([GH-733](https://github.com/ystia/yorc/issues/733))

## Applicable Issues

Closes #733 
Backported from #734
