### PR TITLE
Support nested tosca functions in get_secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### FEATURES
 
+* Support nested TOSCA functions in get_secret (added a get_vault_secret function) ([GH-777](https://github.com/ystia/yorc/issues/777))
 * Allow to replay workflow steps even if they are not in error ([GH-771](https://github.com/ystia/yorc/issues/771))
 * Workflows steps replays on error ([GH-753](https://github.com/ystia/yorc/issues/753))
 

--- a/commands/bootstrap/tosca_resources.go
+++ b/commands/bootstrap/tosca_resources.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !testing
 // +build !testing
 
 package bootstrap

--- a/commands/bootstrap/tosca_resources_testing.go
+++ b/commands/bootstrap/tosca_resources_testing.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build testing
 // +build testing
 
 package bootstrap

--- a/deployments/resolver_test.go
+++ b/deployments/resolver_test.go
@@ -278,6 +278,15 @@ func testResolveSecret(t *testing.T) {
 		{"ResolvePropWithVault", data{"JDK", "", ""}, &vaultClientMock{"/secrets/myapp/javahome", "mysupersecret", []string{"java_opt1=1", "java_opt2=2"}}, func(data data) (*TOSCAValue, error) {
 			return GetNodePropertyValue(ctx, deploymentID, data.nodeName, "java_home")
 		}, false, true, "mysupersecret"},
+		{"ResolvePropWithVaultAndNestedFn1", data{"JDK", "", ""}, &vaultClientMock{"/secrets/myapp/javahome", "mysupersecret", []string{"java_opt1=1", "java_opt2=2"}}, func(data data) (*TOSCAValue, error) {
+			return GetNodePropertyValue(ctx, deploymentID, data.nodeName, "java_home2")
+		}, false, true, "mysupersecret"},
+		{"ResolvePropWithVaultAndNestedFn2", data{"JDK", "", ""}, &vaultClientMock{"/secrets/myapp/javahome", "mysupersecret", []string{"java_opt1=1", "java_opt2=2"}}, func(data data) (*TOSCAValue, error) {
+			return GetNodePropertyValue(ctx, deploymentID, data.nodeName, "java_home3")
+		}, false, true, "mysupersecret"},
+		{"ResolvePropWithVaultAndNestedFn3", data{"JDK", "", ""}, &vaultClientMock{"/secrets/myapp/javahome", "mysupersecret", []string{"java_opt1=1", "java_opt2=2"}}, func(data data) (*TOSCAValue, error) {
+			return GetNodePropertyValue(ctx, deploymentID, data.nodeName, "java_home4")
+		}, false, true, "mysupersecret"},
 		{"ResolveCapabilityPropWithoutVault", data{"Tomcat", "", ""}, &vaultClientMock{"/secrets/myapp/tomcatport", "443", []string{"tom_opt1=1", "tom_opt2=2"}}, func(data data) (*TOSCAValue, error) {
 			return GetCapabilityPropertyValue(ctx, deploymentID, data.nodeName, "data_endpoint", "port")
 		}, false, true, "443"},

--- a/deployments/testdata/get_secrets.yaml
+++ b/deployments/testdata/get_secrets.yaml
@@ -15,6 +15,13 @@ topology_template:
       properties:
         java_url: "https://edelivery.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz"
         java_home: { get_secret: ["/secrets/myapp/javahome", java_opt1=1, java_opt2=2]}
+        java_home2: { get_vault_secret: [ concat: ["/secrets", "/myapp", "/javahome"], java_opt1=1, java_opt2=2]}
+        java_home3: { get_secret: [ concat: ["/secrets", "/myapp", "/javahome"], java_opt1=1, java_opt2=2]}
+        java_home4:
+          get_vault_secret:
+            - concat: ["/secrets", "/myapp", "/javahome"]
+            - java_opt1=1
+            - java_opt2=2
         component_version: "8.101"
       requirements:
         - host:

--- a/deployments/update_store_oss_test.go
+++ b/deployments/update_store_oss_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !premium
 // +build !premium
 
 package deployments

--- a/helper/executil/cmd_kill_group.go
+++ b/helper/executil/cmd_kill_group.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build !windows
+//go:build !windows
+// +build !windows
 
 package executil
 

--- a/helper/executil/cmd_standard.go
+++ b/helper/executil/cmd_standard.go
@@ -1,4 +1,5 @@
-//+build windows
+//go:build windows
+// +build windows
 
 package executil
 

--- a/prov/ansible/scripts_output_handler_oss.go
+++ b/prov/ansible/scripts_output_handler_oss.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !premium
 // +build !premium
 
 package ansible

--- a/rest/deployments_oss_test.go
+++ b/rest/deployments_oss_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !premium
 // +build !premium
 
 package rest

--- a/rest/updates_oss.go
+++ b/rest/updates_oss.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !premium
 // +build !premium
 
 package rest

--- a/server/builtin_types.go
+++ b/server/builtin_types.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !testing
 // +build !testing
 
 package server

--- a/server/builtin_types_testing.go
+++ b/server/builtin_types_testing.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build testing
 // +build testing
 
 package server

--- a/tasks/workflow/worker_oss.go
+++ b/tasks/workflow/worker_oss.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !premium
 // +build !premium
 
 package workflow

--- a/tools.go
+++ b/tools.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build tools
 // +build tools
 
 package main

--- a/tosca/tosca_functions.go
+++ b/tosca/tosca_functions.go
@@ -17,10 +17,10 @@ package tosca
 import (
 	"bytes"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"strconv"
 
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 
 	"github.com/ystia/yorc/v4/log"
 )
@@ -47,6 +47,8 @@ const (
 	GetSecretOperator Operator = "get_secret"
 )
 
+const getVaultSecretOperator = "get_vault_secret"
+
 // IsOperator checks if a given token is a known TOSCA function keyword
 func IsOperator(op string) bool {
 	return op == string(GetPropertyOperator) ||
@@ -54,7 +56,8 @@ func IsOperator(op string) bool {
 		op == string(GetInputOperator) ||
 		op == string(GetOperationOutputOperator) ||
 		op == string(ConcatOperator) ||
-		op == string(GetSecretOperator)
+		op == string(GetSecretOperator) ||
+		op == getVaultSecretOperator
 }
 
 func parseOperator(op string) (Operator, error) {
@@ -69,7 +72,7 @@ func parseOperator(op string) (Operator, error) {
 		return GetOperationOutputOperator, nil
 	case op == string(ConcatOperator):
 		return ConcatOperator, nil
-	case op == string(GetSecretOperator):
+	case op == string(GetSecretOperator), op == getVaultSecretOperator:
 		return GetSecretOperator, nil
 	default:
 		return GetPropertyOperator, errors.Errorf("%q is not a known or supported TOSCA operator", op)
@@ -118,7 +121,7 @@ func (f Function) String() string {
 	var b bytes.Buffer
 	b.WriteString(string(f.Operator))
 	b.WriteString(": ")
-	if len(f.Operands) == 1 {
+	if len(f.Operands) == 1 && f.Operands[0].IsLiteral() {
 		// Shortcut
 		b.WriteString(f.Operands[0].String())
 		return b.String()


### PR DESCRIPTION
# Pull Request description

## Description of the change

The issue was mainly that Alien4Cloud does not support nested functions in get_secret while Yorc itself does.

### What I did

Created an alias for `get_secret` called `get_vault_secret` allowing to use this function in TOSCA types that are designed to be used in Alien4Cloud

### Description for the changelog

* Support nested TOSCA functions in get_secret (added a get_vault_secret function) ([GH-777](https://github.com/ystia/yorc/issues/777))

## Applicable Issues

Fixes #777 
