### PR TITLE
[Backport 4.1] Slurm: Use sacct to retrieve job status when scontrol show job does not show the job anymore 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### ENHANCEMENTS
+
+* Slurm: Use sacct to retrieve job status when scontrol show job does not show the job anymore ([GH-757](https://github.com/ystia/yorc/issues/757))
+
 ### BUG FIXES
 
 * [Bootstrap] Error in AWS location configuration for the bootstrapped Yorc ([GH-762](https://github.com/ystia/yorc/issues/762))

--- a/prov/slurm/helper_test.go
+++ b/prov/slurm/helper_test.go
@@ -15,6 +15,7 @@
 package slurm
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -357,7 +358,7 @@ func TestGetJobInfoWithInvalidJob(t *testing.T) {
 			return "", nil
 		},
 	}
-	info, err := getJobInfo(s, "1234")
+	info, err := getJobInfo(context.Background(), s, "d1", "1234")
 	require.Nil(t, info, "info should be nil")
 
 	require.Equal(t, true, isNoJobFoundError(err), "expected no job found error")
@@ -373,7 +374,7 @@ func TestGetJobInfoWithEmptyResponseButAccounting(t *testing.T) {
 			return "COMPLETED", nil
 		},
 	}
-	info, err := getJobInfo(s, "1234")
+	info, err := getJobInfo(context.Background(), s, "d1", "1234")
 	require.NotNil(t, info, "info should not be nil")
 	require.Nil(t, err)
 	require.Equal(t, map[string]string{"JobState": "COMPLETED"}, info, "unexpected job info")
@@ -389,7 +390,7 @@ func TestGetJobInfoWithEmptyResponseAndAccountingError(t *testing.T) {
 			return "", errors.New("some error")
 		},
 	}
-	info, err := getJobInfo(s, "1234")
+	info, err := getJobInfo(context.Background(), s, "d1", "1234")
 	require.Nil(t, info, "info should be nil")
 
 	require.NotNil(t, err, "expecting an error")
@@ -405,7 +406,7 @@ func TestGetJobInfoWithEmptyResponseAndAccountingNotConfigured(t *testing.T) {
 			return errMsgAccountingDisabled, errors.New("1")
 		},
 	}
-	info, err := getJobInfo(s, "1234")
+	info, err := getJobInfo(context.Background(), s, "d1", "1234")
 	require.Nil(t, info, "info should be nil")
 
 	require.Equal(t, true, isNoJobFoundError(err), "expected no job found error")
@@ -425,7 +426,7 @@ func TestGetJobInfo(t *testing.T) {
 	require.Nil(t, err, "unexpected error while opening test file")
 	expected, err := parseJobInfo(data)
 	require.Nil(t, err, "Unexpected error parsing job info")
-	info, err := getJobInfo(s, "1234")
+	info, err := getJobInfo(context.Background(), s, "d1", "1234")
 	require.Nil(t, err, "Unexpected error retrieving job info")
 	require.NotNil(t, info, "info should not be nil")
 
@@ -439,7 +440,7 @@ func TestGetJobInfoWithEmptyResponse(t *testing.T) {
 			return "", nil
 		},
 	}
-	info, err := getJobInfo(s, "1234")
+	info, err := getJobInfo(context.Background(), s, "d1", "1234")
 	require.Nil(t, info, "info should be nil")
 
 	require.Equal(t, true, isNoJobFoundError(err), "expected no job found error")
@@ -452,7 +453,7 @@ func TestGetJobInfoWithError(t *testing.T) {
 			return "oups, it's bad", errors.New("this is an error !")
 		},
 	}
-	info, err := getJobInfo(s, "1234")
+	info, err := getJobInfo(context.Background(), s, "d1", "1234")
 	require.Nil(t, info, "info should be nil")
 
 	require.Equal(t, "oups, it's bad: this is an error !", err.Error(), "expected error")

--- a/prov/slurm/monitoring_jobs.go
+++ b/prov/slurm/monitoring_jobs.go
@@ -163,7 +163,7 @@ func (o *actionOperator) analyzeJob(ctx context.Context, cc *api.Client, sshClie
 		return true, err
 	}
 
-	info, err := getJobInfo(sshClient, actionData.jobID)
+	info, err := getJobInfo(ctx, sshClient, deploymentID, actionData.jobID)
 
 	// TODO(loicalbertin): This should be improved instance name should not be hard-coded (https://github.com/ystia/yorc/issues/670)
 	instanceName := "0"

--- a/prov/slurm/testdata/scontrol_show_job_completed.txt
+++ b/prov/slurm/testdata/scontrol_show_job_completed.txt
@@ -20,5 +20,5 @@ JobId=6260 JobName=test-salloc-Environment
    Command=(null)
    WorkDir=/home_nfs/john
    StdOut=/home_nfs/john/file.out
-   StdErr=/home_nfs/john/file.err
+   StdErr=/home_nfs/john/file.out
    Power= SICP=0


### PR DESCRIPTION
# Pull Request description

## Description of the change

If `scontrol show job` fails to retrieve the job for some reason then try to use `sacct`.

### How to verify it

Set a monitoring job interval higher than 5min and try to run a run workflow

### Description for the changelog

* Slurm: Use sacct to retrieve job status when scontrol show job does not show the job anymore ([GH-757](https://github.com/ystia/yorc/issues/757))

## Applicable Issues

Fixes #757 
Backport of #758 