### PR TITLE
Fixed name of variable containing the error of script output hander stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### BUG FIXES
 
+* Yorc panics attempting to print an error handling a script execution stdout ([GH-741](https://github.com/ystia/yorc/issues/741))
 * Error submitting a SLURM job with no execution option ([GH-739](https://github.com/ystia/yorc/issues/739))
 * Workflow with asynchronous action never stops after another step failure  ([GH-733](https://github.com/ystia/yorc/issues/733))
 

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -1267,7 +1267,7 @@ func (e *executionCommon) executePlaybook(ctx context.Context, retry bool,
 
 	err := cmd.Run()
 	if handlerErr := handler.stop(); handlerErr != nil {
-		log.Printf("Error stopping output handler: %s", err.Error())
+		log.Printf("Error stopping output handler: %s", handlerErr.Error())
 	}
 	if err != nil {
 		return e.checkAnsibleRetriableError(ctx, err)


### PR DESCRIPTION
# Pull Request description

## Description of the change

Fixed a log that was attempting to print the wrong error variable name.

Such an error of handler stop only happens in the case of Yorc premium, when it is getting the outputs of a script execution live, and after the script execution is done and yorc stops the handling to this script output, it gets an error when it attempts to close a ssh session.

### Description for the changelog

Yorc panics attempting to print an error handling a script execution stdout ([GH-741](https://github.com/ystia/yorc/issues/741))

## Applicable Issues

Fixes #741 
