### PR TITLE
[Backport 4.1] Checking TOSCA value RawString() to see if property execution_option is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,9 @@
 ### BUG FIXES
 
 * Over-consumption of Consul connections ([GH-745](https://github.com/ystia/yorc/issues/745))
+* Error submitting a SLURM job with no execution option ([GH-739](https://github.com/ystia/yorc/issues/739))
 
 ## 4.1.1 (May 06, 2021)
-
-### ENHANCEMENTS
-
-* Support Alien4Cloud 3.2.0 ([GH-723](https://github.com/ystia/yorc/issues/723))
 
 ### BUG FIXES
 

--- a/prov/slurm/execution.go
+++ b/prov/slurm/execution.go
@@ -380,7 +380,7 @@ func (e *executionCommon) buildJobInfo(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if eo != nil && eo.Value != nil {
+	if eo != nil && eo.RawString() != "" {
 		err = mapstructure.Decode(eo.Value, &e.jobInfo.ExecutionOptions)
 		if err != nil {
 			return errors.Wrapf(err, `invalid execution options datatype for attribute "execution_options" for node %q`, e.NodeName)


### PR DESCRIPTION
# Pull Request description

Backport of pull request #740 to 4.1

## Description of the change

Checking the TOSCA value raw string to find if the SLURM job property `execution_options` is defined

### Description for the changelog

Error submitting a SLURM job with no execution option ([GH-739](https://github.com/ystia/yorc/issues/739))

## Applicable Issues

Fixes #739 
Backported from #740
