### PR TITLE
Bugfix/gh 739 slurm execution option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### BUG FIXES
 
+* Error submitting a SLURM job with no execution option ([GH-739](https://github.com/ystia/yorc/issues/739))
 * Workflow with asynchronous action never stops after another step failure  ([GH-733](https://github.com/ystia/yorc/issues/733))
 
 ## 4.2.0-milestone.1 (May 06, 2021)

--- a/prov/slurm/execution.go
+++ b/prov/slurm/execution.go
@@ -380,7 +380,7 @@ func (e *executionCommon) buildJobInfo(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if eo != nil && eo.Value != nil {
+	if eo != nil && eo.RawString() != "" {
 		err = mapstructure.Decode(eo.Value, &e.jobInfo.ExecutionOptions)
 		if err != nil {
 			return errors.Wrapf(err, `invalid execution options datatype for attribute "execution_options" for node %q`, e.NodeName)


### PR DESCRIPTION
# Pull Request description

## Description of the change

Checking the TOSCA value raw string to find if the SLURM job property `execution_options` is defined

### Description for the changelog

Error submitting a SLURM job with no execution option ([GH-739](https://github.com/ystia/yorc/issues/739))

## Applicable Issues

Fixes #739 
