### PR TITLE
[Backport 4.0] Checking TOSCA value RawString() to see if property execution_option is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Error submitting a SLURM job with no execution option ([GH-739](https://github.com/ystia/yorc/issues/739))
+
 ## 4.0.7 (May 19, 2021)
 
 ### BUG FIXES

--- a/prov/slurm/execution.go
+++ b/prov/slurm/execution.go
@@ -379,7 +379,7 @@ func (e *executionCommon) buildJobInfo(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if eo != nil && eo.Value != nil {
+	if eo != nil && eo.RawString() != "" {
 		err = mapstructure.Decode(eo.Value, &e.jobInfo.ExecutionOptions)
 		if err != nil {
 			return errors.Wrapf(err, `invalid execution options datatype for attribute "execution_options" for node %q`, e.NodeName)


### PR DESCRIPTION
# Pull Request description

Backport of pull request #740 to 4.0

## Description of the change

Checking the TOSCA value raw string to find if the SLURM job property `execution_options` is defined

### Description for the changelog

Error submitting a SLURM job with no execution option ([GH-739](https://github.com/ystia/yorc/issues/739))

## Applicable Issues

Fixes #739 
Backported from #740
