### PR TITLE
[backport 40] Fix Consul connections over consumtion on task monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### BUG FIXES
 
+* Over-consumption of Consul connections ([GH-745](https://github.com/ystia/yorc/issues/745))
 * Yorc panics attempting to print an error handling a script execution stdout ([GH-741](https://github.com/ystia/yorc/issues/741))
 * Error submitting a SLURM job with no execution option ([GH-739](https://github.com/ystia/yorc/issues/739))
 

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -625,15 +625,11 @@ func MonitorTaskFailure(ctx context.Context, taskID string, f func()) {
 func monitorTaskFlag(ctx context.Context, taskID, flag string, value []byte, f func()) {
 	go func() {
 		var lastIndex uint64
+		queryMeta := &api.QueryOptions{}
+		queryMeta = queryMeta.WithContext(ctx)
 		for {
-			select {
-			case <-ctx.Done():
-				log.Debugf("Task monitoring for flag %s exit", flag)
-				return
-			default:
-			}
-
-			kvp, qMeta, err := consulutil.GetKV().Get(path.Join(consulutil.TasksPrefix, taskID, flag), &api.QueryOptions{WaitIndex: lastIndex})
+			queryMeta.WaitIndex = lastIndex
+			kvp, qMeta, err := consulutil.GetKV().Get(path.Join(consulutil.TasksPrefix, taskID, flag), queryMeta)
 
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Just added the context to the consul query options.
This context is then passed to the http request used by the Consul client and finally can be used for request cancellation

### How to verify it

Generate a high load of job monitoring actions for exemple by using a monitoring interval of `0.5s` and monitor the consul connections using for instance `lsof`. It should remain constant

### Description for the changelog

* Over-consumption of Consul connections ([GH-745](https://github.com/ystia/yorc/issues/745))

## Applicable Issues

Fixes #745
Backported from PR #746