### PR TITLE
Fix `get_property`/`get_attribute` functions with `REQ_TARGET` keyword failing even if requirement is optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Install sphinx dependencies
         run: |
-          pip install --user --upgrade sphinx==1.8.1 semantic-version requests urllib3[secure]==1.23 Pygments>=2.7.1
+          pip install --user --upgrade sphinx<2 semantic-version requests urllib3[secure]==1.23 Pygments>=2.7.1
           pip install -r doc/requirements.txt
           sudo apt-get install -y jq \
                                   latexmk \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Install sphinx dependencies
         run: |
-          pip install --user --upgrade "sphinx<2" "semantic-version" "requests" "urllib3[secure]==1.23" "Pygments>=2.7.1"
+          pip install --user --upgrade "sphinx<2" "semantic-version" "requests" "urllib3[secure]==1.23" "Pygments>=2.7.1" "jinja2<3.1.0"
           pip install -r doc/requirements.txt
           sudo apt-get install -y jq \
                                   latexmk \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Install sphinx dependencies
         run: |
-          pip install --user --upgrade sphinx<2 semantic-version requests urllib3[secure]==1.23 Pygments>=2.7.1
+          pip install --user --upgrade "sphinx<2" "semantic-version" "requests" "urllib3[secure]==1.23" "Pygments>=2.7.1"
           pip install -r doc/requirements.txt
           sudo apt-get install -y jq \
                                   latexmk \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Yorc panics attempting to print an error handling a script execution stdout ([GH-741](https://github.com/ystia/yorc/issues/741))
 * Error submitting a SLURM job with no execution option ([GH-739](https://github.com/ystia/yorc/issues/739))
 * Workflow with asynchronous action never stops after another step failure  ([GH-733](https://github.com/ystia/yorc/issues/733))
+* Fix `get_property`/`get_attribute` functions with `REQ_TARGET` keyword failing even if requirement is optional ([GH-789](https://github.com/ystia/yorc/issues/789))
 
 ### ENGINEERING
 

--- a/config/config.go
+++ b/config/config.go
@@ -52,10 +52,10 @@ const DefaultPluginDir = "plugins"
 // DefaultServerGracefulShutdownTimeout is the default timeout for a graceful shutdown of a Yorc server before exiting
 const DefaultServerGracefulShutdownTimeout = 5 * time.Minute
 
-//DefaultKeepOperationRemotePath is set to false by default in order to remove path created to store operation artifacts on nodes.
+// DefaultKeepOperationRemotePath is set to false by default in order to remove path created to store operation artifacts on nodes.
 const DefaultKeepOperationRemotePath = false
 
-//DefaultArchiveArtifacts is set to false by default.
+// DefaultArchiveArtifacts is set to false by default.
 // When ArchiveArtifacts is true, destination hosts need tar to be installed,
 // to be able to unarchive artifacts.
 const DefaultArchiveArtifacts = false

--- a/deployments/definition_store.go
+++ b/deployments/definition_store.go
@@ -602,7 +602,8 @@ func fixAlienBlockStorages(ctx context.Context, deploymentID, nodeName string) e
 	return nil
 }
 
-/**
+/*
+*
 This function create a given number of floating IP instances
 */
 func createNodeInstances(consulStore consulutil.ConsulStore, numberInstances uint32, deploymentID, nodeName string) {
@@ -643,7 +644,8 @@ func createMissingBlockStorageForNodes(ctx context.Context, consulStore consulut
 	return nil
 }
 
-/**
+/*
+*
 This function check if a nodes need a block storage, and return the name of BlockStorage node.
 */
 func checkBlockStorage(ctx context.Context, deploymentID, nodeName string) (bool, []string, error) {

--- a/deployments/deployments.go
+++ b/deployments/deployments.go
@@ -83,14 +83,16 @@ func DeploymentStatusFromString(status string, ignoreCase bool) (DeploymentStatu
 // GetDeploymentStatus returns a DeploymentStatus for a given deploymentId
 //
 // If the given deploymentId doesn't refer to an existing deployment an error is returned. This error could be checked with
-//  IsDeploymentNotFoundError(err error) bool
+//
+//	IsDeploymentNotFoundError(err error) bool
 //
 // For example:
-//  if status, err := GetDeploymentStatus(kv, deploymentId); err != nil {
-//  	if IsDeploymentNotFoundError(err) {
-//  		// Do something in case of deployment not found
-//  	}
-//  }
+//
+//	if status, err := GetDeploymentStatus(kv, deploymentId); err != nil {
+//		if IsDeploymentNotFoundError(err) {
+//			// Do something in case of deployment not found
+//		}
+//	}
 func GetDeploymentStatus(ctx context.Context, deploymentID string) (DeploymentStatus, error) {
 	exist, value, err := consulutil.GetStringValue(path.Join(consulutil.DeploymentKVPrefix, deploymentID, "status"))
 	if err != nil {

--- a/deployments/resolver.go
+++ b/deployments/resolver.go
@@ -247,6 +247,25 @@ func (fr *functionResolver) resolveGetPropertyOrAttribute(ctx context.Context, r
 		if err != nil {
 			return nil, err
 		}
+		if actualNode == "" {
+			nodeType, err := GetNodeType(ctx, fr.deploymentID, fr.nodeName)
+			if err != nil {
+				return nil, err
+			}
+			req, err := GetRequirementDefinitionOnTypeByName(ctx, fr.deploymentID, nodeType, operands[1])
+			if err != nil {
+				return nil, err
+			}
+			if req == nil {
+				return nil, errors.Errorf("missing requirement %q on node %q", operands[1], fr.nodeName)
+			}
+			if req.Occurrences.LowerBound != 0 {
+				return nil, errors.Errorf("requirement %q on node %q not found while not optional (occurrences lower bound set to %d)", operands[1], fr.nodeName, req.Occurrences.LowerBound)
+			}
+			// this means that the relationship between those 2 nodes does not exist
+			// and the requirement definition occurrence lower bound is set to 0 meaning it is optional.
+			return nil, nil
+		}
 	default:
 		actualNode = entity
 	}

--- a/deployments/substitution_mappings.go
+++ b/deployments/substitution_mappings.go
@@ -205,11 +205,11 @@ func isSubstitutionNodeInstance(ctx context.Context, deploymentID, nodeName, nod
 
 // getSubstitutableNodeType returns the node type of a substitutable node.
 // There are 2 cases :
-// - either this node a reference to an external service, and the node type
-//   here is a real node type (abstract)
-// - or this is a reference to a managed service, and the node type here
-//   does not exist, it is the name of a template whose import contains the
-//    real node type
+//   - either this node a reference to an external service, and the node type
+//     here is a real node type (abstract)
+//   - or this is a reference to a managed service, and the node type here
+//     does not exist, it is the name of a template whose import contains the
+//     real node type
 func getSubstitutableNodeType(ctx context.Context, deploymentID, nodeName, nodeType string) (string, error) {
 	_, err := GetParentType(ctx, deploymentID, nodeType)
 	if err == nil {

--- a/helper/labelsutil/internal/filters.go
+++ b/helper/labelsutil/internal/filters.go
@@ -214,7 +214,7 @@ func (o *SetOperator) createFilter(labelKey string) (Filter, error) {
 /* ###################################################### */
 /* ###################################################### */
 
-//CompositionStrategy is used to define the type of combination used into composite filter
+// CompositionStrategy is used to define the type of combination used into composite filter
 type CompositionStrategy int
 
 const (
@@ -224,7 +224,7 @@ const (
 	Or CompositionStrategy = iota
 )
 
-//CompositeFilter is a filter made of other filters, combined using AND method
+// CompositeFilter is a filter made of other filters, combined using AND method
 type CompositeFilter struct {
 	Strat   CompositionStrategy //combination operator, AND or OR
 	filters []Filter
@@ -270,7 +270,7 @@ func (f *CompositeFilter) matchOr(labels map[string]string) (bool, error) {
 
 /* ###################################################### */
 
-//RegexStrategy is used to define the type of search used into regexp filter
+// RegexStrategy is used to define the type of search used into regexp filter
 type RegexStrategy int
 
 const (
@@ -284,7 +284,7 @@ const (
 	Differs RegexStrategy = iota
 )
 
-//RegexFilter is a filter checking if a label matches a regular expression
+// RegexFilter is a filter checking if a label matches a regular expression
 type RegexFilter struct {
 	LabelKey string
 	Strat    RegexStrategy
@@ -321,7 +321,7 @@ func (f *RegexFilter) Matches(labels map[string]string) (bool, error) {
 
 /* ###################################################### */
 
-//ComparisonOperator is used to define the type of comparison used into comparison filter
+// ComparisonOperator is used to define the type of comparison used into comparison filter
 type ComparisonOperator int
 
 const (
@@ -339,7 +339,7 @@ const (
 	Neq ComparisonOperator = iota
 )
 
-//ComparisonFilter is a filter checking if a label is higher than a certain value
+// ComparisonFilter is a filter checking if a label is higher than a certain value
 type ComparisonFilter struct {
 	LabelKey string
 	Cop      ComparisonOperator
@@ -474,7 +474,7 @@ func siToFloat64(fval float64, funit string, lvalS string) (float64, float64, er
 
 /* ###################################################### */
 
-//KeyFilterStrat is used to define the type of combination used into LabelExists filter
+// KeyFilterStrat is used to define the type of combination used into LabelExists filter
 type KeyFilterStrat int
 
 const (
@@ -484,7 +484,7 @@ const (
 	Absent KeyFilterStrat = iota
 )
 
-//KeyFilter is a filter checking if a label is existing or not
+// KeyFilter is a filter checking if a label is existing or not
 type KeyFilter struct {
 	LabelKey string
 	Strat    KeyFilterStrat

--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -19,7 +19,9 @@ ADD rootfs /
 # Python is required here as it should not be removed automatically when uninstalling python-dev
 # We do not install the whole docker package but just docker-cli
 
-RUN apk add --update make openssh-client python3 python3-dev gcc musl-dev libffi-dev openssl-dev docker-cli cargo rust && \
+RUN apk add --update make openssh-client python3 python3-dev gcc musl-dev libffi-dev openssl-dev docker-cli cargo && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output /tmp/rustup.sh && \
+    chmod +x /tmp/rustup.sh && /tmp/rustup.sh -y && source "$HOME/.cargo/env" && \
     python3 -m ensurepip --upgrade && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
     if [ ! -e /usr/bin/python ]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
@@ -50,6 +52,7 @@ RUN apk add --update make openssh-client python3 python3-dev gcc musl-dev libffi
     chmod 775 ${YORC_TERRAFORM_PLUGINS_DIR}/* && \
     echo "Cleaning up" && \
     apk del make py-pip python3-dev gcc musl-dev libffi-dev openssl-dev && \
+    rustup self uninstall -y && \
     rm -rf /var/cache/apk/* && \
     rm -fr /tmp/*
 

--- a/prov/ansible/execution.go
+++ b/prov/ansible/execution.go
@@ -715,7 +715,9 @@ func (e *executionCommon) addRunnablesSpecificInputsAndOutputs() error {
 }
 
 // resolveIsPerInstanceOperation sets e.isPerInstanceOperation to true if the given operationName contains one of the following patterns (case doesn't matter):
+//
 //	add_target, remove_target, add_source, remove_source, target_changed
+//
 // And in case of a relationship operation the relationship does not derive from "tosca.relationships.HostedOn" as it makes no sense till we scale at compute level
 func (e *executionCommon) resolveIsPerInstanceOperation(ctx context.Context, operationName string) error {
 	op := strings.ToLower(operationName)

--- a/prov/kubernetes/k8s_utils.go
+++ b/prov/kubernetes/k8s_utils.go
@@ -299,7 +299,7 @@ func replaceServiceIPInResourceSpec(ctx context.Context, clientset kubernetes.In
 	return replaceServiceDepLookups(ctx, clientset, namespace, rSpec, serviceDepsLookups.RawString())
 }
 
-//Return the external IP of a given node
+// Return the external IP of a given node
 func getExternalIPAdress(ctx context.Context, clientset kubernetes.Interface, nodeName string) (string, error) {
 	node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {

--- a/prov/kubernetes/k8s_utils_test.go
+++ b/prov/kubernetes/k8s_utils_test.go
@@ -120,8 +120,11 @@ func TestGetNoneExternalIPAdress(t *testing.T) {
 	}
 }
 
-/* Return a map of mocked k8s objects corresponding to their resource in
-Currently support only : StatefulSet, PVC, Service and Deployment */
+/*
+	Return a map of mocked k8s objects corresponding to their resource in
+
+Currently support only : StatefulSet, PVC, Service and Deployment
+*/
 func mockSupportedResources() map[string]runtime.Object {
 	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvcTest", Namespace: "test-ns"}}
 	dep := &v1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deploymentTest", Namespace: "test-ns"}}
@@ -136,9 +139,12 @@ func mockSupportedResources() map[string]runtime.Object {
 	return supportedRes
 }
 
-/*  React to get on k8s objects. After 2 get if deleteObj boolean is set to true then it fakely delete it. If the boolean is set to false,
+/*
+	React to get on k8s objects. After 2 get if deleteObj boolean is set to true then it fakely delete it. If the boolean is set to false,
+
 then it marked the object as succefully present or deployed for pods controllers.
-If the API continue to receive GET, raise error by signaling the errorChan */
+If the API continue to receive GET, raise error by signaling the errorChan
+*/
 func fakeGetObjectReaction(k8sObject runtime.Object, errorChan chan struct{}, deleteObj bool) k8stesting.ReactionFunc {
 	getCount := 0
 	return func(action k8stesting.Action) (bool, runtime.Object, error) {

--- a/prov/kubernetes/supported_resource.go
+++ b/prov/kubernetes/supported_resource.go
@@ -32,7 +32,7 @@ import (
 	"github.com/ystia/yorc/v4/events"
 )
 
-//Interface to implement for new supported objects in K8s
+// Interface to implement for new supported objects in K8s
 type yorcK8sObject interface {
 	// Operations for yorc kubernetes objects
 	createResource(ctx context.Context, deploymentID string, clientset kubernetes.Interface, namespace string) error
@@ -130,9 +130,9 @@ func (yorcPVC *yorcK8sPersistentVolumeClaim) streamLogs(ctx context.Context, dep
 }
 
 /*
-	----------------------------------------------
-	| 				Deployment					 |
-	----------------------------------------------
+----------------------------------------------
+| 				Deployment					 |
+----------------------------------------------
 */
 func (yorcDep *yorcK8sDeployment) unmarshalResource(ctx context.Context, e *execution, deploymentID string, clientset kubernetes.Interface, rSpec string) error {
 	err := json.Unmarshal([]byte(rSpec), &yorcDep)
@@ -231,9 +231,9 @@ func (yorcDep *yorcK8sDeployment) streamLogs(ctx context.Context, deploymentID s
 }
 
 /*
-	----------------------------------------------
-	| 				StatefulSet					 |
-	----------------------------------------------
+----------------------------------------------
+| 				StatefulSet					 |
+----------------------------------------------
 */
 func (yorcSts *yorcK8sStatefulSet) unmarshalResource(ctx context.Context, e *execution, deploymentID string, clientset kubernetes.Interface, rSpec string) error {
 	err := json.Unmarshal([]byte(rSpec), &yorcSts)
@@ -325,9 +325,9 @@ func (yorcSts *yorcK8sStatefulSet) streamLogs(ctx context.Context, deploymentID 
 }
 
 /*
-	----------------------------------------------
-	| 					Service					 |
-	----------------------------------------------
+----------------------------------------------
+| 					Service					 |
+----------------------------------------------
 */
 func (yorcSvc *yorcK8sService) unmarshalResource(ctx context.Context, e *execution, deploymentID string, clientset kubernetes.Interface, rSpec string) error {
 	return json.Unmarshal([]byte(rSpec), &yorcSvc)

--- a/prov/operations/inputs.go
+++ b/prov/operations/inputs.go
@@ -118,13 +118,13 @@ func ResolveInputsWithInstances(ctx context.Context, deploymentID, nodeName, tas
 //
 // It may happen in rare cases that several capabilities match the same requirement.
 // Values are stored in this way:
-//   * TARGET_CAPABILITY_NAMES: comma-separated list of matching capabilities names. It could be use to loop over the injected variables
-//   * TARGET_CAPABILITY_<capabilityName>_TYPE: actual type of the capability
-//   * TARGET_CAPABILITY_TYPE: actual type of the capability of the first matching capability
-// 	 * TARGET_CAPABILITY_<capabilityName>_PROPERTY_<propertyName>: value of a property
-// 	 * TARGET_CAPABILITY_PROPERTY_<propertyName>: value of a property for the first matching capability
-// 	 * TARGET_CAPABILITY_<capabilityName>_<instanceName>_ATTRIBUTE_<attributeName>: value of an attribute of a given instance
-// 	 * TARGET_CAPABILITY_<instanceName>_ATTRIBUTE_<attributeName>: value of an attribute of a given instance for the first matching capability
+//   - TARGET_CAPABILITY_NAMES: comma-separated list of matching capabilities names. It could be use to loop over the injected variables
+//   - TARGET_CAPABILITY_<capabilityName>_TYPE: actual type of the capability
+//   - TARGET_CAPABILITY_TYPE: actual type of the capability of the first matching capability
+//   - TARGET_CAPABILITY_<capabilityName>_PROPERTY_<propertyName>: value of a property
+//   - TARGET_CAPABILITY_PROPERTY_<propertyName>: value of a property for the first matching capability
+//   - TARGET_CAPABILITY_<capabilityName>_<instanceName>_ATTRIBUTE_<attributeName>: value of an attribute of a given instance
+//   - TARGET_CAPABILITY_<instanceName>_ATTRIBUTE_<attributeName>: value of an attribute of a given instance for the first matching capability
 func GetTargetCapabilityPropertiesAndAttributesValues(ctx context.Context, deploymentID, nodeName string, op prov.Operation) (map[string]*deployments.TOSCAValue, error) {
 	// Only for relationship operations
 	if !IsRelationshipOperation(op) {

--- a/storage/internal/elastic/store.go
+++ b/storage/internal/elastic/store.go
@@ -268,8 +268,9 @@ func (s *elasticStore) verifyLastIndex(indexName string, deploymentID string, es
 // List simulates long polling request by :
 // - periodically querying ES for documents (Aggregation to get the max iid and 0 size result).
 // - if a some result is found, wait some time (es_refresh_wait_timeout) in order to:
-//   	- let ES index recently added documents AND to let
-// 		- let Yorc eventually Set a document that has a less iid than the older known document in ES (concurrence issues)
+//   - let ES index recently added documents AND to let
+//   - let Yorc eventually Set a document that has a less iid than the older known document in ES (concurrence issues)
+//
 // - if no result if found after the the given 'timeout', return empty slice
 func (s *elasticStore) List(ctx context.Context, k string, waitIndex uint64, timeout time.Duration) ([]store.KeyValueOut, uint64, error) {
 	log.Debugf("List called k: %s, waitIndex: %d, timeout: %v", k, waitIndex, timeout)

--- a/testutil/helper.go
+++ b/testutil/helper.go
@@ -32,10 +32,11 @@ import (
 )
 
 // NewTestConsulInstance allows to :
-//  - creates and returns a new Consul server and client
-//  - starts a Consul Publisher
-//  - loads stores
-//  - stores common-types to Consul
+//   - creates and returns a new Consul server and client
+//   - starts a Consul Publisher
+//   - loads stores
+//   - stores common-types to Consul
+//
 // Warning: You need to defer the server stop command in the caller
 func NewTestConsulInstance(t testing.TB, cfg *config.Configuration) (*testutil.TestServer, *api.Client) {
 	logLevel := "debug"
@@ -57,9 +58,10 @@ func NewTestConsulInstanceWithConfigAndStore(t testing.TB, cb testutil.ServerCon
 }
 
 // NewTestConsulInstanceWithConfig sets up a consul instance for testing :
-//  - creates and returns a new Consul server and client
-//  - starts a Consul Publisher
-//  - stores common-types to Consul only if storeCommons bool parameter is true
+//   - creates and returns a new Consul server and client
+//   - starts a Consul Publisher
+//   - stores common-types to Consul only if storeCommons bool parameter is true
+//
 // Warning: You need to defer the server stop command in the caller
 func NewTestConsulInstanceWithConfig(t testing.TB, cb testutil.ServerConfigCallback, cfg *config.Configuration, storeCommons bool) (*testutil.TestServer, *api.Client) {
 

--- a/tosca/outputs.go
+++ b/tosca/outputs.go
@@ -22,8 +22,6 @@ import (
 )
 
 // An Output is the representation of the output part of a TOSCA Operation Definition
-//
-//
 type Output struct {
 	ValueAssign      *ValueAssignment  `json:"value_assignment,omitempty"`
 	AttributeMapping *AttributeMapping `json:"attribute_mapping,omitempty"`

--- a/tosca/substitution_mapping.go
+++ b/tosca/substitution_mapping.go
@@ -36,26 +36,26 @@ type SubstitutionMapping struct {
 // PropAttrMapping defines a property or attribute mapping.
 // It accepts several grammars.
 //
-// - Single-line grammar:
-//   <property_name>: <property_value>
-//   or
-//   <property_name>: [ <input_name> ]
-//   or
-//   <property_name>: [ <node_template_name>, <node_template_property_name> ]
-//   or
-//   <property_name>: [ <node_template_name>, <node_template_capability_name> | <node_template_requirement_name>, <property_name> ]
+//   - Single-line grammar:
+//     <property_name>: <property_value>
+//     or
+//     <property_name>: [ <input_name> ]
+//     or
+//     <property_name>: [ <node_template_name>, <node_template_property_name> ]
+//     or
+//     <property_name>: [ <node_template_name>, <node_template_capability_name> | <node_template_requirement_name>, <property_name> ]
 //
-// - Multi-line grammar:
-//   <property_name>:
+//   - Multi-line grammar:
+//     <property_name>:
 //     mapping: [ < input_name > ]
-//   or
-//   <property_name>:
+//     or
+//     <property_name>:
 //     mapping: [ <node_template_name>, <node_template_property_name> ]
-//   or
-//   <property_name>:
+//     or
+//     <property_name>:
 //     mapping: [ <node_template_name>, <node_template_capability_name> | <node_template_requirement_name>, <property_name> ]
-//   or
-//   <property_name>:
+//     or
+//     <property_name>:
 //     value: <property_value>
 //
 // See http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.2/TOSCA-Simple-Profile-YAML-v1.2.html
@@ -124,17 +124,17 @@ func (p *PropAttrMapping) UnmarshalYAML(unmarshal func(interface{}) error) error
 // CapReqMapping defines a capability mapping or a requirement mapping.
 // It accepts two grammars.
 //
-// - Single-line grammar:
-//   <capability_name>: [ <node_template_name>, <node_template_capability_name> ]
+//   - Single-line grammar:
+//     <capability_name>: [ <node_template_name>, <node_template_capability_name> ]
 //
-// - Multi-line grammar:
-//   <capability_name>:
-//      mapping: [ <node_template_name>, <node_template_capability_name> ]
-//   <capability_name>:
-//      properties:
-//        <property_name>: <property_value>
-//      attributes:
-//        <attribute_name>: <attribute_value>
+//   - Multi-line grammar:
+//     <capability_name>:
+//     mapping: [ <node_template_name>, <node_template_capability_name> ]
+//     <capability_name>:
+//     properties:
+//     <property_name>: <property_value>
+//     attributes:
+//     <attribute_name>: <attribute_value>
 //
 // See http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.2/TOSCA-Simple-Profile-YAML-v1.2.html
 // section 3.8.9 Capability mapping and 3.8.10 Requirement mapping

--- a/tosca/topology.go
+++ b/tosca/topology.go
@@ -80,9 +80,9 @@ type NodeTemplate struct {
 	Interfaces   map[string]InterfaceDefinition  `yaml:"interfaces,omitempty" json:"interfaces,omitempty"`
 }
 
-//A Repository is representation of TOSCA Repository
+// A Repository is representation of TOSCA Repository
 //
-//See http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.0/csprd01/TOSCA-Simple-Profile-YAML-v1.0-csprd01.html#_Toc430015673 for more details
+// See http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.0/csprd01/TOSCA-Simple-Profile-YAML-v1.0-csprd01.html#_Toc430015673 for more details
 type Repository struct {
 	URL         string     `yaml:"url,omitempty" json:"url,omitempty"`
 	Type        string     `yaml:"type,omitempty" json:"type,omitempty"`

--- a/tosca/types.go
+++ b/tosca/types.go
@@ -28,18 +28,18 @@ func IsBuiltinType(typeName string) bool {
 // IsPrimitiveType checks if a given type name corresponds to a primitive type
 // It means a data type that can'be broken down into a more simple data type.
 // Known primitive types:
-// 	- string
-//	- integer
-//	- float
-//	- boolean
-//	- timestamp
-//	- null
-//	- version
-//	- range
-//	- scalar-unit.size
-//	- scalar-unit.time
-//	- scalar-unit.frequency
-//	- scalar-unit.bitrate
+//   - string
+//   - integer
+//   - float
+//   - boolean
+//   - timestamp
+//   - null
+//   - version
+//   - range
+//   - scalar-unit.size
+//   - scalar-unit.time
+//   - scalar-unit.frequency
+//   - scalar-unit.bitrate
 func IsPrimitiveType(typeName string) bool {
 	return typeName == "string" || typeName == "integer" || typeName == "float" || typeName == "boolean" ||
 		typeName == "timestamp" || typeName == "null" || typeName == "version" || typeName == "range" ||

--- a/tosca/value_assignment.go
+++ b/tosca/value_assignment.go
@@ -53,7 +53,7 @@ func (vat ValueAssignmentType) String() string {
 	return "unsupported"
 }
 
-//UnmarshalJSON unmarshals json into a ValueAssignmentType
+// UnmarshalJSON unmarshals json into a ValueAssignmentType
 func (vat *ValueAssignmentType) UnmarshalJSON(b []byte) error {
 
 	var i int

--- a/tosca/workflows.go
+++ b/tosca/workflows.go
@@ -15,7 +15,6 @@
 package tosca
 
 // A Workflow is the representation of a TOSCA Workflow
-//
 type Workflow struct {
 	Inputs  map[string]PropertyDefinition  `yaml:"inputs,omitempty" json:"inputs,omitempty"`
 	Steps   map[string]*Step               `yaml:"steps,omitempty" json:"steps,omitempty"`


### PR DESCRIPTION
# Pull Request description

## Description of the change

Added a check that the requirement is not optional before failing.
Note that this is very unlikely to happen when using Alien4Cloud as it enforces this rule.

### What I did

If target node is not found and requirement is optional then return an empty value without error

### Description for the changelog

*  Fix `get_property`/`get_attribute` functions with `REQ_TARGET` keyword failing even if requirement is optional  ([GH-789](https://github.com/ystia/yorc/issues/789))

## Applicable Issues

Fixes #789 
