### PR TITLE
Ability to authenticate against OpenStack with application credentials or token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### FEATURES
 
+* Ability to authenticate against OpenStack with token or application credentials ([GH-775](https://github.com/ystia/yorc/issues/775))
 * Allow to replay workflow steps even if they are not in error ([GH-771](https://github.com/ystia/yorc/issues/771))
 * Workflows steps replays on error ([GH-753](https://github.com/ystia/yorc/issues/753))
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1010,13 +1010,15 @@ OpenStack location type is ``openstack`` in lower case.
 +-----------------------------------+---------------------------------------------------------------------------------------------------------------------+-----------+----------------------------------------------------+---------------+
 | ``user_domain_name``              | Specify the domain name where the user is located (Identity v3 only).                                               | string    | yes (if use Identity v3)                           |               |
 +-----------------------------------+---------------------------------------------------------------------------------------------------------------------+-----------+----------------------------------------------------+---------------+
+| ``domain_id``                     | Specify the ID of the Domain to scope to (Identity v3 only).                                                        | string    | no                                                 |               |
++-----------------------------------+---------------------------------------------------------------------------------------------------------------------+-----------+----------------------------------------------------+---------------+
 | ``project_id``                    | Specify the ID of the project to login with (Identity v3 only).                                                     | string    | Either this or ``project_name`` should be provided.|               |
 +-----------------------------------+---------------------------------------------------------------------------------------------------------------------+-----------+----------------------------------------------------+---------------+
 | ``project_name``                  | Specify the name of the project to login with (Identity v3 only).                                                   | string    | Either this or ``project_id`` should be provided.  |               |
 +-----------------------------------+---------------------------------------------------------------------------------------------------------------------+-----------+----------------------------------------------------+---------------+
-| ``user_name``                     | Specify the OpenStack user name to use.                                                                             | string    | yes                                                |               |
+| ``user_name``                     | Specify the OpenStack user name to use.                                                                             | string    | yes (see note below for more details)              |               |
 +-----------------------------------+---------------------------------------------------------------------------------------------------------------------+-----------+----------------------------------------------------+---------------+
-| ``password``                      | Specify the OpenStack password to use.                                                                              | string    | yes                                                |               |
+| ``password``                      | Specify the OpenStack password to use.                                                                              | string    | yes (see note below for more details)              |               |
 +-----------------------------------+---------------------------------------------------------------------------------------------------------------------+-----------+----------------------------------------------------+---------------+
 | ``region``                        | Specify the OpenStack region to use                                                                                 | string    | no                                                 | ``RegionOne`` |
 +-----------------------------------+---------------------------------------------------------------------------------------------------------------------+-----------+----------------------------------------------------+---------------+
@@ -1041,6 +1043,10 @@ OpenStack location type is ``openstack`` in lower case.
 |                                   | the contents of the key                                                                                             |           |                                                    |               |
 +-----------------------------------+---------------------------------------------------------------------------------------------------------------------+-----------+----------------------------------------------------+---------------+
 
+Note:
+In environments where user/password authentication cannot be used to authenticate against OpenStack, it is possible to define in a topology, within the TOSCA Compute node template metadata property, which is a map of key/value pairs:
+* either the key `token` and an OpenStack token value, to perform a token-based authentication,
+* or the keys `application_credential_id` and `application_credential_secret` with respective values, to perform an authentication based on OpenStack application credentials.
 
 .. _option_infra_kubernetes:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1044,8 +1044,8 @@ OpenStack location type is ``openstack`` in lower case.
 +-----------------------------------+---------------------------------------------------------------------------------------------------------------------+-----------+----------------------------------------------------+---------------+
 
 Note:
-In environments where user/password authentication cannot be used to authenticate against OpenStack, it is possible to define in a topology, within the TOSCA Compute node template metadata property, which is a map of key/value pairs:
-* either the key `token` and an OpenStack token value, to perform a token-based authentication,
+In environments where user/password authentication cannot be used to authenticate against OpenStack, it is possible to define in a topology, within a TOSCA node template metadata property, which is a map of key/value pairs:
+* either the key `token` and an OpenStack token value, to perform an OpenStack token-based authentication,
 * or the keys `application_credential_id` and `application_credential_secret` with respective values, to perform an authentication based on OpenStack application credentials.
 
 .. _option_infra_kubernetes:

--- a/prov/terraform/openstack/consul_test.go
+++ b/prov/terraform/openstack/consul_test.go
@@ -86,6 +86,9 @@ func TestRunConsulOpenstackPackageTests(t *testing.T) {
 		t.Run("TestGenerateTerraformInfo", func(t *testing.T) {
 			testGenerateTerraformInfo(t, srv, locationMgr)
 		})
+		t.Run("TestAppCredentials", func(t *testing.T) {
+			testAppCredentials(t, srv, locationMgr)
+		})
 		t.Run("TestComputeBootVolumeWrongSize", func(t *testing.T) {
 			testComputeBootVolumeWrongSize(t, srv)
 		})

--- a/prov/terraform/openstack/generator.go
+++ b/prov/terraform/openstack/generator.go
@@ -82,7 +82,10 @@ func (g *osGenerator) generateTerraformInfraForNode(ctx context.Context, cfg con
 		return false, nil, nil, nil, err
 	}
 	var cmdEnv []string
-	infrastructure.Provider, cmdEnv = getOpenStackProviderEnv(cfg, locationProps)
+	infrastructure.Provider, cmdEnv, err = getOpenStackProviderEnv(ctx, cfg, locationProps, deploymentID, nodeName)
+	if err != nil {
+		return false, nil, nil, nil, err
+	}
 
 	log.Debugf("inspecting node %s", nodeName)
 	nodeType, err := deployments.GetNodeType(ctx, deploymentID, nodeName)
@@ -130,33 +133,78 @@ func (g *osGenerator) generateTerraformInfraForNode(ctx context.Context, cfg con
 	return true, outputs, cmdEnv, nil, nil
 }
 
-func getOpenStackProviderEnv(cfg config.Configuration, locationProps config.DynamicMap) (map[string]interface{}, []string) {
-	cmdEnv := []string{
-		fmt.Sprintf("OS_USERNAME=%s", locationProps.GetString("user_name")),
-		fmt.Sprintf("OS_PASSWORD=%s", locationProps.GetString("password")),
-		fmt.Sprintf("OS_PROJECT_NAME=%s", locationProps.GetString("project_name")),
-		fmt.Sprintf("OS_PROJECT_ID=%s", locationProps.GetString("project_id")),
-		fmt.Sprintf("OS_USER_DOMAIN_NAME=%s", locationProps.GetString("user_domain_name")),
-		fmt.Sprintf("OS_AUTH_URL=%s", locationProps.GetString("auth_url")),
+func getOpenStackProviderEnv(ctx context.Context, cfg config.Configuration, locationProps config.DynamicMap, deploymentID, nodeName string) (map[string]interface{}, []string, error) {
+
+	// Token authentication is not performed from location configuration settings
+	// but using a token value in the node metadata
+	tokenFound, tokenValue, err := deployments.GetNodeMetadata(ctx, deploymentID, nodeName, tosca.MetadataTokenKey)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	// Management of variables for Terraform
+	// Getting application credentials as well to workaround a keystone bug
+	// hit by Terraform when token generated from application credentials are provided
+	// See keystone bug https://bugs.launchpad.net/keystone/+bug/1878438
+	secretFound, credsSecret, err := deployments.GetNodeMetadata(ctx, deploymentID, nodeName, tosca.MetadataApplicationCredentialSecretKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	_, credsID, err := deployments.GetNodeMetadata(ctx, deploymentID, nodeName, tosca.MetadataApplicationCredentialIDKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var cmdEnv []string
+	if secretFound && credsSecret != "" && credsID != "" {
+		// Specifying the User domain name when application credentials are used.
+		// No environment variable is defined for application credentials, they will be set
+		// in the OpenStack provider settings below
+		cmdEnv = []string{
+			fmt.Sprintf("OS_USER_DOMAIN_NAME=%s", locationProps.GetString("user_domain_name")),
+		}
+	} else if tokenFound && tokenValue != "" {
+		// Specifying the Domain ID when a token is used
+		cmdEnv = []string{
+			fmt.Sprintf("OS_TOKEN=%s", tokenValue),
+			fmt.Sprintf("OS_DOMAIN_ID=%s", locationProps.GetString("domain_id")),
+		}
+	} else {
+		// User/password authentication
+		// No OS_USER_DOMAIN_NAME set here as this will cause an issue to terraform here
+		cmdEnv = []string{
+			fmt.Sprintf("OS_USERNAME=%s", locationProps.GetString("user_name")),
+			fmt.Sprintf("OS_PASSWORD=%s", locationProps.GetString("password")),
+			fmt.Sprintf("OS_DOMAIN_ID=%s", locationProps.GetString("domain_id")),
+		}
+	}
+	// Variables common to all authentication modes
+	cmdEnv = append(cmdEnv,
+		fmt.Sprintf("OS_PROJECT_NAME=%s", locationProps.GetString("project_name")),
+		fmt.Sprintf("OS_PROJECT_ID=%s", locationProps.GetString("project_id")),
+		fmt.Sprintf("OS_AUTH_URL=%s", locationProps.GetString("auth_url")))
+
+	// Defining OpenStack parameters for Terraform
+	openStackSettings := map[string]interface{}{
+		"version":     cfg.Terraform.OpenStackPluginVersionConstraint,
+		"tenant_name": locationProps.GetString("tenant_name"),
+		"insecure":    locationProps.GetString("insecure"),
+		"cacert_file": locationProps.GetString("cacert_file"),
+		"cert":        locationProps.GetString("cert"),
+		"key":         locationProps.GetString("key"),
+	}
+	if secretFound && credsSecret != "" && credsID != "" {
+		openStackSettings["application_credential_id"] = credsID
+		openStackSettings["application_credential_secret"] = credsSecret
+	}
 	provider := map[string]interface{}{
-		"openstack": map[string]interface{}{
-			"version":     cfg.Terraform.OpenStackPluginVersionConstraint,
-			"tenant_name": locationProps.GetString("tenant_name"),
-			"insecure":    locationProps.GetString("insecure"),
-			"cacert_file": locationProps.GetString("cacert_file"),
-			"cert":        locationProps.GetString("cert"),
-			"key":         locationProps.GetString("key"),
-		},
-		"consul": commons.GetConsulProviderfiguration(cfg),
+		"openstack": openStackSettings,
+		"consul":    commons.GetConsulProviderfiguration(cfg),
 		"null": map[string]interface{}{
 			"version": commons.NullPluginVersionConstraint,
 		},
 	}
 
-	return provider, cmdEnv
+	return provider, cmdEnv, err
 }
 
 func (g *osGenerator) generateInstanceInfra(ctx context.Context, opts generateInfraOptions,

--- a/prov/terraform/openstack/generator_test.go
+++ b/prov/terraform/openstack/generator_test.go
@@ -17,13 +17,14 @@ package openstack
 import (
 	"context"
 	"encoding/json"
-	"github.com/ystia/yorc/v4/storage"
-	"github.com/ystia/yorc/v4/storage/types"
-	"github.com/ystia/yorc/v4/tosca"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/ystia/yorc/v4/storage"
+	"github.com/ystia/yorc/v4/storage/types"
+	"github.com/ystia/yorc/v4/tosca"
 
 	"github.com/hashicorp/consul/testutil"
 	"github.com/stretchr/testify/assert"
@@ -96,7 +97,7 @@ func testGenerateTerraformInfo(t *testing.T, srv1 *testutil.TestServer, location
 		})
 	require.NoError(t, err, "Failed to create a location")
 	defer func() {
-		locationMgr.RemoveLocation(t.Name())
+		_ = locationMgr.RemoveLocation(t.Name())
 	}()
 
 	var cfg config.Configuration
@@ -171,7 +172,59 @@ func testGenerateTerraformInfo(t *testing.T, srv1 *testutil.TestServer, location
 	err = storage.GetStore(types.StoreTypeDeployment).Set(ctx, path.Join(consulutil.DeploymentKVPrefix, depID, "topology/nodes/FIPCompute"), FIPCompute)
 	require.Nil(t, err)
 
-	_, outputs, _, _, err = g.generateTerraformInfraForNode(context.Background(), cfg, depID, "FIPCompute", tempdir)
+	_, _, _, _, err = g.generateTerraformInfraForNode(context.Background(), cfg, depID, "FIPCompute", tempdir)
 	require.NoError(t, err, "Unexpected error generating FIPCompute terraform info")
 
+}
+
+func testAppCredentials(t *testing.T, srv1 *testutil.TestServer, locationMgr locations.Manager) {
+	t.Parallel()
+	log.SetDebug(true)
+	ctx := context.Background()
+	depID := path.Base(t.Name())
+	yamlName := "testdata/topology_test_app_creds.yaml"
+	err := deployments.StoreDeploymentDefinition(context.Background(), depID, yamlName)
+	require.Nil(t, err, "Failed to parse "+yamlName+" definition")
+
+	// Simulate the persistent disk "volume_id" attribute registration
+	instancesPrefix := path.Join(consulutil.DeploymentKVPrefix,
+		depID, "topology/instances")
+	srv1.PopulateKV(t, map[string][]byte{
+		path.Join(instancesPrefix, "BlockStorage/0/attributes/volume_id"): []byte("my_vol_id"),
+		path.Join(instancesPrefix, "/FIPCompute/0/capabilities/endpoint",
+			"attributes/floating_ip_address"): []byte("1.2.3.4"),
+		path.Join(instancesPrefix, "/Network_2/0/attributes/network_id"): []byte("netID"),
+	})
+
+	locationProps := config.DynamicMap{
+		"auth_url":                "http://1.2.3.4:5000/v2.0",
+		"default_security_groups": []string{"default", "sec2"},
+		"password":                "test",
+		"private_network_name":    "private-net",
+		"region":                  "RegionOne",
+		"tenant_name":             "test",
+		"user_name":               "test",
+		"user_domain_name":        "test_user_domain_name",
+	}
+	err = locationMgr.CreateLocation(
+		locations.LocationConfiguration{
+			Name:       t.Name(),
+			Type:       infrastructureType,
+			Properties: locationProps,
+		})
+	require.NoError(t, err, "Failed to create a location")
+	defer func() {
+		_ = locationMgr.RemoveLocation(t.Name())
+	}()
+
+	var cfg config.Configuration
+	provider, _, err := getOpenStackProviderEnv(ctx, cfg, locationProps, depID, "Compute")
+	require.NoError(t, err, "Unexpected error getting openstack provider")
+	val, openStackProviderFound := provider["openstack"]
+	require.True(t, openStackProviderFound, "Expected to get an openstack provider")
+	openStackSettings, isMap := val.(map[string]interface{})
+	require.True(t, isMap, "Expected to get map for openstack settings")
+
+	require.Equal(t, "test_cred_id", openStackSettings["application_credential_id"], "Wrong openstack credential id")
+	require.Equal(t, "test_cred_secret", openStackSettings["application_credential_secret"], "Wrong openstack credential secret")
 }

--- a/prov/terraform/openstack/testdata/topology_test_app_creds.yaml
+++ b/prov/terraform/openstack/testdata/topology_test_app_creds.yaml
@@ -1,0 +1,195 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: TestAppCreds
+  template_version: 0.1.0-SNAPSHOT
+  template_author: ${template_author}
+
+description: ""
+
+imports:
+  - <yorc-types.yml>
+  - <normative-types.yml>
+  - <yorc-openstack-types.yml>
+
+topology_template:
+  node_templates:
+    BlockStorage:
+      type: yorc.nodes.openstack.BlockStorage
+      properties:
+        deletable: false
+        size: "10 GB"
+      requirements:
+        - attachToComputeAttach:
+            type_requirement: attachment
+            node: Compute
+            capability: tosca.capabilities.Attachment
+            relationship: tosca.relationships.AttachTo
+    Compute:
+      type: yorc.nodes.openstack.Compute
+      metadata:
+        application_credential_id: test_cred_id
+        application_credential_secret: test_cred_secret
+      properties:
+        image: "a460db41-e574-416f-9634-96f2862f10fe"
+        flavor: 3
+        key_pair: yorc
+      requirements:
+        - networkNetwork2Connection:
+            type_requirement: network
+            node: Network_2
+            capability: tosca.capabilities.Connectivity
+            relationship: tosca.relationships.Network
+        - Compute_FIPCompute:
+            type_requirement: network
+            node: FIPCompute
+            capability: yorc.capabilities.openstack.FIPConnectivity
+            relationship: tosca.relationships.Network
+      capabilities:
+        endpoint:
+          properties:
+            credentials:
+              keys:
+                0: |
+                  -----BEGIN RSA PRIVATE KEY-----
+                  MIIEpAIBAAKCAQEAuEl5Wjgdvlqbz0x2vcllSQrDiRd+bWdA2MgpOl726ovxw9uE
+                  QJSlXYBJbSCQg+q++OEtXmvfahN5Y9aemuPey/o/S9RWyQ/X+uVeXdNV4Xkgar6b
+                  uYr1n1Ju7ltmdVJME7fr+Ti+2d+EMBs7V+jGXyZzBTdr6wCJuBHHXV/ZKDzw1cHd
+                  bRF8obBmMcxyzNbXnhSUvBgXT+GQ0/CgkNdrTwGOgtckqNYTuw1Rd6wAsF5xgN23
+                  uss5WJOg3/eMW2JMjyxNqaJhBUtA2CKcdnLjwyDxWdmC1NMHKL1umPOjuCyNczpl
+                  axMKW//UZT3WyfVt/gcHGGNIuI0izwFJ6QjlrQIDAQABAoIBAAet8COlUP/8sJ97
+                  1TrlaJYZn7pXw0n10or2FFm9WVa+zC1YOXOjfhyeWvD0OXF1181xPL3BiwbVlupl
+                  KCjWNBOV8wtK5u7r/RkUc9E/HEYQERzBoqWht8iS29KM9oEPE+KCeI/jIHjdypli
+                  mR95sMKITKS8AYBCfnqwKvmmI9t8VIXsrZWsg1dUD9TCa8QxoA66raSpXegDgjox
+                  T8IjZW90BwD6oG/5+HfbuwtjKR1Lca5tMzqxDMvqBf3KdCuee1x2Uuzla9/MsK/4
+                  Nuqv88gpoI7bDJOJnF/KrJqEH1ihF5zNVOs5c7XKmnAdry05tA7CjbiILOeFq3yn
+                  elkdR5UCgYEA3RC0bAR/TjSKGBEzvzfJFNp2ipdlZ1svobHl5sqDJzQp7P9aIogU
+                  qUhw2vr/nHg4dfmLnMHJYh6GCIjN1H7NZzaBiQSUcT+s2GRxYJqRV4geFHvKNzt3
+                  a50Hi5rSsbKm0LvlUA3vGkMABICyzkETPDl2WSFtKWUYrTMZSKixCtsCgYEA1Wjj
+                  fn+3HOmAv3lX4PzhHiBBfBj60BKPCnBbWG6TTF4ya7UEU+e5aAbLD10QdQyx77rL
+                  V3G3Xda1BWA2wGKRDfC9ksFUuxH2egNPGadOVZH2U/a/87YGOFUmbf03jJ6mbeRV
+                  BBBVcB8oGSD+NemiDPqYUi/G1lT+oRLFIkkYhBcCgYEApjKj4j2zVCFt3NA5/j27
+                  gGEKFAHka8MDWWY8uLlxxuyRxKrpoeJ63hYnOorP11wO3qshClYqyAi4rfvj+yjl
+                  1f4FfvShgU7k7L7++ijaslsUekPi8IlVq+MfxBY+5vewMGfC69+97hmHDtuPEj+c
+                  bX+p+TKHNkLaPYSYMqcYi1cCgYEAxf6JSfyt48oT5BFtYdTb+zpL5xm54T/GrBWv
+                  +eylBm5Cc0E/YaUUlBnxXTCnqyD7GQKB04AycoJX8kPgqD8KexeGmlh6BxFUTsEx
+                  KwjZGXTRR/cfAbo4LR17CQKr/e/XUw9LfPi2e868QgwlLdmzujzpAx9GZ+X1U3V5
+                  piSQ9UMCgYBdegnYh2fqU/oGH+d9WahuO1LW9vz8sFEIhRgJyLfA/ypAg6WCgJF2
+                  GtepEYBXL+QZnhudVxi0YPTmNN3+gtHdr+B4dKZ8z7m9NO2nk5AKdf0sYGWHEzhy
+                  PAgZzG5OTZiu+YohUPnC66eFiyS6anLBj0DGNa9VA8j352ecgeNO4A==
+                  -----END RSA PRIVATE KEY-----
+              user: centos
+            secure: true
+            protocol: tcp
+            network_name: PRIVATE
+            initiator: source
+        scalable:
+          properties:
+            min_instances: 1
+            max_instances: 1
+            default_instances: 1
+    Network_2:
+      type: yorc.nodes.openstack.Network
+      properties:
+        ip_version: 4
+        cidr: "10.1.0.0/24"
+    FIPCompute:
+      type: yorc.nodes.openstack.FloatingIP
+      properties:
+        floating_network_name: "public-net1"
+  workflows:
+    install:
+      steps:
+        Compute_install:
+          target: Compute
+          activities:
+            - delegate: install
+        FIPCompute_install:
+          target: FIPCompute
+          activities:
+            - delegate: install
+          on_success:
+            - Compute_install
+        Network_2_install:
+          target: Network_2
+          activities:
+            - delegate: install
+          on_success:
+            - Compute_install
+        BlockStorage_install:
+          target: BlockStorage
+          activities:
+            - delegate: install
+          on_success:
+            - Compute_install
+    uninstall:
+      steps:
+        Compute_uninstall:
+          target: Compute
+          activities:
+            - delegate: uninstall
+          on_success:
+            - Network_2_uninstall
+            - FIPCompute_uninstall
+            - BlockStorage_uninstall
+        Network_2_uninstall:
+          target: Network_2
+          activities:
+            - delegate: uninstall
+        FIPCompute_uninstall:
+          target: FIPCompute
+          activities:
+            - delegate: uninstall
+        BlockStorage_uninstall:
+          target: BlockStorage
+          activities:
+            - delegate: uninstall
+    start:
+      steps:
+        Network_2_start:
+          target: Network_2
+          activities:
+            - delegate: start
+          on_success:
+            - Compute_start
+        Compute_start:
+          target: Compute
+          activities:
+            - delegate: start
+          on_success:
+            - BlockStorage_start
+        FIPCompute_start:
+          target: FIPCompute
+          activities:
+            - delegate: start
+          on_success:
+            - Compute_start
+        BlockStorage_start:
+          target: BlockStorage
+          activities:
+            - delegate: start
+    stop:
+      steps:
+        FIPCompute_stop:
+          target: FIPCompute
+          activities:
+            - delegate: stop
+        Network_2_stop:
+          target: Network_2
+          activities:
+            - delegate: stop
+        BlockStorage_stop:
+          target: BlockStorage
+          activities:
+            - delegate: stop
+          on_success:
+            - Compute_stop
+        Compute_stop:
+          target: Compute
+          activities:
+            - delegate: stop
+          on_success:
+            - FIPCompute_stop
+            - Network_2_stop
+    run:
+    cancel:

--- a/tosca/constants.go
+++ b/tosca/constants.go
@@ -76,6 +76,18 @@ const ComputeNodeNetworksAttributeName = "networks"
 // the name of the location where to create this node template
 const MetadataLocationNameKey = "location"
 
+// MetadataTokenKey is the node template metadata key whose value provides
+// the value of a token
+const MetadataTokenKey = "token"
+
+// MetadataApplicationCredentialIDKey is the node template metadata key whose value provides
+// an application credential identifier
+const MetadataApplicationCredentialIDKey = "application_credential_id"
+
+// MetadataApplicationCredentialSecretKey is the node template metadata key whose value provides
+// the secret value associated to an application credential identifier
+const MetadataApplicationCredentialSecretKey = "application_credential_secret"
+
 // NetworkNameProperty is the name of the property containing the name of a logical
 // network
 //


### PR DESCRIPTION
# Pull Request description

## Description of the change

In some environments, like in LEXIS project, Yorc must be able to allocate OpenStack compute resources on behalf of any user created on demand by a third party AAI (Authentication and Authorization Infrastructure), Yorc being just given an OpenStack token or Openstack application credentials, valid only for a given time defined by the third party AAI.

Added the ability for Yorc to authenticate against OpenStack using a token or application credentials, that are provided in a node template metadata (not in yorc static configuration as these are per user values with a validity defined by an external AAI. 

### What I did

`doc/configuration.rst`

In the table of OpenStack parameters,
added parameter domain_id to be used with tokens, and referencing a note for user_name and password.
The note added below the table specifies that a token or application credentials can be specified in a node template, when user/password authentication can't be used.

`tosca/constants.go`
Added constants for token and application credentials keys that can be define in a node template metadata

`prov/terraform/openstack/generator.go`

When setting OpenStack parameters used for authentication, checking if application credentials are defined in the node template metadata to use them during the authentication,
else do a token-based authentication if a toekn is defined, else do the user/password authentication like previously.

### How to verify it

Verified on a LEXIS setup, using both:
* the usual user/password static configuration
* the external AAI provide application credentials, that a Yorc plugin (https://github.com/lexis-project/yorc-dynamic-orchestration-plugin) injects in  node template metadata.

### Description for the changelog

Ability to authenticate against OpenStack with token or application credentials ([GH-775](https://github.com/ystia/yorc/issues/775))

## Applicable Issues

Closes #775 
