### PR TITLE
Fix concurrent workers register duplicate task execution for nextstep

### DIFF
--- a/tasks/workflow/consul_test.go
+++ b/tasks/workflow/consul_test.go
@@ -79,6 +79,9 @@ func TestRunConsulWorkflowPackageTests(t *testing.T) {
 		t.Run("TestRunWorkflowStepReplay", func(t *testing.T) {
 			testRunWorkflowStepReplay(t, srv, client)
 		})
+		t.Run("testConcurrentTaskExecutionsForNextStep", func(t *testing.T) {
+			testConcurrentTaskExecutionsForNextStep(t, srv, client)
+		})
 	})
 }
 

--- a/tasks/workflow/testdata/workflow.yaml
+++ b/tasks/workflow/testdata/workflow.yaml
@@ -79,6 +79,22 @@ topology_template:
             protocol: tcp
             network_name: PRIVATE
             initiator: source
+
+    Compute_2:
+      type: ystia.yorc.tests.nodes.WFCompute
+      capabilities:
+        scalable:
+          properties:
+            min_instances: 1
+            max_instances: 1
+            default_instances: 1
+        endpoint:
+          properties:
+            secure: true
+            protocol: tcp
+            network_name: PRIVATE
+            initiator: source
+
     JobNode:
       type: ystia.yorc.tests.nodes.JobNode
   workflows:
@@ -141,6 +157,12 @@ topology_template:
           - delegate: install
           on_success:
           - WFNode_hostedOnComputeHost_add_target
+          - WFNode_creating
+        Compute_2_install:
+          target: Compute_2
+          activities:
+          - delegate: install
+          on_success:
           - WFNode_creating
         WFNode_initial:
           target: WFNode


### PR DESCRIPTION
# Pull Request description

## Description of the change

* When one or more steps (e.g., Step1 and Step2) join one Step 3, it may happen occasionally that two workers register two duplicate task executions for one next step.
* As a result, workers work on the duplicated executions. They create and remove ansible files from each other and cause unexpected error.
* See bug report in https://github.com/ystia/yorc/issues/786

### What I did

* Before registering a new task execution, a worker checks if the task execution has already been registered for the given step (at _yorc/tasks/<taskID>/.registeredExecutions/<stepName>) When deleting the ".runningExecutions" in notifyEnd(), also delete the ".registeredExecution".

* Note: If the step status is DONE, ERROR, or CANCELED, we still register a task execution. This is the case where we resume a workflow. The task executions are registered again. But they will be bypass if the given task status step is DONE.

### How I did it

### How to verify it

See Unitest. It simulates two workers register the same next step but only one task execution is registered.

### Description for the changelog

Fix concurrent workers register duplicate task execution for nextstep.

## Applicable Issues
