### PR TITLE
Feature/job replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### FEATURES
 
-* Workflows steps replays on error  ([GH-753](https://github.com/ystia/yorc/issues/753))
+* Allow to replay workflow steps even if they are not in error ([GH-771](https://github.com/ystia/yorc/issues/771))
+* Workflows steps replays on error ([GH-753](https://github.com/ystia/yorc/issues/753))
 
 ### ENHANCEMENTS
 

--- a/rest/http_api.md
+++ b/rest/http_api.md
@@ -605,7 +605,7 @@ Content-Type: application/json
 
 ### Update a task step status <a name="task-step-update"></a>
 
-Update a task step status for given deployment and task. For the moment, only step status change from "ERROR"
+Update a task step status for given deployment and task. For the moment, only step status change from "ERROR" or "DONE"
 to "DONE" or "INITIAL" is allowed otherwise an HTTP 401 (Forbidden) error is returned.
 
 `PUT    /deployments/<deployment_id>/tasks/<taskId>/steps/<stepId>`

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -543,7 +543,7 @@ func CheckTaskStepStatusChange(before, after string) (bool, error) {
 		return false, err
 	}
 
-	if stBefore != TaskStepStatusERROR || (stAfter != TaskStepStatusDONE && stAfter != TaskStepStatusINITIAL) {
+	if (stBefore != TaskStepStatusERROR && stBefore != TaskStepStatusDONE) || (stAfter != TaskStepStatusDONE && stAfter != TaskStepStatusINITIAL) {
 		return false, nil
 	}
 	return true, nil

--- a/tasks/workflow/consul_test.go
+++ b/tasks/workflow/consul_test.go
@@ -76,6 +76,9 @@ func TestRunConsulWorkflowPackageTests(t *testing.T) {
 		t.Run("TestRunPurgeFails", func(t *testing.T) {
 			testRunPurgeFails(t, srv, client)
 		})
+		t.Run("TestRunWorkflowStepReplay", func(t *testing.T) {
+			testRunWorkflowStepReplay(t, srv, client)
+		})
 	})
 }
 

--- a/tasks/workflow/step.go
+++ b/tasks/workflow/step.go
@@ -215,7 +215,13 @@ func (s *step) run(ctx context.Context, cfg config.Configuration, deploymentID s
 				// Set step in error but continue if needed
 				s.setStatus(tasks.TaskStepStatusERROR)
 				if !bypassErrors {
-					tasks.NotifyErrorOnTask(s.t.taskID)
+					if len(s.OnFailure) > 0 {
+						// Do not end the workflow as there is a on failure branch
+						events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelWARN, deploymentID).Registerf(
+							"TaskStep %q had error: %+v, workflow continues with on failure step", s.Name, err)
+					} else {
+						tasks.NotifyErrorOnTask(s.t.taskID)
+					}
 					// only set generic error message here.
 					// Task status is handled in task execution final function
 					tasks.CheckAndSetTaskErrorMessage(s.t.taskID, fmt.Sprintf("Workflow %q step %q failed.", workflowName, s.Name), false)

--- a/tasks/workflow/testdata/workflow.yaml
+++ b/tasks/workflow/testdata/workflow.yaml
@@ -36,6 +36,24 @@ node_types:
             type: ystia.yorc.tests.artifacts.Implementation.Custom
             file: whatever
 
+  ystia.yorc.tests.nodes.JobNode:
+    derived_from: org.alien4cloud.nodes.Job
+    interfaces:
+      Standard:
+        create:
+          implementation:
+            type: ystia.yorc.tests.artifacts.Implementation.Custom
+            file: whatever
+      tosca.interfaces.node.lifecycle.Runnable:
+        submit:
+          implementation:
+            type: ystia.yorc.tests.artifacts.Implementation.Custom
+            file: whatever
+        run:
+          implementation:
+            type: ystia.yorc.tests.artifacts.Implementation.Custom
+            file: whatever
+
 topology_template:
   node_templates:
     WFNode:
@@ -61,6 +79,8 @@ topology_template:
             protocol: tcp
             network_name: PRIVATE
             initiator: source
+    JobNode:
+      type: ystia.yorc.tests.nodes.JobNode
   workflows:
     custom_wf1:
       steps:
@@ -80,6 +100,39 @@ topology_template:
           target: WFNode
           activities:
           - call_operation: custom.operation1
+    custom_submit_job:
+      steps:
+        job_create:
+          target: JobNode
+          operation_host: ORCHESTRATOR
+          activities:
+            - call_operation: Standard.create
+          on_success:
+            - job_submit
+        job_submit:
+          target: JobNode
+          operation_host: ORCHESTRATOR
+          activities:
+            - call_operation: tosca.interfaces.node.lifecycle.Runnable.submit
+          on_success:
+            - job_submitted
+        job_submitted:
+          target: JobNode
+          activities:
+            - set_state: submitted
+    custom_monitor_job:
+      steps:
+        job_run:
+          target: JobNode
+          operation_host: ORCHESTRATOR
+          activities:
+            - call_operation: tosca.interfaces.node.lifecycle.Runnable.run
+          on_success:
+            - job_executed
+        job_executed:
+          target: JobNode
+          activities:
+            - set_state: executed
     install:
       steps:
         Compute_install:


### PR DESCRIPTION
# Pull Request description

Added the ability to replay workflow steps, even if they were successful. This can be used to replay the successful submission of a job after a failure during the execution of this job.
 
## Description of the change

### What I did

`rest/http_api.md`
`tasks/tasks.go`
allowing to change a DONE step (to resubmit a job that failed during its execution for example)

`tasks/workflow/step.go`
Not ending the workflow on a step failure if this step has "on failure" next steps

`tasks/workflow/worker.go`
endAction() and runAction(): should not notify the task error if there are on failure steps, to go on in the workflow executing these on failure steps
runWorkflowStep(): on workflow replay, when an asynchronous step is done, its next steps must be registered


`tasks/workflow/consul_test.go`
`tasks/workflow/testdata/workflow.yaml`
`tasks/workflow/worker_test.go`

Added a test checking replaying a workflow containing workflow with an asynchronous step already done, will now execute steps following this asynchronous step


### How to verify it

Tested on a LEXIS step with a job performing data transfers between Compute locations:
Using a workflow containing job steps, make the job executing a data transfer fail.
Then use yorc command :
```bash
yorc deployments tasks update-step-state <deployment ID> <task ID> <step name> initial
```
to re-iniitlalise the run step that was on error and the submit step that was successful.

Then use yorc command:
```bash
yorc deployments tasks resume <deployment ID> <task ID>
```
to replay the workflow.
Check the job is resubmitted, then monitored until its end.

### Description for the changelog

Allow to replay workflow steps even if they are not in error ([GH-771](https://github.com/ystia/yorc/issues/771))

## Applicable Issues

#771 