### PR TITLE
Cenerate a checksum file for release artifacts and sign it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,8 @@ jobs:
         mkdir -p dist/gh-release
         mv dist/yorc-*.tgz dist/yorc-server*-distrib.zip dist/gh-release/
 
-    - uses: tristan-weil/ghaction-checksum-sign-artifact@v1
+    # Use a specific trusted commit (do not relie on tags that could evolve like v1) 
+    - uses: tristan-weil/ghaction-checksum-sign-artifact@1d1a6873e7f53532850e8a6f03e790e063bae662
       with:
         path: 'dist/gh-release/*'
         sign_key: '${{ secrets.YSTIA_BOT_SIGN_KEY }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,11 +85,22 @@ jobs:
         SKIP_TESTS=1 make dist
         # Generate changelog
         awk '{f=1} f{ if (/^## / && i++>=1) exit; else print $0}' CHANGELOG.md | tee CHANGELOG-for-version.md
+        # Move release artifacts for signing
+        mkdir -p dist/gh-release
+        mv dist/yorc-*.tgz dist/yorc-server*-distrib.zip dist/gh-release/
 
+    - uses: tristan-weil/ghaction-checksum-sign-artifact@v1
+      with:
+        path: 'dist/gh-release/*'
+        sign_key: '${{ secrets.YSTIA_BOT_SIGN_KEY }}'
+        sign_key_passphrase: '${{ secrets.YSTIA_BOT_SIGN_KEY_PASSPHRASE }}'
+        sign_key_fingerprint: 'CEC021997E92CADB298EFC8AFA71C23B880E40F9'
+        sign_keyserver: 'keys.openpgp.org'
 
     - name: Create or Update Github Release draft
       id: update_release
-      uses: loicalbertin/action-gh-release@080e2e752ac77817dcfd2e8809873bdc24817584
+      # Wait for a released version containg https://github.com/softprops/action-gh-release/pull/60
+      uses: softprops/action-gh-release@9729932bfb75c05ad1f6e3a729294e05abaa7001
       with:
         tag_name: ${{ env.TAG_NAME }}
         body_path: CHANGELOG-for-version.md
@@ -97,8 +108,7 @@ jobs:
         prerelease: ${{ env.PRERELEASE }}
         draft: true
         files: |
-          dist/yorc-*.tgz
-          dist/yorc-server*-distrib.zip
+          dist/gh-release/*
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 * Error submitting a SLURM job with no execution option ([GH-739](https://github.com/ystia/yorc/issues/739))
 * Workflow with asynchronous action never stops after another step failure  ([GH-733](https://github.com/ystia/yorc/issues/733))
 
+### ENGINEERING
+
+* Generate a checksum file for release artifacts and sign it ([GH-755](https://github.com/ystia/yorc/issues/755))
+
 ## 4.2.0-milestone.1 (May 06, 2021)
 
 ### ENHANCEMENTS


### PR DESCRIPTION
# Pull Request description

## Description of the change

Use a github action to generate a checksum file and sign it

### Description for the changelog

(ENGINEERING section)

* Generate a checksum file for release artifacts and sign it ([GH-755](https://github.com/ystia/yorc/issues/755))

## Applicable Issues

* Fixes #755 
* Backported to release/4.1 branch in #760
* Backported to release/4.0 branch in #761
