### PR TITLE
Workflows steps replays on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### FEATURES
+
+* Workflows steps replays on error  ([GH-753](https://github.com/ystia/yorc/issues/753))
+
 ### ENHANCEMENTS
 
 * Add basic support for ssh on Windows ([GH-751](https://github.com/ystia/yorc/issues/751))

--- a/commands/deployments/tasks/dep_fix_task_step.go
+++ b/commands/deployments/tasks/dep_fix_task_step.go
@@ -15,18 +15,9 @@
 package tasks
 
 import (
-	"bytes"
-	"encoding/json"
-	"log"
-	"net/http"
-	"path"
-	"strings"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/ystia/yorc/v4/commands/deployments"
-	"github.com/ystia/yorc/v4/commands/httputil"
 	"github.com/ystia/yorc/v4/tasks"
 )
 
@@ -35,40 +26,18 @@ func init() {
 }
 
 var updateTaskStepCmd = &cobra.Command{
-	Use:   "fix <DeploymentId> <TaskId> <StepName>",
-	Short: "Fix a deployment task step on error",
+	Deprecated: "use 'yorc deployments tasks update-step-state' instead.",
+	Use:        "fix <DeploymentId> <TaskId> <StepName>",
+	Short:      "Fix a deployment task step on error",
 	Long: `Fix a task step specifying the deployment id, the task id and the step name.
 	The task step must be on error to be fixed.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 3 {
 			return errors.Errorf("Expecting a deployment id, a task id and a step name(got %d parameters)", len(args))
 		}
-		client, err := httputil.GetClient(deployments.ClientConfig)
-		if err != nil {
-			httputil.ErrExit(err)
-		}
 
-		// The task step status is set to "done"
-		step := &tasks.TaskStep{Name: args[2], Status: strings.ToLower(tasks.TaskStepStatusDONE.String())}
-		body, err := json.Marshal(step)
-		if err != nil {
-			log.Panic(err)
-		}
+		updateTaskStepState(args[0], args[1], args[2], tasks.TaskStepStatusDONE.String())
 
-		url := path.Join("/deployments", args[0], "tasks", args[1], "steps", args[2])
-		request, err := client.NewRequest("PUT", url, bytes.NewBuffer(body))
-		if err != nil {
-			httputil.ErrExit(err)
-		}
-
-		request.Header.Add("Content-Type", "application/json")
-		response, err := client.Do(request)
-		if err != nil {
-			httputil.ErrExit(err)
-		}
-		defer response.Body.Close()
-		ids := args[0] + "/" + args[1]
-		httputil.HandleHTTPStatusCode(response, ids, "deployment/task/step", http.StatusOK)
 		return nil
 	},
 }

--- a/commands/deployments/tasks/dep_update_task_step_state.go
+++ b/commands/deployments/tasks/dep_update_task_step_state.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+// Copyright 2021 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/commands/deployments/tasks/dep_update_task_step_state.go
+++ b/commands/deployments/tasks/dep_update_task_step_state.go
@@ -79,10 +79,7 @@ var updateTaskStepStateCmd = &cobra.Command{
 	The task step must be on error to be update.
 	This allows to bypass or retry errors happening in a workflow. So accepted state are either DONE or INITIAL.
 	Use 'yorc deployment tasks resume' command to restart a workflow after having updated it's errors`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-
+	Run: func(cmd *cobra.Command, args []string) {
 		updateTaskStepState(args[0], args[1], args[2], args[3])
-
-		return nil
 	},
 }

--- a/commands/deployments/tasks/dep_update_task_step_state.go
+++ b/commands/deployments/tasks/dep_update_task_step_state.go
@@ -46,7 +46,6 @@ func updateTaskStepState(deploymentID, taskID, stepName, statusStr string) {
 		httputil.ErrExit(err)
 	}
 
-	// The task step status is set to "done"
 	step := &tasks.TaskStep{Status: statusStr}
 	body, err := json.Marshal(step)
 	if err != nil {

--- a/commands/deployments/tasks/dep_update_task_step_state.go
+++ b/commands/deployments/tasks/dep_update_task_step_state.go
@@ -1,0 +1,88 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ystia/yorc/v4/commands/deployments"
+	"github.com/ystia/yorc/v4/commands/httputil"
+	"github.com/ystia/yorc/v4/tasks"
+)
+
+func init() {
+	tasksCmd.AddCommand(updateTaskStepStateCmd)
+}
+
+func updateTaskStepState(deploymentID, taskID, stepName, statusStr string) {
+	client, err := httputil.GetClient(deployments.ClientConfig)
+	if err != nil {
+		httputil.ErrExit(err)
+	}
+
+	statusStr = strings.ToLower(statusStr)
+
+	// Safety check
+	_, err = tasks.ParseTaskStepStatus(statusStr)
+	if err != nil {
+		httputil.ErrExit(err)
+	}
+
+	// The task step status is set to "done"
+	step := &tasks.TaskStep{Status: statusStr}
+	body, err := json.Marshal(step)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	url := path.Join("/deployments", deploymentID, "tasks", taskID, "steps", stepName)
+	request, err := client.NewRequest("PUT", url, bytes.NewBuffer(body))
+	if err != nil {
+		httputil.ErrExit(err)
+	}
+
+	request.Header.Add("Content-Type", "application/json")
+	response, err := client.Do(request)
+	if err != nil {
+		httputil.ErrExit(err)
+	}
+	defer response.Body.Close()
+	ids := deploymentID + "/" + taskID
+	httputil.HandleHTTPStatusCode(response, ids, "deployment/task/step", http.StatusOK)
+}
+
+var updateTaskStepStateCmd = &cobra.Command{
+	Use:     "update-step-state <DeploymentId> <TaskId> <StepName> <state>",
+	Aliases: []string{"update-state", "update-step", "uss", "us"},
+	Short:   "Update a deployment task step on error",
+	Args:    cobra.ExactArgs(4),
+	Long: `Update a task step specifying the deployment id, the task id, the step name and a valid state for the step.
+	The task step must be on error to be update.
+	This allows to bypass or retry errors happening in a workflow. So accepted state are either DONE or INITIAL.
+	Use 'yorc deployment tasks resume' command to restart a workflow after having updated it's errors`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		updateTaskStepState(args[0], args[1], args[2], args[3])
+
+		return nil
+	},
+}

--- a/commands/deployments/tasks/dep_update_task_step_state.go
+++ b/commands/deployments/tasks/dep_update_task_step_state.go
@@ -17,7 +17,6 @@ package tasks
 import (
 	"bytes"
 	"encoding/json"
-	"log"
 	"net/http"
 	"path"
 	"strings"
@@ -51,7 +50,7 @@ func updateTaskStepState(deploymentID, taskID, stepName, statusStr string) {
 	step := &tasks.TaskStep{Status: statusStr}
 	body, err := json.Marshal(step)
 	if err != nil {
-		log.Panic(err)
+		httputil.ErrExit(err)
 	}
 
 	url := path.Join("/deployments", deploymentID, "tasks", taskID, "steps", stepName)

--- a/commands/deployments/tasks/dep_update_task_step_state_test.go
+++ b/commands/deployments/tasks/dep_update_task_step_state_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+// Copyright 2021 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/commands/deployments/tasks/dep_update_task_step_state_test.go
+++ b/commands/deployments/tasks/dep_update_task_step_state_test.go
@@ -1,0 +1,60 @@
+// Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ystia/yorc/v4/commands/deployments"
+	"github.com/ystia/yorc/v4/config"
+)
+
+func Test_updateTaskStepState(t *testing.T) {
+
+	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "fail") {
+			rw.WriteHeader(http.StatusBadRequest)
+			rw.Write([]byte("Some user error"))
+			return
+		}
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer s.Close()
+
+	deployments.ClientConfig = config.Client{
+		YorcAPI: strings.Replace(s.URL, "http://", "", 1),
+	}
+
+	type args struct {
+		deploymentID string
+		taskID       string
+		stepName     string
+		statusStr    string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"TestOK", args{"depOK", "taskID", "step", "initial"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updateTaskStepState(tt.args.deploymentID, tt.args.taskID, tt.args.stepName, tt.args.statusStr)
+		})
+	}
+}

--- a/rest/dep_tasks.go
+++ b/rest/dep_tasks.go
@@ -170,6 +170,7 @@ func (s *Server) updateTaskStepStatusHandler(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		log.Panic(err)
 	}
+	step.Name = stepID
 
 	// Check taskStep status change
 	allowed, err := tasks.CheckTaskStepStatusChange(stepBefore.Status, step.Status)

--- a/rest/http_api.md
+++ b/rest/http_api.md
@@ -605,10 +605,18 @@ Content-Type: application/json
 
 ### Update a task step status <a name="task-step-update"></a>
 
-Update a task step status for given deployment and task. For the moment, only step status change from "ERROR" to "DONE" is allowed otherwise an HTTP 401
-(Forbidden) error is returned.
+Update a task step status for given deployment and task. For the moment, only step status change from "ERROR"
+to "DONE" or "INITIAL" is allowed otherwise an HTTP 401 (Forbidden) error is returned.
 
 `PUT    /deployments/<deployment_id>/tasks/<taskId>/steps/<stepId>`
+
+**Request body**:
+
+```json
+{
+  "status": "step_status"
+}
+```
 
 **Response**:
 

--- a/tasks/collector/collector.go
+++ b/tasks/collector/collector.go
@@ -97,6 +97,14 @@ func (c *Collector) ResumeTask(ctx context.Context, taskID string) error {
 			Key:   path.Join(taskPath, "errorMessage"),
 			Value: []byte(""),
 		},
+		&api.KVTxnOp{
+			Verb: api.KVDelete,
+			Key:  path.Join(taskPath, ".errorFlag"),
+		},
+		&api.KVTxnOp{
+			Verb: api.KVDelete,
+			Key:  path.Join(taskPath, ".cancelFlag"),
+		},
 	}
 	// Set deployment status to initial for some task types
 	switch taskType {

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -543,7 +543,7 @@ func CheckTaskStepStatusChange(before, after string) (bool, error) {
 		return false, err
 	}
 
-	if stBefore != TaskStepStatusERROR || stAfter != TaskStepStatusDONE {
+	if stBefore != TaskStepStatusERROR || (stAfter != TaskStepStatusDONE && stAfter != TaskStepStatusINITIAL) {
 		return false, nil
 	}
 	return true, nil


### PR DESCRIPTION
# Pull Request description

## Description of the change

This PR enable the feature of replaying steps in error.

### What I did

* Updated documentation of the API endpoint to update a step state (most of the work was already done but not documented)
* Allow step state modification from error to initial
* Deprecate the 'yorc dep tasks fix' command
* Add a new 'yorc dep tasks update-step-state' command
* Fix resume issue by deleting .cancelFlag & .errorFlag on task when resuming it

### How to verify it

The easiest way to test it is to simulate a network connectivity issue when provisioning an infrastructure resource or submitting a job. VPNs may help here :smile:. 
Then you should use the new command `yorc dep tasks update-step-state <depID> <taskID> <stepName> initial` to set the step state to initial and finally resume the tasks using `yorc dep tasks resume <depID> <taskID>`.

### Description for the changelog

* Workflows steps replays on error  ([GH-753](https://github.com/ystia/yorc/issues/753))

## Applicable Issues

Fixes #753 