### PR TITLE
Support nested TOSCA functions in `get_input`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Ability to authenticate against OpenStack with token or application credentials ([GH-775](https://github.com/ystia/yorc/issues/775))
 * Support nested TOSCA functions in get_secret (added a get_vault_secret function) ([GH-777](https://github.com/ystia/yorc/issues/777))
+* Support nested TOSCA functions in get_input (added a get_input_nf function) ([GH-791](https://github.com/ystia/yorc/issues/791))
 * Allow to replay workflow steps even if they are not in error ([GH-771](https://github.com/ystia/yorc/issues/771))
 * Workflows steps replays on error ([GH-753](https://github.com/ystia/yorc/issues/753))
 

--- a/deployments/resolver_test.go
+++ b/deployments/resolver_test.go
@@ -162,6 +162,10 @@ func testResolveComplex(t *testing.T) {
 		{"ResolveGetRequirementAttributeWithAbsent", data{"VANode1", "0", "0"}, args{`{get_attribute: [SELF, host, absentAttr]}`}, false, false, ``},
 		{"ResolveGetPropertyWithAbsent", data{"VANode1", "", ""}, args{`{get_property: [SELF, absentAttr]}`}, true, false, ``},
 		{"ResolveGetRequirementPropertyWithAbsent", data{"VANode1", "", "0"}, args{`{get_property: [SELF, host, absentAttr]}`}, true, false, ``},
+		{"ResolveGetInput", data{"VANode1", "", ""}, args{`{get_input: literal}`}, false, true, `literalInput`},
+		{"ResolveGetInputWithNestedFunc", data{"VANode1", "", ""}, args{`{get_input: [get_property: [SELF, input_name]]}`}, false, true, `literalInput`},
+		{"ResolveGetInputWithNestedFuncAlias", data{"VANode1", "", ""}, args{`{get_input_nf: [get_property: [SELF, input_name]]}`}, false, true, `literalInput`},
+		{"ResolveGetInputWithNestedFuncAliasComplex", data{"VANode2", "", ""}, args{`{get_input_nf: [concat: [get_property: [SELF, input_name], "Default"]]}`}, false, true, `1`},
 	}
 	for _, tt := range resolverTests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/deployments/testdata/value_assignments.yaml
+++ b/deployments/testdata/value_assignments.yaml
@@ -58,6 +58,8 @@ node_types:
         type: integer
       list:
         type: list
+      input_name:
+        type: string
       map:
         type: map
         entry_schema:
@@ -421,6 +423,7 @@ topology_template:
       type: yorc.tests.nodes.ValueAssignmentNode
       properties:
         port: "80"
+        input_name: "literal"
         literal: 1
         list: ["http://", "yorc", ".io"]
         map: {one: "1", "two": "2"}
@@ -456,6 +459,7 @@ topology_template:
       properties:
         port: "80"
         literal: 1
+        input_name: "literal"
         list:
           - "http://"
           - "yorc"

--- a/tosca/tosca_functions.go
+++ b/tosca/tosca_functions.go
@@ -48,6 +48,7 @@ const (
 )
 
 const getVaultSecretOperator = "get_vault_secret"
+const getInputWithNestedFunctionsOperator = "get_input_nf"
 
 // IsOperator checks if a given token is a known TOSCA function keyword
 func IsOperator(op string) bool {
@@ -57,7 +58,8 @@ func IsOperator(op string) bool {
 		op == string(GetOperationOutputOperator) ||
 		op == string(ConcatOperator) ||
 		op == string(GetSecretOperator) ||
-		op == getVaultSecretOperator
+		op == getVaultSecretOperator ||
+		op == getInputWithNestedFunctionsOperator
 }
 
 func parseOperator(op string) (Operator, error) {
@@ -66,7 +68,7 @@ func parseOperator(op string) (Operator, error) {
 		return GetPropertyOperator, nil
 	case op == string(GetAttributeOperator):
 		return GetAttributeOperator, nil
-	case op == string(GetInputOperator):
+	case op == string(GetInputOperator), op == getInputWithNestedFunctionsOperator:
 		return GetInputOperator, nil
 	case op == string(GetOperationOutputOperator):
 		return GetOperationOutputOperator, nil

--- a/tosca/tosca_functions_test.go
+++ b/tosca/tosca_functions_test.go
@@ -41,6 +41,7 @@ func TestFunctionParsing(t *testing.T) {
 		{"TestGetPropertyFunction", inputs{yml: "get_property: [SELF, ip_address]"}, false},
 		{"TestConcatFunction", inputs{yml: "concat: [get_property: [SELF, ip_address], get_attribute: [SELF, port]]"}, false},
 		{"TestGetInputFunction", inputs{yml: "get_input: ip_address"}, false},
+		{"TestGetInputFunctionNested", inputs{yml: "get_input_nf: [get_property: [SELF, input_name]]"}, false},
 		{"TestConcatFunctionQuoting", inputs{yml: `concat: ["http://", get_property: [SELF, ip_address], get_attribute: [SELF, port], "\"ff\""]`}, false},
 		{"TestComplexNestedFunctions", inputs{yml: `get_secret: [concat: [/secrets/data/credentials/, get_input: user_name]]`}, false},
 		{"TestComplexNestedFunctions2", inputs{yml: `get_vault_secret: [concat: [/secrets/data/credentials/, get_input: user_name]]`}, false},
@@ -58,6 +59,8 @@ func TestFunctionParsing(t *testing.T) {
 				expecting := tt.inputs.yml
 				// get_vault_secret is an alias to get_secret
 				expecting = strings.Replace(expecting, "get_vault_secret", "get_secret", -1)
+				// get_input_nf is an alias to get_input
+				expecting = strings.Replace(expecting, "get_input_nf", "get_input", -1)
 				if resultFn.String() != expecting {
 					t.Errorf("Function.Unmarshal() expecting = %v, got %v", expecting, resultFn)
 				}


### PR DESCRIPTION
# Pull Request description

## Description of the change

The issue was mainly that Alien4Cloud does not support nested functions in `get_input` while Yorc itself does.

### What I did

Created an alias for `get_input` called `get_input_nf` allowing to use this function in TOSCA types that are designed to be used in Alien4Cloud

### Description for the changelog

* Support nested TOSCA functions in get_input (added a get_input_nf function) ([GH-791](https://github.com/ystia/yorc/issues/791))

## Applicable Issues

Fixes #791 
