### PR TITLE
bootvolume sourcetype was a requirement

### DIFF
--- a/data/tosca/yorc-openstack-types.yml
+++ b/data/tosca/yorc-openstack-types.yml
@@ -18,7 +18,7 @@ data_types:
         description: UUID of the image, volume, or snapshot. Required unless source is set to 'blank'
       source:
         type: string
-        required: true
+        required: false
         description: Source type of the device. Must be one of 'blank', 'image', 'volume', or 'snapshot'
         constraints:
           - valid_values: [ blank, image, volume, snapshot ]


### PR DESCRIPTION
Signed-off-by: Tim Beermann <beermann@osism.tech>

# Pull Request description

1. Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
2. Please read our contribution guidelines
3. PR with a decent set of unit tests have more chance to be reviewed and merged quickly

## Description of the change

Yorc's openstack BootVolume type required the property **source**. This prevented e.g. importing topologies which did not have a BootVolume set.
Leaving **source** as a requirement would force setting a boot volume in terraform resulting in automatically requiring an *image_id* if you want
to boot from an image. Thogh if you want to boot a VM from Terraform from an image name you must leave out the boot volume OR query the *image_id*
as a data source upfront. Anyway, the **source** attribute should never be a requirement.

### What I did

Changed the required value from `true` to `false` for *yorc.datatypes.openstack.BootVolume*'s property **source**.

### How I did it

none

### How to verify it

none

### Description for the changelog

OpenStack type *yorc.datatypes.openstack.BootVolume* required the source propery. This prevented creating VMs without one directly from image names.

## Applicable Issues

none

